### PR TITLE
Enhance tool registry and agent error handling

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -15,11 +15,11 @@ import lmstudio as lms
 
 from internal.schemas import SchemaError, SchemaLike, build_response_format
 from internal.structures import StructuredResponse
-from tooling import resolve_tools
+from tooling import ToolSpec, resolve_tools
 
 ChatInput = Union[str, lms.Chat, Mapping[str, Any]]
 CallbackMap = Mapping[str, Callable[..., Any]]
-ToolList = Sequence[Any]
+ToolList = Sequence[ToolSpec]
 
 __all__ = [
     "ChatInput",
@@ -237,17 +237,25 @@ def _prepare_tools(
     tool_names: Sequence[str] | None = None,
     *,
     default: ToolList | None = None,
-) -> list[Any]:
+) -> list[ToolSpec]:
     """Resolve tool arguments into a deduplicated list."""
 
-    resolved: list[Any] = []
+    resolved: list[ToolSpec] = []
+    seen: set[str] = set()
+
     if default:
-        resolved.extend(default)
+        for spec in default:
+            if spec.name not in seen:
+                resolved.append(spec)
+                seen.add(spec.name)
+
     if tools is not None or tool_names is not None:
         merged = resolve_tools(tools=tools, tool_names=tool_names)
-        for tool in merged:
-            if tool not in resolved:
-                resolved.append(tool)
+        for spec in merged:
+            if spec.name not in seen:
+                resolved.append(spec)
+                seen.add(spec.name)
+
     return resolved
 
 
