### PR TITLE
Add Playwright web search helper and fallbacks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,3 +62,14 @@ print(structured.parsed)
 | `AgentBuilder.with_tools(*tools)` | `agents.py` | Add ad-hoc tools in addition to registered sets. |
 | `AgentSession.act(..., schema=..., response_format=...)` | `session.py` | Enforce structured outputs via JSON Schema or LM Studio response formats. |
 | `AgentSession.act(..., handle_invalid_tool_request=...)` | `session.py` | Provide graceful fallbacks when the model requests unavailable tools. |
+
+## Web search retrieval with Playwright
+
+The `internal.web_playwright.PlaywrightWebClient` module encapsulates Playwright usage for the `WebRAG` helper. Install the dependency and the matching browser binaries before running code that performs web searches:
+
+```bash
+pip install -r requirements.txt
+playwright install
+```
+
+`WebRAG` will default to the Playwright-powered search and rendering pipeline when available, and automatically fall back to the legacy `requests` workflow if the dependency is missing.

--- a/internal/RAG.py
+++ b/internal/RAG.py
@@ -13,6 +13,11 @@ try:
 except Exception:  # pragma: no cover
     requests = None  # Will raise at call time if WebRAG.fetch is used
 
+try:  # pragma: no cover - optional dependency
+    from .web_playwright import PlaywrightWebClient
+except Exception:  # pragma: no cover
+    PlaywrightWebClient = None  # type: ignore
+
 
 _WORD_RE = re.compile(r"[A-Za-z0-9_]+")
 _DEFAULT_STOPWORDS = {
@@ -336,12 +341,40 @@ class WebRAG:
         self.session = requests.Session() if requests else None
         self.index = _RagIndex(kind="web")
         self._lock = threading.Lock()
+        self._playwright_client = None
+        if PlaywrightWebClient is not None:
+            try:
+                self._playwright_client = PlaywrightWebClient(
+                    timeout_ms=self.timeout * 1000,
+                    user_agent=self.user_agent,
+                )
+            except Exception:
+                self._playwright_client = None
 
         try:
             from duckduckgo_search import DDGS  # type: ignore
             self._ddgs_cls = DDGS
         except Exception:
             self._ddgs_cls = None
+
+    def _playwright_available(self) -> bool:
+        return bool(self._playwright_client and self._playwright_client.is_available())
+
+    def _fetch_with_playwright(self, url: str) -> Optional[str]:
+        if not self._playwright_available():
+            return None
+        try:
+            return self._playwright_client.render_page_text(url)  # type: ignore[union-attr]
+        except Exception:
+            return None
+
+    def _search_with_playwright(self, query: str, max_results: int) -> List[Dict[str, str]]:
+        if not self._playwright_available():
+            return []
+        try:
+            return self._playwright_client.collect_search_results(query, max_results=max_results)  # type: ignore[union-attr]
+        except Exception:
+            return []
 
     def _headers(self) -> Dict[str, str]:
         return {"User-Agent": self.user_agent, "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
@@ -389,7 +422,7 @@ class WebRAG:
 
     def _fetch_text(self, url: str) -> Optional[str]:
         if not self.session:
-            raise RuntimeError("requests is required for WebRAG")
+            return None
         try:
             r = self.session.get(url, headers=self._headers(), timeout=self.timeout)
             if r.status_code != 200 or not r.text:
@@ -432,7 +465,9 @@ class WebRAG:
             url = r.get("url")
             if not url:
                 continue
-            txt = self._fetch_text(url)
+            txt = self._fetch_with_playwright(url)
+            if not txt:
+                txt = self._fetch_text(url)
             if not txt:
                 continue
             chunks = chunker.chunk(txt, url)
@@ -445,7 +480,18 @@ class WebRAG:
         seen_urls: set[str] = set()
         results: List[Dict[str, str]] = []
         for q in queries:
-            rs = self._search_ddg(q, max_results=max_search_results)
+            remaining = max_search_results - len(results)
+            if remaining <= 0:
+                break
+            rs: List[Dict[str, str]] = []
+            if self._playwright_available():
+                try:
+                    rs = self._playwright_client.collect_search_results(q, max_results=remaining)  # type: ignore[union-attr]
+                except Exception:
+                    rs = []
+                    self._playwright_client = None
+            if not rs:
+                rs = self._search_ddg(q, max_results=remaining)
             for r in rs:
                 u = r.get("url")
                 if not u or u in seen_urls:

--- a/internal/web_playwright.py
+++ b/internal/web_playwright.py
@@ -1,0 +1,167 @@
+"""Utilities for interacting with the web via Playwright.
+
+This module centralises the logic required to perform search queries and to
+render web pages before extracting readable text.  The functionality is kept in
+one place so that higher-level modules can depend on a thin abstraction without
+having to manage browser lifecycles directly.
+"""
+from __future__ import annotations
+
+import contextlib
+import re
+import urllib.parse
+from typing import Dict, Iterator, List, Optional
+
+try:  # pragma: no cover - import guarded for environments without Playwright
+    from playwright.sync_api import (  # type: ignore
+        Browser,
+        BrowserContext,
+        Page,
+        TimeoutError as PlaywrightTimeoutError,
+        sync_playwright,
+    )
+except Exception:  # pragma: no cover - dependency may be optional at runtime
+    Browser = BrowserContext = Page = object  # type: ignore[assignment]
+    PlaywrightTimeoutError = Exception
+    sync_playwright = None
+
+
+_CLEAN_RE = re.compile(r"\s+")
+
+
+class PlaywrightWebClient:
+    """Small helper around the Playwright sync API.
+
+    Parameters
+    ----------
+    browser : str
+        The browser family to launch (``"chromium"`` by default).
+    headless : bool
+        Whether to launch the browser in headless mode.
+    timeout_ms : int
+        Default timeout applied to navigation and selector waits.
+    user_agent : str | None
+        Optional custom user-agent string for the created context.
+    """
+
+    def __init__(
+        self,
+        browser: str = "chromium",
+        headless: bool = True,
+        timeout_ms: int = 15_000,
+        user_agent: Optional[str] = None,
+    ) -> None:
+        self.browser = browser
+        self.headless = headless
+        self.timeout_ms = timeout_ms
+        self.user_agent = user_agent
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    # ------------------------------------------------------------------
+    def is_available(self) -> bool:
+        """Return True when Playwright can be imported and started."""
+
+        return sync_playwright is not None
+
+    @contextlib.contextmanager
+    def _new_context(self) -> Iterator[BrowserContext]:
+        if not self.is_available():
+            raise RuntimeError("Playwright is not available")
+
+        with sync_playwright() as p:  # type: ignore[misc]
+            browser_launcher = getattr(p, self.browser, None)
+            if browser_launcher is None:
+                browser_launcher = p.chromium
+            browser: Browser = browser_launcher.launch(headless=self.headless)
+            context = browser.new_context(user_agent=self.user_agent)
+            context.set_default_timeout(self.timeout_ms)
+            try:
+                yield context
+            finally:
+                try:
+                    context.close()
+                finally:
+                    browser.close()
+
+    # ------------------------------------------------------------------
+    # Search helpers
+    # ------------------------------------------------------------------
+    def collect_search_results(self, query: str, max_results: int = 10) -> List[Dict[str, str]]:
+        """Query DuckDuckGo and return structured search results.
+
+        The Playwright driven fetch performs the same role as the previous
+        ``requests``-based HTML scraping, but renders the page to allow the
+        search engine to serve dynamic results when necessary.
+        """
+
+        if max_results <= 0:
+            return []
+        if not self.is_available():
+            raise RuntimeError("Playwright is not available")
+
+        encoded_query = urllib.parse.quote_plus(query)
+        results: List[Dict[str, str]] = []
+        try:
+            with self._new_context() as context:
+                page = context.new_page()
+                page.goto(f"https://duckduckgo.com/?q={encoded_query}", wait_until="domcontentloaded")
+                try:
+                    page.wait_for_selector("a.result__a", timeout=self.timeout_ms)
+                except PlaywrightTimeoutError:
+                    pass
+                anchors = page.query_selector_all("a.result__a")
+                for anchor in anchors:
+                    url = anchor.get_attribute("href") or ""
+                    if not url:
+                        continue
+                    title = (anchor.inner_text() or "").strip()
+                    snippet = ""
+                    try:
+                        snippet = anchor.evaluate(
+                            "el => {\n"
+                            "  const article = el.closest('article');\n"
+                            "  if (!article) return '';\n"
+                            "  const snippet = article.querySelector('.result__snippet, .result__snippet.js-result-snippet');\n"
+                            "  return snippet ? snippet.innerText : '';\n"
+                            "}"
+                        )
+                    except Exception:
+                        snippet = ""
+                    results.append({
+                        "url": url,
+                        "title": title,
+                        "snippet": snippet.strip(),
+                    })
+                    if len(results) >= max_results:
+                        break
+        except Exception:
+            return []
+        return results
+
+    # ------------------------------------------------------------------
+    # Page rendering helpers
+    # ------------------------------------------------------------------
+    def render_page_text(self, url: str) -> Optional[str]:
+        """Return readable text for the provided URL."""
+
+        if not self.is_available():
+            raise RuntimeError("Playwright is not available")
+
+        try:
+            with self._new_context() as context:
+                page: Page = context.new_page()
+                page.goto(url, wait_until="domcontentloaded")
+                # Give the page a tiny bit of time to settle.
+                page.wait_for_timeout(300)
+                raw_text = page.evaluate("() => document.body ? document.body.innerText : ''")
+        except Exception:
+            return None
+
+        if not isinstance(raw_text, str):
+            return None
+        cleaned = _CLEAN_RE.sub(" ", raw_text)
+        return cleaned.strip()[:500_000]
+
+
+__all__ = ["PlaywrightWebClient"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+playwright>=1.42.0

--- a/tests/test_rag_web.py
+++ b/tests/test_rag_web.py
@@ -1,0 +1,72 @@
+from internal import RAG as rag_module
+
+
+class _RecordPlaywrightClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.collect_calls = []
+        self.render_calls = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def collect_search_results(self, query: str, max_results: int = 10):
+        self.collect_calls.append((query, max_results))
+        return [
+            {"url": "https://example.com/page", "title": "Example", "snippet": "Snippet"},
+        ]
+
+    def render_page_text(self, url: str):
+        self.render_calls.append(url)
+        return "This page discusses Test query usage."
+
+
+class _UnavailablePlaywrightClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def is_available(self) -> bool:
+        return False
+
+
+def test_web_rag_search_uses_playwright(monkeypatch):
+    monkeypatch.setattr(rag_module, "PlaywrightWebClient", _RecordPlaywrightClient)
+
+    def _unexpected_ddg(self, query, max_results):
+        raise AssertionError("Fallback DuckDuckGo search should not run when Playwright succeeds")
+
+    monkeypatch.setattr(rag_module.WebRAG, "_search_ddg", _unexpected_ddg)
+
+    web = rag_module.WebRAG()
+    results = web.search("Test query", top_k=1, max_search_results=5, allow_rewrite=False)
+
+    assert results, "Expected search results from Playwright ingestion"
+    client = web._playwright_client
+    assert isinstance(client, _RecordPlaywrightClient)
+    assert client.collect_calls == [("Test query", 5)]
+    assert client.render_calls == ["https://example.com/page"]
+
+
+def test_web_rag_search_falls_back_without_playwright(monkeypatch):
+    monkeypatch.setattr(rag_module, "PlaywrightWebClient", _UnavailablePlaywrightClient)
+
+    ddg_calls: list[tuple[str, int]] = []
+
+    def _fake_ddg(self, query, max_results):
+        ddg_calls.append((query, max_results))
+        return [
+            {"url": "https://fallback.example", "title": "Fallback", "snippet": ""},
+        ]
+
+    def _fake_fetch(self, url):
+        return "Fallback content for Fallback test"
+
+    monkeypatch.setattr(rag_module.WebRAG, "_search_ddg", _fake_ddg)
+    monkeypatch.setattr(rag_module.WebRAG, "_fetch_text", _fake_fetch)
+
+    web = rag_module.WebRAG()
+    results = web.search("Fallback test", top_k=1, max_search_results=3, allow_rewrite=False)
+
+    assert ddg_calls == [("Fallback test", 3)]
+    assert results, "Expected fallback results when Playwright is unavailable"
+    assert results[0]["path"] == "https://fallback.example"


### PR DESCRIPTION
## Summary
- declare Playwright as a dependency and document the browser installation step
- add an internal PlaywrightWebClient helper for search result collection and page rendering
- refactor WebRAG to leverage the helper with graceful fallbacks and add tests covering the delegation

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68e4ff9461ac832f913392e6b20c284c