### PR TITLE
Add LM Studio agent session orchestration helpers

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -266,6 +266,7 @@ class ChatSession:
     chat: lms.Chat
     model: Any
     tools: list[Any] = field(default_factory=list)
+    system_prompt: str | None = None
 
     @classmethod
     def create(
@@ -278,6 +279,7 @@ class ChatSession:
         tools: Iterable[Any] | None = None,
         tool_names: Sequence[str] | None = None,
     ) -> "ChatSession":
+        system = system_prompt
         if history is not None:
             if isinstance(history, lms.Chat):
                 chat = history
@@ -285,6 +287,10 @@ class ChatSession:
                 chat = lms.Chat.from_history(history)
             else:
                 chat = lms.Chat.from_history(history)
+            if system is None and getattr(chat, "messages", None):
+                first_message = chat.messages[0]
+                if isinstance(first_message, Mapping) and first_message.get("role") == "system":
+                    system = first_message.get("content")
         else:
             if system_prompt is not None:
                 chat = lms.Chat(system_prompt)
@@ -292,13 +298,53 @@ class ChatSession:
                 chat = lms.Chat.from_history({"messages": []})
         model = model or get_model(model_name)
         resolved_tools = _prepare_tools(tools, tool_names)
-        return cls(chat=chat, model=model, tools=resolved_tools)
+        return cls(chat=chat, model=model, tools=resolved_tools, system_prompt=system)
 
     def add_user_message(self, content: str) -> None:
         self.chat.add_user_message(content)
 
     def add_assistant_message(self, content: str) -> None:
         self.chat.add_assistant_message(content)