@@ -264,6 +272,7 @@ def act(
     response_format: Any | None = None,
     schema_name: str | None = None,
     strict_schema: bool = True,
+    handle_invalid_tool_request: Any | None = None,
     **act_kwargs: Any,
 ) -> tuple[str, StructuredResponse]:
     """Execute :meth:`model.act` with resolved tool definitions.
@@ -288,6 +297,8 @@ def act(
     if callbacks:
         kwargs.update(callbacks)
     kwargs.update(act_kwargs)
+    if handle_invalid_tool_request is not None:
+        kwargs["handle_invalid_tool_request"] = handle_invalid_tool_request
     response_payload, normalized_schema, expect_structured = _resolve_response_format(
         schema=schema,
         response_format=response_format,
@@ -297,7 +308,8 @@ def act(
     if response_payload is not None:
         kwargs["response_format"] = response_payload
     chat_input = _prepare_input(prompt_or_chat)
-    result = model.act(chat_input, resolved_tools, **kwargs)
+    tool_payloads = [spec.to_payload() for spec in resolved_tools]
+    result = model.act(chat_input, tool_payloads, **kwargs)
     raw_payload = _coerce_response_mapping(result)
     fallback_text = _extract_text(raw_payload)
     try:
@@ -399,7 +411,7 @@ class ChatSession:
 
     chat: lms.Chat
     model: Any
-    tools: list[Any] = field(default_factory=list)
+    tools: list[ToolSpec] = field(default_factory=list)
     system_prompt: str | None = None
 
     @classmethod
@@ -537,6 +549,7 @@ class ChatSession:
         response_format: Any | None = None,
         schema_name: str | None = None,
         strict_schema: bool = True,
+        handle_invalid_tool_request: Any | None = None,
         **act_kwargs: Any,
     ) -> tuple[str, Any]:
         if user_message:
@@ -559,6 +572,7 @@ class ChatSession:
             response_format=response_format,
             schema_name=schema_name,
             strict_schema=strict_schema,
+            handle_invalid_tool_request=handle_invalid_tool_request,
             **act_kwargs,
         )
         # Cache the resolved tools for future rounds when overrides are provided.

--- a/session.py
+++ b/session.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 
 from chat import CallbackMap, ChatSession
 from internal.structures import StructuredResponse
+from tooling import ToolSpec
 
 __all__ = ["AgentRound", "AgentSession"]
 
@@ -113,7 +114,7 @@ class AgentSession:
         return self.chat_session.model
 
     @property
-    def tools(self) -> list[Any]:
+    def tools(self) -> list[ToolSpec]:
         return self.chat_session.tools
 
     @property
@@ -261,6 +262,7 @@ class AgentSession:
         tool_names: Sequence[str] | None = None,
         config: Optional[Mapping[str, Any]] = None,
         callbacks: Optional[CallbackMap] = None,
+        handle_invalid_tool_request: Any | None = None,
         **act_kwargs: Any,
     ) -> tuple[str, StructuredResponse]:
         self._current_messages = []
@@ -282,6 +284,7 @@ class AgentSession:
             tool_names=tool_names,
             config=config,
             callbacks=composed_callbacks,
+            handle_invalid_tool_request=handle_invalid_tool_request,
             **act_kwargs,
         )
 

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -73,6 +73,7 @@ def _create_lmstudio_stub():
             self.respond_stream_calls = []
             self.act_calls = []
             self.next_act_response: Any | None = None
+            self.invalid_tool_error: Exception | None = None
 
         def respond(self, chat_input, **kwargs):
             self.respond_calls.append((chat_input, kwargs))
@@ -87,15 +88,35 @@ def _create_lmstudio_stub():
 
         def act(self, chat_input, tools, **kwargs):
             self.act_calls.append((chat_input, tools, kwargs))
-            tool_call = {"id": "call-1", "name": "demo", "arguments": {"value": 1}}
-            if tool_call_cb := kwargs.get("on_tool_call"):
-                tool_call_cb(tool_call)
+            tool_name = "demo"
+            if tools:
+                first = tools[0]
+                tool_name = first.get("function", {}).get("name", tool_name)
+            tool_call = {"id": "call-1", "name": tool_name, "arguments": {"value": 1}}
             tool_result = {
                 "role": "tool",
                 "content": "tool output",
-                "name": "demo",
+                "name": tool_name,
                 "tool_call_id": "call-1",
             }
+            invalid_error = self.invalid_tool_error
+            handler = kwargs.get("handle_invalid_tool_request")
+            if invalid_error is not None:
+                request_payload = {"id": "call-1", "name": tool_name, "arguments": {"value": 1}}
+                if handler is None:
+                    raise invalid_error
+                try:
+                    replacement = handler(invalid_error, request_payload)
+                except Exception as exc:  # pragma: no cover - defensive
+                    raise exc
+                if replacement is None:
+                    tool_result["content"] = str(invalid_error)
+                elif isinstance(replacement, str):
+                    tool_result["content"] = replacement
+                else:
+                    raise replacement
+            if tool_call_cb := kwargs.get("on_tool_call"):
+                tool_call_cb(tool_call)
             if tool_result_cb := kwargs.get("on_tool_result"):
                 tool_result_cb(tool_result)
             if callback := kwargs.get("on_message"):
@@ -199,6 +220,51 @@ def test_resolve_tools_combines_sources(lmstudio_env):
     assert resolved == [first, second]
 
 
+def test_resolve_tools_accepts_callable(lmstudio_env):
+    tooling = lmstudio_env.tooling
+
+    def echo(value: int) -> int:
+        """Echo the provided value."""
+
+        return value
+
+    resolved = tooling.resolve_tools(tools=[echo])
+    assert resolved[0].name == "echo"
+    assert "Echo" in resolved[0].description
+    payload = resolved[0].to_payload()
+    assert payload["function"]["implementation"] is echo
+
+
+def test_register_tool_requires_metadata(lmstudio_env):
+    tooling = lmstudio_env.tooling
+
+    def undecorated(value: int) -> int:
+        return value
+
+    with pytest.raises(ValueError):
+        tooling.register_tool(undecorated)
+
+
+def test_register_tool_with_overrides(lmstudio_env):
+    tooling = lmstudio_env.tooling
+
+    def bare(value: int) -> int:
+        return value
+
+    spec = tooling.register_tool(
+        bare,
+        name="bare_tool",
+        description="Echo the provided integer.",
+        parameters={"value": int},
+    )
+    try:
+        fetched = tooling.get_tool("bare_tool")
+        assert fetched.name == "bare_tool"
+        assert fetched.description.startswith("Echo")
+    finally:
+        tooling.unregister_tool("bare_tool")
+
+
 def test_act_requires_tools(lmstudio_env):
     chat = lmstudio_env.chat
     with pytest.raises(ValueError):
@@ -214,7 +280,7 @@ def test_act_invokes_model_with_resolved_tools(lmstudio_env):
     assert text == "act result"
     assert result.content == "act result"
     assert result.parsed is None
-    assert model.act_calls[0][1] == [tool]
+    assert model.act_calls[0][1] == [tool.to_payload()]
 
 
 def test_chat_session_act_updates_history_and_tools(lmstudio_env):
@@ -230,7 +296,7 @@ def test_chat_session_act_updates_history_and_tools(lmstudio_env):
     assert chat_instance.messages[-1]["content"] == "act result"
     assert session.tools == [tool]
     assert structured.parsed is None
-    assert model.act_calls[0][1] == [tool]
+    assert model.act_calls[0][1] == [tool.to_payload()]
 
 
 def test_chat_session_act_requires_tools(lmstudio_env):
@@ -271,7 +337,7 @@ def test_agent_session_records_round_metadata(lmstudio_env):
     agent = session_mod.AgentSession(system_prompt="sys", model=model, tools=[tool])
     text, result = agent.act("hello")
     assert text == "act result"
-    assert result.raw_response["tool_calls"][0]["name"] == "demo"
+    assert result.raw_response["tool_calls"][0]["name"] == tool.name
     recorded_round = agent.last_round()
     assert recorded_round is not None
     assert recorded_round.user_message == "hello"
@@ -344,6 +410,49 @@ def test_act_accepts_schema_and_returns_structured(lmstudio_env):
     assert response_format["json_schema"]["strict"] is False
     assert result.parsed == {"value": 1}
     assert result.schema == schema
+
+
+def test_handle_invalid_tool_request_summary(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    tooling = lmstudio_env.tooling
+    model = lmstudio_env.stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    model.invalid_tool_error = RuntimeError("boom")
+    observed: list[tuple[Exception, dict[str, Any]]] = []
+
+    def summarize(exc, request):
+        observed.append((exc, request))
+        return "handled"
+
+    text, result = chat_mod.act(
+        "hi",
+        tools=[tool],
+        model=model,
+        handle_invalid_tool_request=summarize,
+    )
+    assert text == "act result"
+    assert observed and observed[0][0] is model.invalid_tool_error
+    tool_result = result.raw_response["tool_results"][0]
+    assert tool_result["content"] == "handled"
+
+
+def test_handle_invalid_tool_request_propagates(lmstudio_env):
+    chat_mod = lmstudio_env.chat
+    tooling = lmstudio_env.tooling
+    model = lmstudio_env.stub.FakeModel()
+    tool = tooling.get_all_tools()[0]
+    model.invalid_tool_error = RuntimeError("boom")
+
+    def raise_it(exc, request):
+        raise exc
+
+    with pytest.raises(RuntimeError):
+        chat_mod.act(
+            "hi",
+            tools=[tool],
+            model=model,
+            handle_invalid_tool_request=raise_it,
+        )
 
 
 def test_chat_session_act_supports_response_format_mapping(lmstudio_env):

--- a/tooling.py
+++ b/tooling.py
@@ -1,61 +1,289 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Sequence
+import importlib
+import inspect
+import pkgutil
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Sequence
 
 from lmstudio import ToolFunctionDef
 
-# Explicitly import and expose tools from internal/tools
-from internal.tools.shell import shell_tool
-from internal.tools.planner import planner_tool
-from internal.tools.patch import patch_tool
-from internal.tools.file import file_tool
-from internal.tools.process import process_tool
-from internal.tools.git import git_tool
+
+ToolCallable = Callable[..., Any]
 
 
-# Build a registry of all tools for easy access
-def _collect_tools():
-    glb = globals()
-    tools = [v for k, v in glb.items() if k.endswith('_tool') and isinstance(v, ToolFunctionDef)]
-    # Sort by tool name for consistency
-    tools.sort(key=lambda t: getattr(t, 'name', ''))
-    return tools
+def _safe_getattr(obj: Any, name: str, default: Any = None) -> Any:
+    try:
+        return getattr(obj, name)
+    except AttributeError:
+        return default
 
 
-TOOLS: list[ToolFunctionDef] = _collect_tools()
-TOOL_MAP: dict[str, ToolFunctionDef] = {t.name: t for t in TOOLS}
+def _is_tool_function_def(obj: Any) -> bool:
+    return isinstance(obj, ToolFunctionDef)
 
 
-def get_all_tools() -> list[ToolFunctionDef]:
-    """Return a shallow copy of every registered :class:`ToolFunctionDef`."""
-
-    return list(TOOLS)
-
-
-def get_tool(name: str) -> ToolFunctionDef:
-    """Return a tool definition by name.
-
-    Raises
-    ------
-    KeyError
-        If ``name`` does not correspond to a registered tool.
-    """
-
-    return TOOL_MAP[name]
+def _normalize_parameters(params: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not params:
+        return {}
+    if isinstance(params, MutableMapping):
+        return dict(params)
+    return {str(key): value for key, value in dict(params).items()}
 
 
-def get_tools(names: Sequence[str] | None = None) -> list[ToolFunctionDef]:
-    """Return tool definitions matching ``names``.
+def _callable_signature_parameters(func: ToolCallable) -> dict[str, Any]:
+    signature = inspect.signature(func)
+    parameters: dict[str, Any] = {}
+    for parameter in signature.parameters.values():
+        if parameter.kind in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD):
+            raise ValueError(
+                f"Tool callable {func.__name__}() uses variadic parameters which are"
+                " not supported."
+            )
+        annotation = parameter.annotation
+        if annotation is inspect.Signature.empty:
+            raise ValueError(
+                "Tool callables must provide type annotations for every argument "
+                f"(missing annotation for parameter '{parameter.name}' in {func.__name__}())."
+            )
+        parameters[parameter.name] = annotation
+    return parameters
 
