### PR TITLE
Enhance schema normalization and tests

### DIFF
--- a/internal/schemas.py
+++ b/internal/schemas.py
@@ -46,22 +46,20 @@ except ImportError:  # pragma: no cover - fallback path
             )
 
 
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _ensure_str_dict(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalize_value(item) for item in value]
+    return value
+
+
 def _ensure_str_dict(data: Mapping[Any, Any]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in data.items():
         if not isinstance(key, str):
             raise SchemaError("Schema keys must be strings.")
-        if isinstance(value, Mapping):
-            value = _ensure_str_dict(value)
-        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-            new_list = []
-            for item in value:
-                if isinstance(item, Mapping):
-                    new_list.append(_ensure_str_dict(item))
-                else:
-                    new_list.append(item)
-            value = new_list
-        result[key] = value
+        result[key] = _normalize_value(value)
     return result
 
 
@@ -91,23 +89,39 @@ def _derive_schema_name(source: SchemaLike, schema: Mapping[str, Any]) -> str:
     return f"schema_{digest[:8]}"
 
 
+def _resolve_model_schema(schema_like: Any) -> Mapping[str, Any] | None:
+    if isinstance(schema_like, type):
+        method = getattr(schema_like, "model_json_schema", None)
+        if callable(method):
+            return method()
+        return None
+    if isinstance(schema_like, ModelSchema):
+        return schema_like.model_json_schema()
+    method = getattr(schema_like, "model_json_schema", None)
+    if callable(method):
+        return method()
+    return None
+
+
 def normalize_schema(schema_like: SchemaLike) -> dict[str, Any]:
-    schema_dict: Mapping[str, Any]
+    schema_dict: Mapping[str, Any] | None = None
     if isinstance(schema_like, Mapping):
         schema_dict = schema_like
     elif isinstance(schema_like, str):
+        stripped = schema_like.strip()
+        if not stripped:
+            raise SchemaError("Schema string must not be empty.")
         try:
-            parsed = json.loads(schema_like)
+            parsed = json.loads(stripped)
         except json.JSONDecodeError as exc:
             raise SchemaError("Schema string must contain valid JSON.") from exc
         if not isinstance(parsed, Mapping):
             raise SchemaError("Parsed schema must be a JSON object.")
         schema_dict = parsed
-    elif isinstance(schema_like, type) and hasattr(schema_like, "model_json_schema"):
-        schema_dict = schema_like.model_json_schema()  # type: ignore[misc]
-    elif hasattr(schema_like, "model_json_schema"):
-        schema_dict = schema_like.model_json_schema()  # type: ignore[misc]
     else:
+        schema_dict = _resolve_model_schema(schema_like)
+
+    if schema_dict is None:
         raise SchemaError("Unsupported schema type provided.")
 
     plain_schema = _ensure_str_dict(schema_dict)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,3 +1,7 @@
+import json
+
+import pytest
+
 from internal.schemas import (
     SchemaError,
     build_response_format,
@@ -34,17 +38,63 @@ def test_build_response_format_from_model_class():
     response_format = build_response_format(ExampleSchema)
     payload = response_format["json_schema"]
     assert payload["name"] == "ExampleSchema"
+    assert payload["strict"] is True
     assert payload["schema"]["required"] == ["name"]
 
 
+def test_build_response_format_derives_name_from_schema_metadata():
+    schema = {
+        "type": "object",
+        "title": "FriendlySchema",
+        "properties": {},
+    }
+    payload = build_response_format(schema)["json_schema"]
+    assert payload["name"] == "FriendlySchema"
+
+
+def test_build_response_format_from_schema_string():
+    schema = json.dumps(
+        {
+            "type": "object",
+            "properties": {"flag": {"type": "boolean"}},
+        }
+    )
+    payload = build_response_format(schema, strict=True)["json_schema"]
+    assert payload["schema"]["properties"]["flag"]["type"] == "boolean"
+    assert payload["strict"] is True
+
+
 def test_normalize_schema_rejects_invalid_json():
-    try:
+    with pytest.raises(SchemaError, match="valid JSON"):
         normalize_schema("{}[]")
-    except SchemaError:
-        return
-    assert False, "Expected SchemaError for invalid JSON"
+
+
+def test_normalize_schema_rejects_empty_string():
+    with pytest.raises(SchemaError, match="must not be empty"):
+        normalize_schema("   ")
+
+
+def test_normalize_schema_rejects_non_object_json():
+    with pytest.raises(SchemaError, match="JSON object"):
+        normalize_schema("[]")
+
+
+def test_normalize_schema_rejects_missing_type_information():
+    with pytest.raises(SchemaError, match="type information"):
+        normalize_schema({"properties": {}})
+
+
+def test_normalize_schema_from_model_instance():
+    instance = ExampleSchema()
+    normalized = normalize_schema(instance)
+    assert normalized["required"] == ["name"]
 
 
 def test_parse_structured_content_from_string():
     data = parse_structured_content('{"name": "Alice"}')
     assert data == {"name": "Alice"}
+
+
+def test_parse_structured_content_rejects_non_object():
+    with pytest.raises(SchemaError, match="JSON object"):
+        parse_structured_content("[]")


### PR DESCRIPTION
## Summary
- normalize schema parsing to handle nested structures and ModelSchema providers
- improve schema response formatting defaults and error messaging
- expand schema unit tests to cover JSON strings, strict flag behavior, and error cases

## Testing
- pytest tests/test_schemas.py

------
https://chatgpt.com/codex/tasks/task_b_68e497a23d4c832f84eeae1a8fd6f936