### PR TITLE
Add agent factory helpers and documentation

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,225 @@
+"""Convenience helpers for constructing :class:`AgentSession` instances."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, MutableSequence, Optional, Sequence
+
+from chat import CallbackMap
+from session import AgentSession, Hook
+from tooling import ToolRegistry, ToolSpec
+
+__all__ = [
+    "AgentBuilder",
+    "create_agent",
+    "register_default_toolset",
+    "list_default_toolsets",
+    "clear_default_toolsets",
+]
+
+
+_DEFAULT_TOOL_REGISTRY = ToolRegistry()
+_DEFAULT_TOOLSETS: dict[str, tuple[ToolSpec, ...]] = {}
+
+
+def _to_sequence(value: Any | None) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, set):
+        return list(value)
+    return [value]
+
+
+def clear_default_toolsets() -> None:
+    """Remove all globally registered default toolsets."""
+
+    _DEFAULT_TOOLSETS.clear()
+
+
+def list_default_toolsets() -> list[str]:
+    """Return the names of configured default toolsets."""
+
+    return sorted(_DEFAULT_TOOLSETS)
+
+
+def register_default_toolset(
+    name: str,
+    tools: Iterable[ToolSpec | Any],
+    *,
+    replace: bool = False,
+) -> tuple[ToolSpec, ...]:
+    """Register a reusable toolset that can be referenced by ``create_agent``.
+
+    Parameters
+    ----------
+    name:
+        Unique identifier for the toolset.
+    tools:
+        Iterable of callables, :class:`ToolSpec` instances, or LM Studio
+        ``ToolFunctionDef`` objects representing the tools that should be
+        included in the set.
+    replace:
+        When ``True``, an existing toolset with the same ``name`` will be
+        overwritten. The default behaviour raises :class:`ValueError` to guard
+        against accidental replacement.
+    """
+
+    if not replace and name in _DEFAULT_TOOLSETS:
+        raise ValueError(f"Toolset '{name}' is already registered")
+
+    specs: list[ToolSpec] = []
+    for tool in tools:
+        spec = _DEFAULT_TOOL_REGISTRY.register(tool, replace=True)
+        specs.append(spec)
+    payload = tuple(specs)
+    _DEFAULT_TOOLSETS[name] = payload
+    return payload
+
+
+def _ensure_registered(registry: ToolRegistry, tool: ToolSpec | Any) -> ToolSpec:
+    if registry is _DEFAULT_TOOL_REGISTRY:
+        return _DEFAULT_TOOL_REGISTRY.register(tool, replace=True)
+    return registry.register(tool, replace=True)
+
+
+def _resolve_tools(
+    *,
+    registry: ToolRegistry,
+    toolsets: Iterable[str] | None = None,
+    tools: Iterable[ToolSpec | Any] | None = None,
+    tool_names: Sequence[str] | None = None,
+) -> list[ToolSpec]:
+    resolved: list[ToolSpec] = []
+    seen: set[str] = set()
+
+    for set_name in _to_sequence(toolsets):
+        if set_name not in _DEFAULT_TOOLSETS:
+            raise KeyError(f"Unknown toolset '{set_name}'")
+        for spec in _DEFAULT_TOOLSETS[set_name]:
+            registered = _ensure_registered(registry, spec)
+            if registered.name not in seen:
+                resolved.append(registered)
+                seen.add(registered.name)
+
+    if tools is not None:
+        for tool in tools:
+            registered = _ensure_registered(registry, tool)
+            if registered.name not in seen:
+                resolved.append(registered)
+                seen.add(registered.name)
+
+    if tool_names:
+        for spec in registry.resolve(tool_names=tool_names):
+            if spec.name not in seen:
+                resolved.append(spec)
+                seen.add(spec.name)
+
+    return resolved
+
+
+def create_agent(
+    *,
+    system_prompt: str | None = None,
+    history: Any | None = None,
+    model: Any | None = None,
+    model_name: str | None = None,
+    toolsets: Iterable[str] | None = None,
+    tools: Iterable[ToolSpec | Any] | None = None,
+    tool_names: Sequence[str] | None = None,
+    registry: ToolRegistry | None = None,
+    callbacks: Optional[CallbackMap] = None,
+    on_message: Hook | None = None,
+    on_tool_call: Hook | None = None,
+    on_tool_result: Hook | None = None,
+    on_round_start: Hook | None = None,
+    on_round_end: Hook | None = None,
+) -> AgentSession:
+    """Instantiate an :class:`AgentSession` configured with helper defaults."""
+
+    registry = registry or _DEFAULT_TOOL_REGISTRY
+    resolved_tools = _resolve_tools(
+        registry=registry,
+        toolsets=toolsets,
+        tools=tools,
+        tool_names=tool_names,
+    )
+
+    return AgentSession(
+        system_prompt=system_prompt,
+        history=history,
+        model=model,
+        model_name=model_name,
+        tools=resolved_tools,
+        tool_names=None,
+        callbacks=callbacks,
+        on_message=on_message,
+        on_tool_call=on_tool_call,
+        on_tool_result=on_tool_result,
+        on_round_start=on_round_start,
+        on_round_end=on_round_end,
+    )
+
+
+@dataclass
+class AgentBuilder:
+    """Fluent builder for assembling agent sessions."""
+
+    system_prompt: str | None = None
+    history: Any | None = None
+    model: Any | None = None
+    model_name: str | None = None
+    callbacks: Optional[CallbackMap] = None
+    on_message: Hook | None = None
+    on_tool_call: Hook | None = None
+    on_tool_result: Hook | None = None
+    on_round_start: Hook | None = None
+    on_round_end: Hook | None = None
+    registry: ToolRegistry | None = None
+    _toolsets: MutableSequence[str] = field(default_factory=list)
+    _tools: MutableSequence[ToolSpec | Any] = field(default_factory=list)
+    _tool_names: MutableSequence[str] = field(default_factory=list)
+
+    def with_toolsets(self, *names: str) -> "AgentBuilder":
+        self._toolsets.extend(names)
+        return self
+
+    def with_tools(self, *tools: ToolSpec | Any) -> "AgentBuilder":
+        self._tools.extend(tools)
+        return self
+
+    def with_tool_names(self, *names: str) -> "AgentBuilder":
+        self._tool_names.extend(names)
+        return self
+
+    def with_model(self, *, model: Any | None = None, model_name: str | None = None) -> "AgentBuilder":
+        if model is not None:
+            self.model = model
+        if model_name is not None:
+            self.model_name = model_name
+        return self
+
+    def using_registry(self, registry: ToolRegistry) -> "AgentBuilder":
+        self.registry = registry
+        return self
+
+    def build(self) -> AgentSession:
+        return create_agent(
+            system_prompt=self.system_prompt,
+            history=self.history,
+            model=self.model,
+            model_name=self.model_name,
+            toolsets=self._toolsets,
+            tools=self._tools,
+            tool_names=self._tool_names,
+            registry=self.registry,
+            callbacks=self.callbacks,
+            on_message=self.on_message,
+            on_tool_call=self.on_tool_call,
+            on_tool_result=self.on_tool_result,
+            on_round_start=self.on_round_start,
+            on_round_end=self.on_round_end,
+        )

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,3 +12,53 @@ Guides and references for installing, configuring, and extending the LM Studio a
 Model cards, weights, and usage guidance for the Liquid LMF2 series that powers parts of this project. Review the [LMF2 index](LMF2/index) to find model-specific details such as context length, licensing, and download locations.
 
 Use the section that matches your task, and feel free to cross-reference between them when you need both application behaviour and underlying model characteristics.
+
+## Quick-start: Structured Agents with Tools
+
+```python
+from agents import AgentBuilder, register_default_toolset
+
+
+def get_weather(city: str) -> str:
+    """Return a canned weather string for demo purposes."""
+
+    return f"The weather in {city} is sunny."
+
+
+# Register a reusable toolset that can be referenced by name.
+register_default_toolset(
+    "demo-tools",
+    [
+        get_weather,
+    ],
+)
+
+# Build an agent with a system prompt and structured output requirements.
+agent = (
+    AgentBuilder(system_prompt="You are a helpful assistant.")
+    .with_toolsets("demo-tools")
+    .build()
+)
+
+response_text, structured = agent.act(
+    "What's the weather in Paris?",
+    schema={
+        "type": "object",
+        "properties": {"status": {"type": "string"}, "city": {"type": "string"}},
+        "required": ["status", "city"],
+    },
+)
+
+print(response_text)
+print(structured.parsed)
+```
+
+### Configuration reference
+
+| Setting | Location | Description |
+| --- | --- | --- |
+| `register_default_toolset(name, tools)` | `agents.py` | Attach reusable tool collections to a name for quick reuse across sessions. |
+| `AgentBuilder.with_toolsets(*names)` | `agents.py` | Include one or more registered toolsets when constructing a session. |
+| `AgentBuilder.with_tools(*tools)` | `agents.py` | Add ad-hoc tools in addition to registered sets. |
+| `AgentSession.act(..., schema=..., response_format=...)` | `session.py` | Enforce structured outputs via JSON Schema or LM Studio response formats. |
+| `AgentSession.act(..., handle_invalid_tool_request=...)` | `session.py` | Provide graceful fallbacks when the model requests unavailable tools. |

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,248 @@
+import sys
+import types
+
+import pytest
+
+
+# Seed a minimal lmstudio stub so that importing ``agents`` succeeds before
+# pytest fixtures have a chance to run.
+_bootstrap_stub = types.ModuleType("lmstudio")
+
+
+class _BootstrapChat:
+    def __init__(self, *args, **kwargs):  # pragma: no cover - bootstrap only
+        self.messages = []
+
+    @classmethod
+    def from_history(cls, history):  # pragma: no cover - bootstrap only
+        chat = cls()
+        chat.messages = history if isinstance(history, list) else []
+        return chat
+
+
+_bootstrap_stub.Chat = _BootstrapChat
+
+
+class _BootstrapToolFunctionDef:
+    def __init__(self, name, description="", parameters=None, implementation=None):  # pragma: no cover - bootstrap only
+        self.name = name
+        self.description = description
+        self.parameters = parameters or {}
+        self.implementation = implementation
+
+
+_bootstrap_stub.ToolFunctionDef = _BootstrapToolFunctionDef
+
+
+def _bootstrap_llm(*args, **kwargs):  # pragma: no cover - bootstrap only
+    raise RuntimeError("lmstudio stub should be provided by tests")
+
+
+_bootstrap_stub.llm = _bootstrap_llm
+sys.modules.setdefault("lmstudio", _bootstrap_stub)
+
+_psutil_stub = types.ModuleType("psutil")
+
+
+class _BootstrapProcess:  # pragma: no cover - bootstrap only
+    def __init__(self, pid=None):
+        self.pid = pid or 0
+
+
+_psutil_stub.Process = _BootstrapProcess
+sys.modules.setdefault("psutil", _psutil_stub)
+
+from agents import (  # noqa: E402  # import after bootstrap stub injection
+    AgentBuilder,
+    clear_default_toolsets,
+    create_agent,
+    list_default_toolsets,
+    register_default_toolset,
+)
+from tooling import ToolRegistry
+
+
+class _FakeTool:
+    """Test helper used to emulate a tool callable."""
+
+    def __init__(self, name):
+        self.name = name
+        self.__name__ = name
+
+    def __call__(self, value: int) -> int:
+        """Increment a value for testing."""
+
+        return value + 1
+
+
+class _FakeModel:
+    def __init__(self):
+        self.act_calls = []
+        self.respond_calls = []
+        self.invalid_tool_error: Exception | None = None
+
+    def respond(self, chat_input, **kwargs):
+        self.respond_calls.append((chat_input, kwargs))
+        return types.SimpleNamespace(message=types.SimpleNamespace(content="respond"))
+
+    def respond_stream(self, chat_input, **kwargs):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def act(self, chat_input, tools, **kwargs):
+        self.act_calls.append((chat_input, tools, kwargs))
+        tool_name = "demo"
+        if tools:
+            tool_name = tools[0]["function"]["name"]
+        if self.invalid_tool_error is not None:
+            handler = kwargs.get("handle_invalid_tool_request")
+            if handler is None:
+                raise self.invalid_tool_error
+            handler(self.invalid_tool_error, {"id": "call-1", "name": tool_name})
+        tool_call = {"id": "call-1", "name": tool_name, "arguments": {}}
+        tool_result = {
+            "role": "tool",
+            "content": "ok",
+            "name": tool_call["name"],
+            "tool_call_id": tool_call["id"],
+        }
+        if cb := kwargs.get("on_tool_call"):
+            cb(tool_call)
+        if cb := kwargs.get("on_tool_result"):
+            cb(tool_result)
+        if cb := kwargs.get("on_message"):
+            cb({"role": "assistant", "content": "done"})
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "done",
+                        "parsed": {"status": "ok"},
+                    }
+                }
+            ],
+            "tool_calls": [tool_call],
+            "tool_results": [tool_result],
+        }
+
+
+@pytest.fixture(autouse=True)
+def lmstudio_stub(monkeypatch):
+    clear_default_toolsets()
+
+    stub = types.ModuleType("lmstudio")
+
+    class Chat:
+        def __init__(self, system_prompt: str | None = None):
+            self.system_prompt = system_prompt
+            self.messages = []
+            if system_prompt:
+                self.messages.append({"role": "system", "content": system_prompt})
+
+        @classmethod
+        def from_history(cls, history):
+            chat = cls(None)
+            if isinstance(history, dict):
+                chat.messages.extend(history.get("messages", []))
+            elif isinstance(history, (list, tuple)):
+                chat.messages.extend(history)
+            elif isinstance(history, str):
+                chat.messages.append({"role": "system", "content": history})
+            return chat
+
+        def add_user_message(self, content: str) -> None:
+            self.messages.append({"role": "user", "content": content})
+
+        def add_assistant_message(self, content: str) -> None:
+            self.messages.append({"role": "assistant", "content": content})
+
+        def append(self, message):
+            self.messages.append(message)
+
+        def add_tool_message(self, content: str, *, name=None, tool_call_id=None):
+            message = {"role": "tool", "content": content}
+            if name:
+                message["name"] = name
+            if tool_call_id:
+                message["tool_call_id"] = tool_call_id
+            self.messages.append(message)
+
+    class ToolFunctionDef:
+        def __init__(self, name, description="", parameters=None, implementation=None):
+            self.name = name
+            self.description = description
+            self.parameters = parameters or {}
+            self.implementation = implementation
+
+    def llm(name=None, **kwargs):
+        return _FakeModel()
+
+    stub.Chat = Chat
+    stub.ToolFunctionDef = ToolFunctionDef
+    stub.llm = llm
+
+    monkeypatch.setitem(sys.modules, "lmstudio", stub)
+    monkeypatch.setattr("chat.lms", stub, raising=False)
+    monkeypatch.setattr("tooling.ToolFunctionDef", stub.ToolFunctionDef, raising=False)
+    yield
+    monkeypatch.delitem(sys.modules, "lmstudio", raising=False)
+
+
+def test_register_default_toolset_and_create_agent():
+    tool = _FakeTool("increment")
+    register_default_toolset("math", [tool])
+
+    agent = create_agent(system_prompt="Assistant", toolsets=["math"])
+    assert list_default_toolsets() == ["math"]
+
+    text, result = agent.act("hi", schema={"type": "object", "properties": {"status": {"type": "string"}}})
+    assert text == "done"
+    assert result.raw_response["choices"][0]["message"]["parsed"] == {"status": "ok"}
+
+    model = agent.chat_session.model
+    assert model.act_calls, "Expected model.act to be called"
+    _, tools, kwargs = model.act_calls[-1]
+    assert tools[0]["function"]["name"] == "increment"
+    assert "response_format" in kwargs
+    assert kwargs["response_format"]["type"] == "json_schema"
+
+
+def test_agent_builder_with_custom_registry():
+    tool = _FakeTool("increment")
+    register_default_toolset("math", [tool])
+
+    registry = ToolRegistry()
+    builder = AgentBuilder(system_prompt="Builder")
+    agent = (
+        builder.using_registry(registry)
+        .with_toolsets("math")
+        .with_tool_names("increment")
+        .build()
+    )
+
+    agent.act("ping", response_format={"type": "json_object"})
+    model = agent.chat_session.model
+    assert model.act_calls, "Builder agent should trigger act()"
+    _, tools, kwargs = model.act_calls[-1]
+    assert len(tools) == 1
+    assert tools[0]["function"]["name"] == "increment"
+    assert "response_format" in kwargs
+
+
+def test_invalid_tool_error_path_invokes_handler():
+    tool = _FakeTool("increment")
+    register_default_toolset("math", [tool])
+    agent = create_agent(toolsets=["math"])
+    model = agent.chat_session.model
+    model.invalid_tool_error = RuntimeError("bad tool")
+
+    captured = {}
+
+    def handler(exc, request):
+        captured["error"] = exc
+        captured["request"] = request
+        return "fallback"
+
+    agent.act("ping", handle_invalid_tool_request=handler)
+    assert captured["error"].args[0] == "bad tool"
+    assert captured["request"]["name"] == "increment"


### PR DESCRIPTION
## Summary
- add a top-level `agents` helper module with factory and builder utilities for constructing `AgentSession` instances and default toolsets
- extend the developer docs with a structured agent quick-start example and configuration reference
- add unit tests that stub LM Studio to verify schema handling, tool dispatch, and invalid tool paths for the new helpers

## Testing
- pytest tests/test_agents.py

------
https://chatgpt.com/codex/tasks/task_b_68e4fa371c38832f85ec08f631fe6cf0