-    When ``names`` is ``None`` the full registry is returned. Duplicate names
-    are ignored while preserving the requested order.
-    """
+
+def _callable_description(func: ToolCallable, explicit: str | None) -> str:
+    if explicit is not None:
+        explicit = explicit.strip()
+        if explicit:
+            return explicit
+    doc = inspect.getdoc(func)
+    if not doc:
+        raise ValueError(
+            f"Tool callable {func.__name__}() must have a docstring describing its behaviour."
+        )
+    return doc.strip()
+
+
+@dataclass(slots=True)
+class ToolSpec:
+    """Normalized representation of a tool definition."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any]
+    implementation: ToolCallable
+    source: Any
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the structure expected by :meth:`model.act`."""
+
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": dict(self.parameters),
+                "implementation": self.implementation,
+            },
+        }
+
+
+class ToolRegistry:
+    """Registry for collecting and validating tool definitions."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolSpec] = {}
+        self._sources: dict[str, Any] = {}
+
+    def register(
+        self,
+        tool: ToolSpec | ToolFunctionDef | ToolCallable,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        replace: bool = False,
+    ) -> ToolSpec:
+        """Register ``tool`` ensuring it is safe for exposure to the model."""
+
+        spec = self._ensure_spec(
+            tool,
+            name=name,
+            description=description,
+            parameters=parameters,
+        )
+        if not replace and spec.name in self._tools:
+            raise ValueError(f"Tool '{spec.name}' is already registered")
+        self._tools[spec.name] = spec
+        self._sources[spec.name] = spec.source
+        return spec
+
+    def unregister(self, name: str) -> None:
+        self._tools.pop(name, None)
+        self._sources.pop(name, None)
+
+    def get(self, name: str) -> ToolSpec:
+        return self._tools[name]
+
+    def all(self) -> list[ToolSpec]:
+        return list(self._tools.values())
+
+    def resolve(
+        self,
+        *,
+        tools: Iterable[ToolSpec | ToolFunctionDef | ToolCallable] | None = None,
+        tool_names: Sequence[str] | None = None,
+    ) -> list[ToolSpec]:
+        """Resolve tool references into normalized :class:`ToolSpec` instances."""
+
+        resolved: list[ToolSpec] = []
+        seen: set[str] = set()
+
+        if tools is not None:
+            for tool in tools:
+                spec = self._ensure_spec(tool)
+                if spec.name not in seen:
+                    resolved.append(spec)
+                    seen.add(spec.name)
+
+        if tool_names is not None:
+            for name in tool_names:
+                spec = self.get(name)
+                if spec.name not in seen:
+                    resolved.append(spec)
+                    seen.add(spec.name)
+
+        return resolved
+
+    def _ensure_spec(
+        self,
+        tool: ToolSpec | ToolFunctionDef | ToolCallable,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        parameters: Mapping[str, Any] | None = None,
+    ) -> ToolSpec:
+        if isinstance(tool, ToolSpec):
+            return tool
+        if _is_tool_function_def(tool):
+            spec_name = name or _safe_getattr(tool, "name")
+            spec_description = description or _safe_getattr(tool, "description", "")
+            if not spec_name:
+                raise ValueError("ToolFunctionDef instances must declare a name")
+            if not spec_description:
+                raise ValueError(
+                    f"Tool '{spec_name}' is missing a description; provide one to register it."
+                )
+            impl = _safe_getattr(tool, "implementation")
+            if not callable(impl):
+                raise ValueError(
+                    f"Tool '{spec_name}' is missing an implementation callable."
+                )
+            params = parameters or _normalize_parameters(_safe_getattr(tool, "parameters", {}))
+            return ToolSpec(
+                name=spec_name,
+                description=str(spec_description),
+                parameters=params,
+                implementation=impl,
+                source=tool,
+            )
+        if callable(tool):
+            spec_name = name or getattr(tool, "__name__", None)
+            if not spec_name:
+                raise ValueError("Tool callables must have a resolvable __name__. Provide name=...")
+            spec_description = _callable_description(tool, description)
+            params = _normalize_parameters(parameters) or _callable_signature_parameters(tool)
+            return ToolSpec(
+                name=spec_name,
+                description=spec_description,
+                parameters=params,
+                implementation=tool,
+                source=tool,
+            )
+        raise TypeError(f"Unsupported tool definition type: {type(tool)!r}")
+
+
+def _iter_tool_modules() -> list[ModuleType]:
+    package = importlib.import_module("internal.tools")
+    search_paths = []
+    if hasattr(package, "__path__"):
+        search_paths.extend(str(Path(path)) for path in package.__path__)
+    elif getattr(package, "__file__", None):
+        search_paths.append(str(Path(package.__file__).parent))
+    modules: list[ModuleType] = []
+    for module_info in pkgutil.iter_modules(search_paths):
+        if module_info.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{package.__name__}.{module_info.name}")
+        modules.append(module)
+    return modules
+
+
+def _load_default_tools(registry: ToolRegistry) -> None:
+    for module in _iter_tool_modules():
+        for attr_name in dir(module):
+            if not attr_name.endswith("_tool"):
+                continue
+            candidate = getattr(module, attr_name)
+            if _is_tool_function_def(candidate) or callable(candidate):
+                try:
+                    registry.register(candidate)
+                except Exception as exc:  # pragma: no cover - defensive
+                    raise RuntimeError(
+                        f"Failed to register tool '{attr_name}' from {module.__name__}: {exc}"
+                    ) from exc
+
+
+_REGISTRY = ToolRegistry()
+_load_default_tools(_REGISTRY)
+
+
+class _ToolSequence(Sequence[ToolSpec]):
+    def __getitem__(self, index: int) -> ToolSpec:
+        return _REGISTRY.all()[index]
+
+    def __len__(self) -> int:
+        return len(_REGISTRY.all())
+
+    def __iter__(self):  # type: ignore[override]
+        return iter(_REGISTRY.all())
+
+
+class _ToolMapping(Mapping[str, ToolSpec]):
+    def __getitem__(self, key: str) -> ToolSpec:
+        return _REGISTRY.get(key)
+
+    def __len__(self) -> int:
+        return len(_REGISTRY.all())
+
+    def __iter__(self):  # type: ignore[override]
+        return (spec.name for spec in _REGISTRY.all())
+
+
+TOOLS: Sequence[ToolSpec] = _ToolSequence()
+TOOL_MAP: Mapping[str, ToolSpec] = _ToolMapping()
+
+
+def get_all_tools() -> list[ToolSpec]:
+    """Return a shallow copy of every registered tool specification."""
+
+    return _REGISTRY.all()
+
+
+def get_tool(name: str) -> ToolSpec:
+    """Return the normalized tool specification by ``name``."""
+
+    return _REGISTRY.get(name)
+
+
+def get_tools(names: Sequence[str] | None = None) -> list[ToolSpec]:
+    """Return registered tools matching ``names`` (or all when ``None``)."""
 
     if names is None:
         return get_all_tools()
