### PR TITLE
Add structured response handling to chat act helpers

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, Optional, Sequence, Union
 
 import lmstudio as lms
 
+from internal.schemas import SchemaError, SchemaLike, build_response_format
+from internal.structures import StructuredResponse
 from tooling import resolve_tools
 
 ChatInput = Union[str, lms.Chat, Mapping[str, Any]]
@@ -87,12 +89,118 @@ def _extract_text(result: Any) -> str:
     for attr in ("content", "text"):
         if hasattr(result, attr):
             return getattr(result, attr)
+    if isinstance(result, Mapping):
+        message = result.get("message")
+        if isinstance(message, Mapping):
+            for attr in ("content", "text"):
+                value = message.get(attr)
+                if isinstance(value, str):
+                    return value
+        content = result.get("content")
+        if isinstance(content, str):
+            return content
+        choices = result.get("choices")
+        if isinstance(choices, Sequence) and choices:
+            first_choice = choices[0]
+            if isinstance(first_choice, Mapping):
+                choice_message = first_choice.get("message")
+                if isinstance(choice_message, Mapping):
+                    for attr in ("content", "text"):
+                        value = choice_message.get(attr)
+                        if isinstance(value, str):
+                            return value
+                for attr in ("content", "text"):
+                    value = first_choice.get(attr)
+                    if isinstance(value, str):
+                        return value
     message = getattr(result, "message", None)
     if message is not None:
         for attr in ("content", "text"):
             if hasattr(message, attr):
                 return getattr(message, attr)
     return ""
