### PR TITLE
Add tool-enabled chat helpers and tests

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -7,20 +7,24 @@ loosely following the quick-start snippets from
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Mapping
-from dataclasses import dataclass
-from typing import Any, Dict, Optional, Union
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Sequence, Union
 
 import lmstudio as lms
 
+from tooling import resolve_tools
+
 ChatInput = Union[str, lms.Chat, Mapping[str, Any]]
 CallbackMap = Mapping[str, Callable[..., Any]]
+ToolList = Sequence[Any]
 
 __all__ = [
     "ChatInput",
     "CallbackMap",
     "ChatSession",
     "ResponseStream",
+    "act",
     "get_model",
     "respond",
     "respond_stream",
@@ -120,6 +124,63 @@ def respond(
     return _extract_text(result), result
 
 
+def _prepare_tools(
+    tools: Iterable[Any] | None = None,
+    tool_names: Sequence[str] | None = None,
+    *,
+    default: ToolList | None = None,
+) -> list[Any]:
+    """Resolve tool arguments into a deduplicated list."""
+
+    resolved: list[Any] = []
+    if default:
+        resolved.extend(default)
+    if tools is not None or tool_names is not None:
+        merged = resolve_tools(tools=tools, tool_names=tool_names)
+        for tool in merged:
+            if tool not in resolved:
+                resolved.append(tool)
+    return resolved
+
+
+def act(
+    prompt_or_chat: ChatInput,
+    *,
+    tools: Iterable[Any] | None = None,
+    tool_names: Sequence[str] | None = None,
+    model: Any | None = None,
+    model_name: str | None = None,
+    config: Optional[Mapping[str, Any]] = None,
+    callbacks: Optional[CallbackMap] = None,
+    **act_kwargs: Any,
+) -> tuple[str, Any]:
+    """Execute :meth:`model.act` with resolved tool definitions.
+
+    This mirrors the tool-calling workflow documented in
+    ``docs/LMStudio/developer/python/agent/act.md`` by resolving tool
+    definitions from ``tooling.py`` and forwarding any configuration or
+    callback arguments to the underlying SDK call. The return value follows
+    :func:`respond`, yielding a tuple of the assistant's final text and the raw
+    SDK result.
+    """
+
+    resolved_tools = _prepare_tools(tools, tool_names)
+    if not resolved_tools:
+        raise ValueError(
+            "No tools were provided to act(); specify tool definitions or names."
+        )
+    model = model or get_model(model_name)
+    kwargs: Dict[str, Any] = {}
+    if config is not None:
+        kwargs["config"] = config
+    if callbacks:
+        kwargs.update(callbacks)
+    kwargs.update(act_kwargs)
+    chat_input = _prepare_input(prompt_or_chat)
+    result = model.act(chat_input, resolved_tools, **kwargs)
+    return _extract_text(result), result
+
+
 class ResponseStream(Iterator[Any]):
     """Iterator wrapper for streamed responses.
 
@@ -204,6 +265,7 @@ class ChatSession:
 
     chat: lms.Chat
     model: Any
+    tools: list[Any] = field(default_factory=list)
 
     @classmethod
     def create(
@@ -213,6 +275,8 @@ class ChatSession:
         history: ChatInput | None = None,
         model: Any | None = None,
         model_name: str | None = None,
+        tools: Iterable[Any] | None = None,
+        tool_names: Sequence[str] | None = None,
     ) -> "ChatSession":
         if history is not None:
             if isinstance(history, lms.Chat):
@@ -227,7 +291,8 @@ class ChatSession:
             else:
                 chat = lms.Chat.from_history({"messages": []})
         model = model or get_model(model_name)
-        return cls(chat=chat, model=model)
+        resolved_tools = _prepare_tools(tools, tool_names)
+        return cls(chat=chat, model=model, tools=resolved_tools)
 
     def add_user_message(self, content: str) -> None:
         self.chat.add_user_message(content)
@@ -270,3 +335,44 @@ class ChatSession:
             config=config,
             callbacks=merged_callbacks,
         )
+
+    def set_tools(
+        self,
+        tools: Iterable[Any] | None = None,
+        tool_names: Sequence[str] | None = None,
+    ) -> None:
+        """Replace the active tool list for subsequent :meth:`act` calls."""
+
+        self.tools = _prepare_tools(tools, tool_names)
+
+    def act(
+        self,
+        user_message: str | None = None,
+        *,
+        tools: Iterable[Any] | None = None,
+        tool_names: Sequence[str] | None = None,
+        config: Optional[Mapping[str, Any]] = None,
+        callbacks: Optional[CallbackMap] = None,
+        **act_kwargs: Any,
+    ) -> tuple[str, Any]:
+        if user_message:
+            self.add_user_message(user_message)
+        resolved_tools = _prepare_tools(tools, tool_names, default=self.tools)
+        if not resolved_tools:
+            raise ValueError(
+                "ChatSession.act() requires at least one tool; call set_tools() or"
+                " provide tools/tool_names explicitly."
+            )
+        merged_callbacks = dict(callbacks or {})
+        merged_callbacks.setdefault("on_message", self.chat.append)
+        text, result = act(
+            self.chat,
+            tools=resolved_tools,
+            model=self.model,
+            config=config,
+            callbacks=merged_callbacks,
+            **act_kwargs,
+        )
+        # Cache the resolved tools for future rounds when overrides are provided.
+        self.tools = list(resolved_tools)
+        return text, result

--- a/docs/plans/tool-enabled-chat.md
+++ b/docs/plans/tool-enabled-chat.md
@@ -1,0 +1,66 @@
+# Plan: Tool-Enabled Chat Integrations
+
+## Background
+
+The current `chat.py` module wraps the LM Studio Python SDK's high-level chat helpers (`respond`, `respond_stream`, and `ChatSession`) but does not expose any utilities for automatic tool use. LM Studio's documentation describes the `.act()` API for multi-round tool execution and the `ToolFunctionDef` structure for defining tools. Our repository already defines several tools (`shell`, `planner`, `patch`, `file`, `process`, `git`) under `internal/tools`, and `tooling.py` gathers them into `TOOLS` and `TOOL_MAP`. However, there is no helper to surface these tools through the chat helpers, nor a convenience wrapper that mirrors the documented `.act()` workflow.
+
+## Goals
+
+1. Extend the chat utilities with functions that forward to `model.act(...)`, mirroring the LM Studio docs for automatic tool use.
+2. Allow callers to select tools by name or pass custom tool definitions, defaulting to the project's registered tools.
+3. Update `ChatSession` so a conversation can opt into tool usage while maintaining the existing respond/respond_stream behaviour.
+4. Ensure `tooling.py` exposes ergonomic helpers to fetch tool definitions by name and report all registered tools.
+5. Provide automated tests covering tool resolution and the chat/tool integration using lightweight stubs for the LM Studio SDK.
+
+## References
+
+- LM Studio Docs — Python Agent `.act()` API: `docs/LMStudio/developer/python/agent/act.md`
+- LM Studio Docs — Defining tools: `docs/LMStudio/developer/python/agent/tools.md`
+- Existing chat helpers: `chat.py`
+- Tool registry: `tooling.py` and `internal/tools/*.py`
+
+## Implementation Steps
+
+1. **Tooling enhancements**
+   - Add helper functions to `tooling.py` to look up tools by name (`get_tool`, `get_tools`).
+   - Provide a reusable `resolve_tools` utility that accepts tool names and/or explicit definitions and returns a deduplicated, ordered list of `ToolFunctionDef` instances.
+   - Update `__all__` to export the new helpers and ensure the registry still loads all tools from `internal/tools`.
+
+2. **Chat helper updates**
+   - Introduce a `_resolve_tools` helper inside `chat.py` that delegates to `tooling.resolve_tools` while handling default fallbacks.
+   - Implement a new top-level `act(...)` function that:
+     - Resolves the requested tools.
+     - Prepares chat input (string, `lms.Chat`, or mapping) consistently with existing helpers.
+     - Calls `model.act` with configuration/callback kwargs and returns `(assistant_text, raw_result)` similar to `respond`.
+     - Raises a clear error when no tools are supplied or resolved.
+   - Optionally expose an iterator-friendly wrapper if needed (e.g., future streaming), but keep scope to parity with docs for now.
+
+3. **ChatSession integration**
+   - Expand the `ChatSession` dataclass with an optional `tools` attribute storing the active tool list.
+   - Extend `ChatSession.create` to accept `tools` or `tool_names`, resolving and storing them for reuse across turns.
+   - Add methods to update tools (`set_tools`) and to execute `.act()` rounds (`act`), reusing the new top-level helper.
+   - Ensure callbacks default to appending messages to the chat history and that user messages are queued before tool execution.
+
+4. **Testing**
+   - Create lightweight LM Studio stubs (`ToolFunctionDef`, `Chat`, `llm`) inside the tests to avoid depending on the real SDK.
+   - Write tests validating:
+     - `tooling.resolve_tools` and the new lookup helpers correctly return registered tools and handle invalid names.
+     - `chat.act` forwards tool lists and merges kwargs/callbacks, returning extracted text from stubbed responses.
+     - `ChatSession.act` uses stored tools, appends user messages, and captures assistant replies via the callback stub.
+   - Use `importlib.reload` to ensure modules pick up the stubs during tests.
+
+5. **Documentation & developer notes**
+   - Keep this plan document in `docs/plans/tool-enabled-chat.md` for future contributors.
+   - Update docstrings or inline comments where necessary to reference the new tool-usage functionality.
+
+## Risk & Mitigations
+
+- **SDK availability**: Since the real `lmstudio` package may not be present in all environments, rely on stubs within tests and avoid importing `lmstudio` at test collection time before stubbing.
+- **Tool side effects**: The helpers will resolve tool definitions without executing them during tests; ensure tests do not call tool implementations directly.
+- **Backward compatibility**: Existing respond/stream behaviour should remain unchanged; keep default behaviour intact unless tools are explicitly requested.
+
+## Future Considerations
+
+- Provide higher-level orchestration utilities for multi-round inspection (progress callbacks, tool result introspection).
+- Surface richer metadata objects for `.act()` outcomes, including per-round summaries and tool execution logs.
+- Integrate configuration presets for different tool subsets once more tools are added.

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -1,0 +1,198 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _create_lmstudio_stub():
+    stub = types.ModuleType("lmstudio")
+
+    class ToolFunctionDef:
+        def __init__(self, name: str, description: str = "", parameters=None, implementation=None):
+            self.name = name
+            self.description = description
+            self.parameters = parameters or {}
+            self.implementation = implementation
+
+    class Chat:
+        def __init__(self, system_prompt: str | None = None):
+            self.messages: list[dict[str, str]] = []
+            if system_prompt:
+                self.messages.append({"role": "system", "content": system_prompt})
+
+        @classmethod
+        def from_history(cls, history):
+            chat = cls(None)
+            if isinstance(history, str):
+                chat.messages.append({"role": "system", "content": history})
+            elif isinstance(history, dict):
+                chat.messages.extend(history.get("messages", []))
+            else:
+                chat.messages.extend(history)
+            return chat
+
+        def add_user_message(self, content: str) -> None:
+            self.messages.append({"role": "user", "content": content})
+
+        def add_assistant_message(self, content: str) -> None:
+            self.messages.append({"role": "assistant", "content": content})
+
+        def append(self, message):
+            self.messages.append(message)
+
+    class FakeStream:
+        def __init__(self, fragments):
+            self._fragments = fragments
+            self._index = 0
+
+        def __iter__(self):
+            return iter(self._fragments)
+
+        def result(self):
+            return self._fragments[-1] if self._fragments else None
+
+        def wait_for_result(self):
+            return self.result()
+
+    class FakeModel:
+        def __init__(self):
+            self.respond_calls = []
+            self.respond_stream_calls = []
+            self.act_calls = []
+
+        def respond(self, chat_input, **kwargs):
+            self.respond_calls.append((chat_input, kwargs))
+            if callback := kwargs.get("on_message"):
+                callback({"role": "assistant", "content": "respond"})
+            return types.SimpleNamespace(message=types.SimpleNamespace(content="respond"))
+
+        def respond_stream(self, chat_input, **kwargs):
+            self.respond_stream_calls.append((chat_input, kwargs))
+            fragments = [types.SimpleNamespace(content="fragment1"), types.SimpleNamespace(content="fragment2")]
+            return FakeStream(fragments)
+
+        def act(self, chat_input, tools, **kwargs):
+            self.act_calls.append((chat_input, tools, kwargs))
+            if callback := kwargs.get("on_message"):
+                callback({"role": "assistant", "content": "act result"})
+            return types.SimpleNamespace(message=types.SimpleNamespace(content="act result"))
+
+    def llm(name=None, **kwargs):
+        return FakeModel()
+
+    stub.ToolFunctionDef = ToolFunctionDef
+    stub.Chat = Chat
+    stub.llm = llm
+    stub.FakeModel = FakeModel
+    return stub
+
+
+@pytest.fixture()
+def lmstudio_env(monkeypatch):
+    stub = _create_lmstudio_stub()
+    monkeypatch.setitem(sys.modules, "lmstudio", stub)
+
+    psutil_stub = types.ModuleType("psutil")
+
+    class _FakePsutilProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def kill(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            return 0
+
+        def is_running(self):
+            return False
+
+        def as_dict(self, attrs=None):
+            return {attr: None for attr in (attrs or [])}
+
+        def children(self, recursive=False):
+            return []
+
+    def _process_iter(attrs=None):
+        return iter(())
+
+    psutil_stub.Process = _FakePsutilProcess
+    psutil_stub.NoSuchProcess = RuntimeError
+    psutil_stub.TimeoutExpired = RuntimeError
+    psutil_stub.process_iter = _process_iter
+    monkeypatch.setitem(sys.modules, "psutil", psutil_stub)
+
+    for module_name in [
+        "tooling",
+        "chat",
+        "internal.tools.shell",
+        "internal.tools.planner",
+        "internal.tools.patch",
+        "internal.tools.file",
+        "internal.tools.process",
+        "internal.tools.git",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    tooling = importlib.import_module("tooling")
+    chat = importlib.import_module("chat")
+    return types.SimpleNamespace(stub=stub, tooling=tooling, chat=chat)
+
+
+def test_get_tools_by_name_deduplicates(lmstudio_env):
+    tooling = lmstudio_env.tooling
+    all_tools = tooling.get_all_tools()
+    names = [all_tools[0].name, all_tools[0].name]
+    resolved = tooling.get_tools(names)
+    assert [tool.name for tool in resolved] == [all_tools[0].name]
+
+
+def test_resolve_tools_combines_sources(lmstudio_env):
+    tooling = lmstudio_env.tooling
+    first, second = tooling.get_all_tools()[:2]
+    resolved = tooling.resolve_tools(tools=[first], tool_names=[second.name, first.name])
+    assert resolved == [first, second]
+
+
+def test_act_requires_tools(lmstudio_env):
+    chat = lmstudio_env.chat
+    with pytest.raises(ValueError):
+        chat.act("hello", model=lmstudio_env.stub.FakeModel())
+
+
+def test_act_invokes_model_with_resolved_tools(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    tooling = lmstudio_env.tooling
+    model = lmstudio_env.stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    text, result = chat_mod.act("hi", tools=[tool], model=model)
+    assert text == "act result"
+    assert result.message.content == "act result"
+    assert model.act_calls[0][1] == [tool]
+
+
+def test_chat_session_act_updates_history_and_tools(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    tooling = lmstudio_env.tooling
+    stub = lmstudio_env.stub
+    chat_instance = stub.Chat("system")
+    model = stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    session = chat_mod.ChatSession(chat=chat_instance, model=model, tools=[tool])
+    text, _ = session.act("do something")
+    assert text == "act result"
+    assert chat_instance.messages[-1]["content"] == "act result"
+    assert session.tools == [tool]
+    assert model.act_calls[0][1] == [tool]
+
+
+def test_chat_session_act_requires_tools(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    stub = lmstudio_env.stub
+    session = chat_mod.ChatSession(chat=stub.Chat("system"), model=stub.FakeModel())
+    with pytest.raises(ValueError):
+        session.act("hello")

--- a/tooling.py
+++ b/tooling.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Sequence
+
 from lmstudio import ToolFunctionDef
 
 # Explicitly import and expose tools from internal/tools
@@ -23,12 +28,66 @@ TOOL_MAP: dict[str, ToolFunctionDef] = {t.name: t for t in TOOLS}
 
 
 def get_all_tools() -> list[ToolFunctionDef]:
-    """Returns a list of all ToolFunctionDef objects available in the project."""
+    """Return a shallow copy of every registered :class:`ToolFunctionDef`."""
+
     return list(TOOLS)
+
+
+def get_tool(name: str) -> ToolFunctionDef:
+    """Return a tool definition by name.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` does not correspond to a registered tool.
+    """
+
+    return TOOL_MAP[name]
+
+
+def get_tools(names: Sequence[str] | None = None) -> list[ToolFunctionDef]:
+    """Return tool definitions matching ``names``.
+
+    When ``names`` is ``None`` the full registry is returned. Duplicate names
+    are ignored while preserving the requested order.
+    """
+
+    if names is None:
+        return get_all_tools()
+    seen: set[str] = set()
+    resolved: list[ToolFunctionDef] = []
+    for name in names:
+        if name in seen:
+            continue
+        resolved.append(get_tool(name))
+        seen.add(name)
+    return resolved
+
+
+def resolve_tools(
+    *,
+    tools: Iterable[ToolFunctionDef] | None = None,
+    tool_names: Sequence[str] | None = None,
+) -> list[ToolFunctionDef]:
+    """Resolve explicit tool definitions and names into a merged tool list."""
+
+    resolved: list[ToolFunctionDef] = []
+    if tools is not None:
+        for tool in tools:
+            if tool not in resolved:
+                resolved.append(tool)
+    if tool_names is not None:
+        for tool in get_tools(tool_names):
+            if tool not in resolved:
+                resolved.append(tool)
+    return resolved
 
 
 __all__ = [
     "get_all_tools",
+    "get_tool",
+    "get_tools",
+    "resolve_tools",
     "TOOLS",
     "TOOL_MAP",
 ] + [t.name + "_tool" for t in TOOLS if hasattr(t, 'name')]


### PR DESCRIPTION
## Summary
- document the plan for adding tool-enabled chat helpers
- extend the chat utilities with `act` support, session tooling management, and helper wiring to the tool registry
- expose additional tooling lookup helpers so chat can resolve registered tools by name and add regression tests with LM Studio stubs

## Testing
- pytest tests/test_chat_tools.py


------
https://chatgpt.com/codex/tasks/task_b_68e4be593620832faa89630ad2fdfb21