+    resolved: list[ToolSpec] = []
     seen: set[str] = set()
-    resolved: list[ToolFunctionDef] = []
     for name in names:
         if name in seen:
             continue
@@ -66,28 +294,55 @@ def get_tools(names: Sequence[str] | None = None) -> list[ToolFunctionDef]:
 
 def resolve_tools(
     *,
-    tools: Iterable[ToolFunctionDef] | None = None,
+    tools: Iterable[ToolSpec | ToolFunctionDef | ToolCallable] | None = None,
     tool_names: Sequence[str] | None = None,
-) -> list[ToolFunctionDef]:
-    """Resolve explicit tool definitions and names into a merged tool list."""
+) -> list[ToolSpec]:
+    """Resolve explicit tool definitions and names into normalized specifications."""
 
-    resolved: list[ToolFunctionDef] = []
-    if tools is not None:
-        for tool in tools:
-            if tool not in resolved:
-                resolved.append(tool)
-    if tool_names is not None:
-        for tool in get_tools(tool_names):
-            if tool not in resolved:
-                resolved.append(tool)
-    return resolved
+    return _REGISTRY.resolve(tools=tools, tool_names=tool_names)
+
+
+def register_tool(
+    tool: ToolSpec | ToolFunctionDef | ToolCallable,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    parameters: Mapping[str, Any] | None = None,
+    replace: bool = False,
+) -> ToolSpec:
+    """Register ``tool`` into the default registry."""
+
+    return _REGISTRY.register(
+        tool,
+        name=name,
+        description=description,
+        parameters=parameters,
+        replace=replace,
+    )
+
+
+def unregister_tool(name: str) -> None:
+    """Remove ``name`` from the default registry if present."""
+
+    _REGISTRY.unregister(name)
 
 
 __all__ = [
+    "ToolSpec",
+    "ToolRegistry",
+    "TOOLS",
+    "TOOL_MAP",
     "get_all_tools",
     "get_tool",
     "get_tools",
     "resolve_tools",
-    "TOOLS",
-    "TOOL_MAP",
-] + [t.name + "_tool" for t in TOOLS if hasattr(t, 'name')]
+    "register_tool",
+    "unregister_tool",
+]
+
+
+# Re-export individual tool definitions for compatibility.
+for spec in get_all_tools():
+    if isinstance(spec.source, ToolFunctionDef):
+        globals()[f"{spec.name}_tool"] = spec.source
+        __all__.append(f"{spec.name}_tool")


### PR DESCRIPTION
## Summary
- introduce a ToolSpec abstraction and registry that auto-discovers default tools while validating callable metadata
- update chat and session helpers to normalize tool payloads, expose handle_invalid_tool_request, and pass structured tool specs to act()
- expand chat tool tests to cover callable registration, error hook behaviour, and the new registry interfaces

## Testing
- pytest tests/test_chat_tools.py
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68e4d68c21d8832fa411dbacfb65238f