+
+    def append_user_input(self, content: str) -> None:
+        """Alias for :meth:`add_user_message` for parity with agent helpers."""
+
+        self.add_user_message(content)
+
+    def append_tool_response(
+        self,
+        content: str,
+        *,
+        name: str | None = None,
+        tool_call_id: str | None = None,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Append a tool response message to the chat history.
+
+        Parameters
+        ----------
+        content:
+            Tool output text to record in the chat transcript.
+        name:
+            Optional tool name associated with the response.
+        tool_call_id:
+            Identifier correlating the response with a prior tool invocation.
+        payload:
+            Optional mapping merged into the message before appending. This is
+            convenient when callers want to preserve additional metadata (e.g.,
+            structured outputs) in the chat history.
+        """
+
+        message: Dict[str, Any] = {"role": "tool", "content": content}
+        if name is not None:
+            message["name"] = name
+        if tool_call_id is not None:
+            message["tool_call_id"] = tool_call_id
+        if payload:
+            for key, value in payload.items():
+                if key not in message:
+                    message[key] = value
+        self.chat.append(message)
 
     def send(
         self,

--- a/session.py
+++ b/session.py
@@ -1,1 +1,303 @@
-# session.py
+"""High-level session orchestration for LM Studio agent workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from chat import CallbackMap, ChatSession
+
+__all__ = ["AgentRound", "AgentSession"]
+
+
+Hook = Callable[..., None]
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, set):
+        return list(value)
+    return [value]
+
+
+def _coerce_mapping(obj: Any) -> Mapping[str, Any] | None:
+    if isinstance(obj, Mapping):
+        return obj
+    return None
+
+
+def _extract_sequence(obj: Any, names: Sequence[str]) -> list[Any]:
+    for name in names:
+        if isinstance(obj, Mapping) and name in obj:
+            return _as_list(obj[name])
+        if hasattr(obj, name):
+            return _as_list(getattr(obj, name))
+    return []
+
+
+@dataclass(slots=True)
+class AgentRound:
+    """Container for per-round metadata captured by :class:`AgentSession`."""
+
+    index: int
+    user_message: str | None
+    response_text: str
+    result: Any
+    transcript: list[Any]
+    messages: list[Any] = field(default_factory=list)
+    tool_history: dict[str, list[Any]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "user_message": self.user_message,
+            "response_text": self.response_text,
+            "result": self.result,
+            "transcript": list(self.transcript),
+            "messages": list(self.messages),
+            "tool_history": {
+                key: list(values) for key, values in self.tool_history.items()
+            },
+        }
+
+
+class AgentSession:
+    """Wrap LM Studio ``model.act`` calls with convenient state tracking."""
+
+    def __init__(
+        self,
+        *,
+        system_prompt: str | None = None,
+        history: Any | None = None,
+        model: Any | None = None,
+        model_name: str | None = None,
+        tools: Iterable[Any] | None = None,
+        tool_names: Sequence[str] | None = None,
+        callbacks: Optional[CallbackMap] = None,
+        on_message: Hook | None = None,
+        on_tool_call: Hook | None = None,
+        on_tool_result: Hook | None = None,
+        on_round_start: Hook | None = None,
+        on_round_end: Hook | None = None,
+    ) -> None:
+        self.chat_session = ChatSession.create(
+            system_prompt=system_prompt,
+            history=history,
+            model=model,
+            model_name=model_name,
+            tools=tools,
+            tool_names=tool_names,
+        )
+        self._base_callbacks: dict[str, Callable[..., Any]] = dict(callbacks or {})
+        self._current_messages: list[Any] = []
+        self._current_tool_calls: list[Any] = []
+        self._current_tool_results: list[Any] = []
+        self._on_message = on_message
+        self._on_tool_call = on_tool_call
+        self._on_tool_result = on_tool_result
+        self._on_round_start = on_round_start
+        self._on_round_end = on_round_end
+        self.rounds: list[AgentRound] = []
+
+    @property
+    def model(self) -> Any:
+        return self.chat_session.model
+
+    @property
+    def tools(self) -> list[Any]:
+        return self.chat_session.tools
+
+    @property
+    def system_prompt(self) -> str | None:
+        return self.chat_session.system_prompt
+
+    @property
+    def transcript(self) -> list[Any]:
+        messages = getattr(self.chat_session.chat, "messages", [])
+        return [message.copy() if isinstance(message, dict) else message for message in messages]
+
+    def set_tools(
+        self,
+        tools: Iterable[Any] | None = None,
+        tool_names: Sequence[str] | None = None,
+    ) -> None:
+        self.chat_session.set_tools(tools, tool_names)
+
+    def append_user_input(self, content: str) -> None:
+        self.chat_session.append_user_input(content)
+
+    def append_tool_response(
+        self,
+        content: str,
+        *,
+        name: str | None = None,
+        tool_call_id: str | None = None,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.chat_session.append_tool_response(
+            content,
+            name=name,
+            tool_call_id=tool_call_id,
+            payload=payload,
+        )
+
+    def _compose_callbacks(self, callbacks: Optional[CallbackMap]) -> dict[str, Callable[..., Any]]:
+        merged: dict[str, Callable[..., Any]] = dict(self._base_callbacks)
+        if callbacks:
+            merged.update(callbacks)
+
+        downstream_on_message = merged.get("on_message")
+        downstream_tool_call = merged.get("on_tool_call")
+        downstream_tool_result = merged.get("on_tool_result")
+
+        def handle_message(message: Any, *args: Any, **kwargs: Any) -> None:
+            appended_via_downstream = False
+            if downstream_on_message and downstream_on_message is not handle_message:
+                downstream_on_message(message, *args, **kwargs)
+                appended_via_downstream = (
+                    getattr(downstream_on_message, "__self__", None)
+                    is self.chat_session.chat
+                    and getattr(downstream_on_message, "__func__", None)
+                    is getattr(self.chat_session.chat.append, "__func__", None)
+                )
+            if not appended_via_downstream:
+                self.chat_session.chat.append(message)
+            self._current_messages.append(message)
+            if self._on_message:
+                self._on_message(message)
+
+        def handle_tool_call(call: Any, *args: Any, **kwargs: Any) -> None:
+            if downstream_tool_call and downstream_tool_call is not handle_tool_call:
+                downstream_tool_call(call, *args, **kwargs)
+            self._current_tool_calls.append(call)
+            if self._on_tool_call:
+                self._on_tool_call(call)
+
+        def handle_tool_result(result: Any, *args: Any, **kwargs: Any) -> None:
+            if downstream_tool_result and downstream_tool_result is not handle_tool_result:
+                downstream_tool_result(result, *args, **kwargs)
+            self._current_tool_results.append(result)
+            self._append_tool_result_to_chat(result)
+            if self._on_tool_result:
+                self._on_tool_result(result)
+
+        merged["on_message"] = handle_message
+        merged["on_tool_call"] = handle_tool_call
+        merged["on_tool_result"] = handle_tool_result
+        return merged
+
+    def _append_tool_result_to_chat(self, result: Any) -> None:
+        mapping = _coerce_mapping(result)
+        if mapping is not None:
+            if mapping.get("role") == "tool":
+                self.chat_session.chat.append(dict(mapping))
+                return
+            content = mapping.get("content") or mapping.get("output") or mapping.get("result")
+            if content is not None:
+                payload = mapping.copy()
+                payload.pop("content", None)
+                payload.pop("output", None)
+                payload.pop("result", None)
+                name = payload.pop("name", None)
+                tool_call_id = payload.pop("tool_call_id", None) or payload.pop("id", None)
+                self.append_tool_response(
+                    str(content),
+                    name=name,
+                    tool_call_id=tool_call_id,
+                    payload=payload if payload else None,
+                )
+                return
+        if isinstance(result, str):
+            self.append_tool_response(result)
+
+    def _finalize_round(
+        self,
+        *,
+        index: int,
+        user_message: str | None,
+        response_text: str,
+        result: Any,
+    ) -> AgentRound:
+        transcript_snapshot = self.transcript
+        tool_calls = list(self._current_tool_calls)
+        tool_results = list(self._current_tool_results)
+
+        result_calls = _extract_sequence(result, ("tool_calls", "toolInvocations", "tool_invocations"))
+        result_results = _extract_sequence(result, ("tool_results", "toolOutputs", "tool_outputs"))
+
+        if result_calls:
+            tool_calls.extend(item for item in result_calls if item not in tool_calls)
+        if result_results:
+            tool_results.extend(item for item in result_results if item not in tool_results)
+
+        round_record = AgentRound(
+            index=index,
+            user_message=user_message,
+            response_text=response_text,
+            result=result,
+            transcript=transcript_snapshot,
+            messages=list(self._current_messages),
+            tool_history={
+                "calls": tool_calls,
+                "results": tool_results,
+            },
+        )
+        return round_record
+
+    def act(
+        self,
+        user_message: str | None = None,
+        *,
+        tools: Iterable[Any] | None = None,
+        tool_names: Sequence[str] | None = None,
+        config: Optional[Mapping[str, Any]] = None,
+        callbacks: Optional[CallbackMap] = None,
+        **act_kwargs: Any,
+    ) -> tuple[str, Any]:
+        self._current_messages = []
+        self._current_tool_calls = []
+        self._current_tool_results = []
+
+        round_index = len(self.rounds)
+        if self._on_round_start:
+            self._on_round_start({
+                "index": round_index,
+                "user_message": user_message,
+                "session": self,
+            })
+
+        composed_callbacks = self._compose_callbacks(callbacks)
+        text, result = self.chat_session.act(
+            user_message,
+            tools=tools,
+            tool_names=tool_names,
+            config=config,
+            callbacks=composed_callbacks,
+            **act_kwargs,
+        )
+
+        round_record = self._finalize_round(
+            index=round_index,
+            user_message=user_message,
+            response_text=text,
+            result=result,
+        )
+        self.rounds.append(round_record)
+
+        if self._on_round_end:
+            self._on_round_end(round_record)
+
+        return text, result
+
+    def last_round(self) -> AgentRound | None:
+        return self.rounds[-1] if self.rounds else None
+
+    @property
+    def tool_history(self) -> list[dict[str, list[Any]]]:
+        return [round.tool_history for round in self.rounds]

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+from typing import Any
 
 import pytest
 
@@ -17,6 +18,7 @@ def _create_lmstudio_stub():
 
     class Chat:
         def __init__(self, system_prompt: str | None = None):
+            self.system_prompt = system_prompt
             self.messages: list[dict[str, str]] = []
             if system_prompt:
                 self.messages.append({"role": "system", "content": system_prompt})
@@ -39,6 +41,14 @@ def _create_lmstudio_stub():
             self.messages.append({"role": "assistant", "content": content})
 
         def append(self, message):
+            self.messages.append(message)
+
+        def add_tool_message(self, content: str, *, name: str | None = None, tool_call_id: str | None = None):
+            message = {"role": "tool", "content": content}
+            if name is not None:
+                message["name"] = name
+            if tool_call_id is not None:
+                message["tool_call_id"] = tool_call_id
             self.messages.append(message)
 
     class FakeStream:
@@ -74,9 +84,24 @@ def _create_lmstudio_stub():
 
         def act(self, chat_input, tools, **kwargs):
             self.act_calls.append((chat_input, tools, kwargs))
+            tool_call = {"id": "call-1", "name": "demo", "arguments": {"value": 1}}
+            if tool_call_cb := kwargs.get("on_tool_call"):
+                tool_call_cb(tool_call)
+            tool_result = {
+                "role": "tool",
+                "content": "tool output",
+                "name": "demo",
+                "tool_call_id": "call-1",
+            }
+            if tool_result_cb := kwargs.get("on_tool_result"):
+                tool_result_cb(tool_result)
             if callback := kwargs.get("on_message"):
                 callback({"role": "assistant", "content": "act result"})
-            return types.SimpleNamespace(message=types.SimpleNamespace(content="act result"))
+            return types.SimpleNamespace(
+                message=types.SimpleNamespace(content="act result"),
+                tool_calls=[tool_call],
+                tool_results=[tool_result],
+            )
 
     def llm(name=None, **kwargs):
         return FakeModel()
@@ -129,6 +154,7 @@ def lmstudio_env(monkeypatch):
     for module_name in [
         "tooling",
         "chat",
+        "session",
         "internal.tools.shell",
         "internal.tools.planner",
         "internal.tools.patch",
@@ -140,7 +166,8 @@ def lmstudio_env(monkeypatch):
 
     tooling = importlib.import_module("tooling")
     chat = importlib.import_module("chat")
-    return types.SimpleNamespace(stub=stub, tooling=tooling, chat=chat)
+    session = importlib.import_module("session")
+    return types.SimpleNamespace(stub=stub, tooling=tooling, chat=chat, session=session)
 
 
 def test_get_tools_by_name_deduplicates(lmstudio_env):
@@ -196,3 +223,81 @@ def test_chat_session_act_requires_tools(lmstudio_env):
     session = chat_mod.ChatSession(chat=stub.Chat("system"), model=stub.FakeModel())
     with pytest.raises(ValueError):
         session.act("hello")
+
+
+def test_chat_session_create_tracks_system_prompt(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    stub = lmstudio_env.stub
+    model = stub.FakeModel()
+    session = chat_mod.ChatSession.create(system_prompt="base", model=model)
+    assert session.system_prompt == "base"
+    assert session.chat.messages[0]["content"] == "base"
+
+
+def test_chat_session_append_tool_response_records_metadata(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    stub = lmstudio_env.stub
+    session = chat_mod.ChatSession(chat=stub.Chat("system"), model=stub.FakeModel())
+    session.append_tool_response("done", name="demo", tool_call_id="call-1")
+    assert session.chat.messages[-1] == {
+        "role": "tool",
+        "content": "done",
+        "name": "demo",
+        "tool_call_id": "call-1",
+    }
+
+
+def test_agent_session_records_round_metadata(lmstudio_env):
+    session_mod = lmstudio_env.session
+    tooling = lmstudio_env.tooling
+    model = lmstudio_env.stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    agent = session_mod.AgentSession(system_prompt="sys", model=model, tools=[tool])
+    text, result = agent.act("hello")
+    assert text == "act result"
+    assert result.tool_calls[0]["name"] == "demo"
+    recorded_round = agent.last_round()
+    assert recorded_round is not None
+    assert recorded_round.user_message == "hello"
+    assert recorded_round.tool_history["results"][0]["role"] == "tool"
+    assert agent.transcript[-1]["content"] == "act result"
+
+
+def test_agent_session_hooks_fire(lmstudio_env):
+    session_mod = lmstudio_env.session
+    tooling = lmstudio_env.tooling
+    model = lmstudio_env.stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    events: list[tuple[str, Any]] = []
+
+    def on_message(message):
+        events.append(("message", message))
+
+    def on_tool_call(call):
+        events.append(("tool_call", call))
+
+    def on_tool_result(result):
+        events.append(("tool_result", result))
+
+    def on_round_start(ctx):
+        events.append(("start", ctx["index"]))
+
+    def on_round_end(round_record):
+        events.append(("end", round_record.index))
+
+    agent = session_mod.AgentSession(
+        system_prompt="sys",
+        model=model,
+        tools=[tool],
+        on_message=on_message,
+        on_tool_call=on_tool_call,
+        on_tool_result=on_tool_result,
+        on_round_start=on_round_start,
+        on_round_end=on_round_end,
+    )
+    agent.act("hi there")
+    assert ("start", 0) in events
+    assert any(event[0] == "message" for event in events)
+    assert any(event[0] == "tool_call" for event in events)
+    assert any(event[0] == "tool_result" for event in events)
+    assert ("end", 0) in events


### PR DESCRIPTION
## Summary
- instantiate `ChatSession` with an optional system prompt and add helpers to append user and tool messages
- introduce an `AgentSession` wrapper that orchestrates `model.act` rounds, captures transcripts/tool history, and exposes lifecycle hooks
- extend the LM Studio stubs and unit tests to cover the new session behavior

## Testing
- pytest tests/test_chat_tools.py

------
https://chatgpt.com/codex/tasks/task_b_68e4cf4c655c832fa7706a1cedaf730b