+
+
+def _coerce_response_mapping(result: Any) -> Mapping[str, Any]:
+    if isinstance(result, Mapping):
+        return result
+    for attr in ("raw_response", "response"):
+        candidate = getattr(result, attr, None)
+        if isinstance(candidate, Mapping):
+            return candidate
+    for method_name in ("to_dict", "model_dump", "dict"):
+        method = getattr(result, method_name, None)
+        if callable(method):
+            candidate = method()
+            if isinstance(candidate, Mapping):
+                return candidate
+    try:
+        mapping = vars(result)
+    except TypeError:  # pragma: no cover - non-object fallback
+        mapping = None
+    if isinstance(mapping, Mapping):
+        return mapping
+    raise TypeError("Model.act response must be a mapping-compatible object.")
+
+
+def _resolve_response_format(
+    *,
+    schema: SchemaLike | None = None,
+    response_format: Any | None = None,
+    schema_name: str | None = None,
+    strict: bool = True,
+) -> tuple[dict[str, Any] | None, Mapping[str, Any] | None, bool]:
+    if schema is not None and response_format is not None:
+        raise ValueError("Specify either schema or response_format, not both.")
+
+    if schema is None and response_format is None:
+        return None, None, False
+
+    payload: dict[str, Any] | None = None
+    normalized_schema: Mapping[str, Any] | None = None
+
+    candidate = schema if schema is not None else response_format
+
+    if hasattr(candidate, "as_response_format") and callable(
+        getattr(candidate, "as_response_format")
+    ):
+        payload = candidate.as_response_format()  # type: ignore[assignment]
+        if isinstance(payload, Mapping):
+            json_schema = payload.get("json_schema")
+            if isinstance(json_schema, Mapping):
+                normalized_schema = json_schema.get("schema")  # type: ignore[assignment]
+                strict_flag = json_schema.get("strict")
+                if isinstance(strict_flag, bool):
+                    strict = strict_flag
+        payload = dict(payload)  # shallow copy for mutation safety
+    elif isinstance(candidate, Mapping) and {
+        "type",
+        "json_schema",
+    }.issubset(candidate.keys()):
+        payload = dict(candidate)
+        json_schema = candidate.get("json_schema")
+        if isinstance(json_schema, Mapping):
+            normalized_schema = json_schema.get("schema")  # type: ignore[assignment]
+            strict_flag = json_schema.get("strict")
+            if isinstance(strict_flag, bool):
+                strict = strict_flag
+    else:
+        schema_like: Any = candidate
+        if isinstance(candidate, Mapping) and "schema" in candidate:
+            schema_like = candidate["schema"]
+            if schema_name is None and isinstance(candidate.get("name"), str):
+                schema_name = candidate["name"]
+            if "strict" in candidate:
+                strict = bool(candidate["strict"])
+        payload = build_response_format(schema_like, name=schema_name, strict=strict)
+        json_schema = payload.get("json_schema")
+        if isinstance(json_schema, Mapping):
+            normalized_schema = json_schema.get("schema")  # type: ignore[assignment]
+
+    if payload is None:
+        return None, None, False
+
+    return payload, normalized_schema, True
 
 
 def respond(
@@ -152,8 +260,12 @@ def act(
     model_name: str | None = None,
     config: Optional[Mapping[str, Any]] = None,
     callbacks: Optional[CallbackMap] = None,
+    schema: SchemaLike | None = None,
+    response_format: Any | None = None,
+    schema_name: str | None = None,
+    strict_schema: bool = True,
     **act_kwargs: Any,
-) -> tuple[str, Any]:
+) -> tuple[str, StructuredResponse]:
     """Execute :meth:`model.act` with resolved tool definitions.
 
     This mirrors the tool-calling workflow documented in
@@ -176,9 +288,31 @@ def act(
     if callbacks:
         kwargs.update(callbacks)
     kwargs.update(act_kwargs)
+    response_payload, normalized_schema, expect_structured = _resolve_response_format(
+        schema=schema,
+        response_format=response_format,
+        schema_name=schema_name,
+        strict=strict_schema,
+    )
+    if response_payload is not None:
+        kwargs["response_format"] = response_payload
     chat_input = _prepare_input(prompt_or_chat)
     result = model.act(chat_input, resolved_tools, **kwargs)
-    return _extract_text(result), result
+    raw_payload = _coerce_response_mapping(result)
+    fallback_text = _extract_text(raw_payload)
+    try:
+        structured = StructuredResponse.from_response(
+            raw_payload,
+            schema=normalized_schema,
+            structured=expect_structured,
+            fallback_text=fallback_text,
+        )
+    except SchemaError as exc:
+        message = "Model response did not match the expected structured schema"
+        if fallback_text:
+            message = f"{message}: {fallback_text!r}"
+        raise SchemaError(message) from exc
+    return structured.content, structured
 
 
 class ResponseStream(Iterator[Any]):
@@ -399,6 +533,10 @@ class ChatSession:
         tool_names: Sequence[str] | None = None,
         config: Optional[Mapping[str, Any]] = None,
         callbacks: Optional[CallbackMap] = None,
+        schema: SchemaLike | None = None,
+        response_format: Any | None = None,
+        schema_name: str | None = None,
+        strict_schema: bool = True,
         **act_kwargs: Any,
     ) -> tuple[str, Any]:
         if user_message:
@@ -417,6 +555,10 @@ class ChatSession:
             model=self.model,
             config=config,
             callbacks=merged_callbacks,
+            schema=schema,
+            response_format=response_format,
+            schema_name=schema_name,
+            strict_schema=strict_schema,
             **act_kwargs,
         )
         # Cache the resolved tools for future rounds when overrides are provided.

--- a/session.py
+++ b/session.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from chat import CallbackMap, ChatSession
+from internal.structures import StructuredResponse
 
 __all__ = ["AgentRound", "AgentSession"]
 
@@ -33,6 +34,8 @@ def _coerce_mapping(obj: Any) -> Mapping[str, Any] | None:
 
 
 def _extract_sequence(obj: Any, names: Sequence[str]) -> list[Any]:
+    if isinstance(obj, StructuredResponse):
+        return _extract_sequence(obj.raw_response, names)
     for name in names:
         if isinstance(obj, Mapping) and name in obj:
             return _as_list(obj[name])
@@ -48,7 +51,7 @@ class AgentRound:
     index: int
     user_message: str | None
     response_text: str
-    result: Any
+    result: StructuredResponse
     transcript: list[Any]
     messages: list[Any] = field(default_factory=list)
     tool_history: dict[str, list[Any]] = field(default_factory=dict)
@@ -222,7 +225,7 @@ class AgentSession:
         index: int,
         user_message: str | None,
         response_text: str,
-        result: Any,
+        result: StructuredResponse,
     ) -> AgentRound:
         transcript_snapshot = self.transcript
         tool_calls = list(self._current_tool_calls)
@@ -259,7 +262,7 @@ class AgentSession:
         config: Optional[Mapping[str, Any]] = None,
         callbacks: Optional[CallbackMap] = None,
         **act_kwargs: Any,
-    ) -> tuple[str, Any]:
+    ) -> tuple[str, StructuredResponse]:
         self._current_messages = []
         self._current_tool_calls = []
         self._current_tool_results = []

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import pytest
 
+from internal.schemas import SchemaError
+
 
 def _create_lmstudio_stub():
     stub = types.ModuleType("lmstudio")
@@ -70,6 +72,7 @@ def _create_lmstudio_stub():
             self.respond_calls = []
             self.respond_stream_calls = []
             self.act_calls = []
+            self.next_act_response: Any | None = None
 
         def respond(self, chat_input, **kwargs):
             self.respond_calls.append((chat_input, kwargs))
@@ -97,11 +100,22 @@ def _create_lmstudio_stub():
                 tool_result_cb(tool_result)
             if callback := kwargs.get("on_message"):
                 callback({"role": "assistant", "content": "act result"})
-            return types.SimpleNamespace(
-                message=types.SimpleNamespace(content="act result"),
-                tool_calls=[tool_call],
-                tool_results=[tool_result],
-            )
+            if self.next_act_response is not None:
+                return self.next_act_response
+            response: dict[str, Any] = {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "act result",
+                            "parsed": {"value": 1},
+                        }
+                    }
+                ],
+                "tool_calls": [tool_call],
+                "tool_results": [tool_result],
+            }
+            return response
 
     def llm(name=None, **kwargs):
         return FakeModel()
@@ -198,7 +212,8 @@ def test_act_invokes_model_with_resolved_tools(lmstudio_env):
     tool = tooling.get_all_tools()[0]
     text, result = chat_mod.act("hi", tools=[tool], model=model)
     assert text == "act result"
-    assert result.message.content == "act result"
+    assert result.content == "act result"
+    assert result.parsed is None
     assert model.act_calls[0][1] == [tool]
 
 
@@ -210,10 +225,11 @@ def test_chat_session_act_updates_history_and_tools(lmstudio_env):
     model = stub.FakeModel()
     tool = tooling.get_all_tools()[0]
     session = chat_mod.ChatSession(chat=chat_instance, model=model, tools=[tool])
-    text, _ = session.act("do something")
+    text, structured = session.act("do something")
     assert text == "act result"
     assert chat_instance.messages[-1]["content"] == "act result"
     assert session.tools == [tool]
+    assert structured.parsed is None
     assert model.act_calls[0][1] == [tool]
 
 
@@ -255,7 +271,7 @@ def test_agent_session_records_round_metadata(lmstudio_env):
     agent = session_mod.AgentSession(system_prompt="sys", model=model, tools=[tool])
     text, result = agent.act("hello")
     assert text == "act result"
-    assert result.tool_calls[0]["name"] == "demo"
+    assert result.raw_response["tool_calls"][0]["name"] == "demo"
     recorded_round = agent.last_round()
     assert recorded_round is not None
     assert recorded_round.user_message == "hello"
@@ -301,3 +317,80 @@ def test_agent_session_hooks_fire(lmstudio_env):
     assert any(event[0] == "tool_call" for event in events)
     assert any(event[0] == "tool_result" for event in events)
     assert ("end", 0) in events
+
+
+def test_act_accepts_schema_and_returns_structured(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    tooling = lmstudio_env.tooling
+    model = lmstudio_env.stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+        "required": ["value"],
+    }
+    text, result = chat_mod.act(
+        "hi",
+        tools=[tool],
+        model=model,
+        schema=schema,
+        schema_name="value_schema",
+        strict_schema=False,
+    )
+    assert text == "act result"
+    response_format = model.act_calls[0][2]["response_format"]
+    assert response_format["json_schema"]["schema"] == schema
+    assert response_format["json_schema"]["name"] == "value_schema"
+    assert response_format["json_schema"]["strict"] is False
+    assert result.parsed == {"value": 1}
+    assert result.schema == schema
+
+
+def test_chat_session_act_supports_response_format_mapping(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    tooling = lmstudio_env.tooling
+    stub = lmstudio_env.stub
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+        "required": ["value"],
+    }
+    session = chat_mod.ChatSession.create(
+        system_prompt="sys",
+        model=stub.FakeModel(),
+        tools=[tooling.get_all_tools()[0]],
+    )
+    response_format = {"schema": schema, "name": "custom", "strict": False}
+    _, structured = session.act("hello", response_format=response_format)
+    assert structured.parsed == {"value": 1}
+    assert structured.schema == schema
+    model_call = session.model.act_calls[0]
+    assert model_call[2]["response_format"]["json_schema"]["name"] == "custom"
+    assert model_call[2]["response_format"]["json_schema"]["strict"] is False
+
+
+def test_act_raises_schema_error_with_invalid_json(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    tooling = lmstudio_env.tooling
+    model = lmstudio_env.stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    model.next_act_response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "not json",
+                }
+            }
+        ],
+        "tool_calls": [],
+        "tool_results": [],
+    }
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+        "required": ["value"],
+    }
+    with pytest.raises(SchemaError) as excinfo:
+        chat_mod.act("hi", tools=[tool], model=model, schema=schema)
+    assert "not json" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- allow chat.act to accept schema or response_format hints, forward them through build_response_format, and parse results via StructuredResponse
- return StructuredResponse objects through ChatSession and AgentSession tracking so tool history can still be aggregated
- extend chat tool tests to cover structured output success and failure paths

## Testing
- pytest tests/test_chat_tools.py tests/test_schemas.py tests/test_structures.py

------
https://chatgpt.com/codex/tasks/task_b_68e4d1a4e2f4832f8743752a094913f8