### PR TITLE
Add configuration for anonymous WebRAG browsing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,3 +73,16 @@ playwright install
 ```
 
 `WebRAG` will default to the Playwright-powered search and rendering pipeline when available, and automatically fall back to the legacy `requests` workflow if the dependency is missing.
+
+### Anonymous browsing controls
+
+Configure anonymous browsing behaviour via constructor arguments or environment variables before creating a `WebRAG` instance:
+
+| Option | Description |
+| --- | --- |
+| `AUTO_CODER_WEB_PROXY` | HTTP(S) proxy to forward both Playwright and `requests` traffic through (e.g. `http://127.0.0.1:8080`). |
+| `AUTO_CODER_WEB_USER_AGENTS` | Comma-separated or JSON list of user-agent strings to rotate for each request. |
+| `AUTO_CODER_WEB_ANONYMIZE` | When set to `1`, `true`, or `yes`, enables anonymous browsing defaults such as incognito contexts and user-agent rotation. |
+| `AUTO_CODER_WEB_INCOGNITO` | Force per-call incognito contexts regardless of other settings. |
+
+Equivalent keyword arguments (`proxy`, `user_agent_pool`, `anonymous_browsing`, `incognito_contexts`) are also accepted by `internal.RAG.WebRAG` if you prefer direct configuration in code.

--- a/internal/RAG.py
+++ b/internal/RAG.py
@@ -4,9 +4,10 @@ import math
 import time
 import json
 import html
+import random
 import threading
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 try:
     import requests  # type: ignore
@@ -335,10 +336,54 @@ class SystemRAG:
 
 
 class WebRAG:
-    def __init__(self, user_agent: Optional[str] = None, timeout: int = 15) -> None:
-        self.user_agent = user_agent or "Mozilla/5.0 (compatible; RAGBot/1.0; +https://example.com)"
+    def __init__(
+        self,
+        user_agent: Optional[str] = None,
+        timeout: int = 15,
+        *,
+        user_agent_pool: Optional[Sequence[str]] = None,
+        proxy: Optional[str | Mapping[str, str]] = None,
+        incognito_contexts: Optional[bool] = None,
+        anonymous_browsing: Optional[bool] = None,
+        random_seed: Optional[int] = None,
+    ) -> None:
+        env_anon = os.getenv("AUTO_CODER_WEB_ANONYMIZE")
+        if anonymous_browsing is None and env_anon is not None:
+            anonymous_browsing = env_anon.strip().lower() in {"1", "true", "yes", "on"}
+        self.anonymous_browsing = bool(anonymous_browsing)
+
+        env_proxy = os.getenv("AUTO_CODER_WEB_PROXY")
+        if proxy is None and env_proxy:
+            proxy = env_proxy
+
+        env_user_agents = os.getenv("AUTO_CODER_WEB_USER_AGENTS")
+        if user_agent_pool is None and env_user_agents:
+            user_agent_pool = self._parse_user_agent_pool(env_user_agents)
+
+        if incognito_contexts is None:
+            env_incognito = os.getenv("AUTO_CODER_WEB_INCOGNITO")
+            if env_incognito is not None:
+                incognito_contexts = env_incognito.strip().lower() in {"1", "true", "yes", "on"}
+            elif self.anonymous_browsing:
+                incognito_contexts = True
+        self.incognito_contexts = bool(incognito_contexts if incognito_contexts is not None else True)
+
+        pool: List[str] = []
+        if user_agent_pool:
+            pool.extend([ua.strip() for ua in user_agent_pool if ua and ua.strip()])
+
+        default_agent = "Mozilla/5.0 (compatible; RAGBot/1.0; +https://example.com)"
+        self._rng = random.Random(random_seed)
+        self._user_agent_pool = pool
+        self.user_agent = user_agent or (pool[0] if pool else default_agent)
+        if not self._user_agent_pool and self.anonymous_browsing:
+            self._user_agent_pool = [self.user_agent]
+
         self.timeout = timeout
         self.session = requests.Session() if requests else None
+        self._requests_proxies, self._playwright_proxy = self._normalize_proxy(proxy)
+        if self.session and self._requests_proxies:
+            self.session.proxies.update(self._requests_proxies)
         self.index = _RagIndex(kind="web")
         self._lock = threading.Lock()
         self._playwright_client = None
@@ -347,6 +392,10 @@ class WebRAG:
                 self._playwright_client = PlaywrightWebClient(
                     timeout_ms=self.timeout * 1000,
                     user_agent=self.user_agent,
+                    user_agent_pool=self._user_agent_pool,
+                    proxy=self._playwright_proxy,
+                    incognito_contexts=self.incognito_contexts,
+                    random_seed=random_seed,
                 )
             except Exception:
                 self._playwright_client = None
@@ -356,6 +405,54 @@ class WebRAG:
             self._ddgs_cls = DDGS
         except Exception:
             self._ddgs_cls = None
+
+    @staticmethod
+    def _parse_user_agent_pool(raw: str) -> List[str]:
+        raw = raw.strip()
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(ua).strip() for ua in parsed if str(ua).strip()]
+        except Exception:
+            pass
+        # Fall back to comma or newline separated text
+        parts = re.split(r"[,\n]", raw)
+        return [part.strip() for part in parts if part.strip()]
+
+    @staticmethod
+    def _normalize_proxy(proxy: Optional[str | Mapping[str, str]]) -> Tuple[Optional[Dict[str, str]], Optional[Dict[str, str]]]:
+        if proxy is None:
+            return None, None
+        if isinstance(proxy, str):
+            proxy = proxy.strip()
+            if not proxy:
+                return None, None
+            return {"http": proxy, "https": proxy}, {"server": proxy}
+        cleaned: Dict[str, str] = {}
+        playwright_proxy: Dict[str, str] = {}
+        for key, value in proxy.items():
+            if value is None:
+                continue
+            val = str(value).strip()
+            if not val:
+                continue
+            lowered = str(key).lower()
+            if lowered in {"http", "https"}:
+                cleaned[lowered] = val
+            elif lowered == "server":
+                playwright_proxy["server"] = val
+        if "server" not in playwright_proxy:
+            server = cleaned.get("https") or cleaned.get("http")
+            if server:
+                playwright_proxy["server"] = server
+        return (cleaned or None), (playwright_proxy or None)
+
+    def _choose_user_agent(self) -> str:
+        if self._user_agent_pool:
+            return self._rng.choice(self._user_agent_pool)
+        return self.user_agent
 
     def _playwright_available(self) -> bool:
         return bool(self._playwright_client and self._playwright_client.is_available())
@@ -377,7 +474,11 @@ class WebRAG:
             return []
 
     def _headers(self) -> Dict[str, str]:
-        return {"User-Agent": self.user_agent, "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
+        ua = self._choose_user_agent()
+        return {
+            "User-Agent": ua,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        }
 
     def _search_ddg(self, query: str, max_results: int = 10) -> List[Dict[str, str]]:
         out: List[Dict[str, str]] = []

--- a/internal/web_playwright.py
+++ b/internal/web_playwright.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import contextlib
 import re
 import urllib.parse
-from typing import Dict, Iterator, List, Optional
+import random
+from typing import Any, Dict, Iterator, List, Optional, Sequence
 
 try:  # pragma: no cover - import guarded for environments without Playwright
     from playwright.sync_api import (  # type: ignore
@@ -50,11 +51,25 @@ class PlaywrightWebClient:
         headless: bool = True,
         timeout_ms: int = 15_000,
         user_agent: Optional[str] = None,
+        *,
+        user_agent_pool: Optional[Sequence[str]] = None,
+        proxy: Optional[Dict[str, Any]] = None,
+        incognito_contexts: bool = True,
+        random_seed: Optional[int] = None,
     ) -> None:
         self.browser = browser
         self.headless = headless
         self.timeout_ms = timeout_ms
         self.user_agent = user_agent
+        self.user_agent_pool = [ua.strip() for ua in user_agent_pool or [] if ua and ua.strip()]
+        self.proxy = dict(proxy) if proxy else None
+        self.incognito_contexts = incognito_contexts
+        self._rng = random.Random(random_seed)
+
+    def _choose_user_agent(self) -> Optional[str]:
+        if self.user_agent_pool:
+            return self._rng.choice(self.user_agent_pool)
+        return self.user_agent
 
     # ------------------------------------------------------------------
     # Lifecycle helpers
@@ -73,8 +88,15 @@ class PlaywrightWebClient:
             browser_launcher = getattr(p, self.browser, None)
             if browser_launcher is None:
                 browser_launcher = p.chromium
-            browser: Browser = browser_launcher.launch(headless=self.headless)
-            context = browser.new_context(user_agent=self.user_agent)
+            launch_kwargs: Dict[str, Any] = {"headless": self.headless}
+            if self.proxy:
+                launch_kwargs["proxy"] = dict(self.proxy)
+            browser: Browser = browser_launcher.launch(**launch_kwargs)
+            context_options: Dict[str, Any] = {}
+            user_agent = self._choose_user_agent()
+            if user_agent:
+                context_options["user_agent"] = user_agent
+            context: BrowserContext = browser.new_context(**context_options)
             context.set_default_timeout(self.timeout_ms)
             try:
                 yield context

--- a/tests/test_rag_web.py
+++ b/tests/test_rag_web.py
@@ -70,3 +70,33 @@ def test_web_rag_search_falls_back_without_playwright(monkeypatch):
     assert ddg_calls == [("Fallback test", 3)]
     assert results, "Expected fallback results when Playwright is unavailable"
     assert results[0]["path"] == "https://fallback.example"
+
+
+def test_web_rag_configuration_passed_to_playwright(monkeypatch):
+    captured_clients: list[_RecordPlaywrightClient] = []
+
+    class _CapturePlaywrightClient(_RecordPlaywrightClient):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            captured_clients.append(self)
+
+    monkeypatch.setattr(rag_module, "PlaywrightWebClient", _CapturePlaywrightClient)
+
+    web = rag_module.WebRAG(
+        user_agent_pool=["AgentOne", "AgentTwo"],
+        proxy="http://proxy.example:8080",
+        incognito_contexts=True,
+        random_seed=123,
+    )
+
+    assert captured_clients, "Expected Playwright client to be constructed"
+    client = captured_clients[0]
+    assert client.kwargs["user_agent_pool"] == ["AgentOne", "AgentTwo"]
+    assert client.kwargs["proxy"] == {"server": "http://proxy.example:8080"}
+    assert client.kwargs["incognito_contexts"] is True
+    assert client.kwargs["random_seed"] == 123
+
+    headers = web._headers()
+    assert headers["User-Agent"] in {"AgentOne", "AgentTwo"}
+    if web.session is not None:
+        assert web.session.proxies.get("http") == "http://proxy.example:8080"

--- a/tests/test_web_playwright.py
+++ b/tests/test_web_playwright.py
@@ -1,0 +1,114 @@
+from internal import web_playwright as module
+
+
+class _FakePage:
+    def __init__(self, goto_log):
+        self._goto_log = goto_log
+
+    def goto(self, url, wait_until=None):  # noqa: D401 - signature match
+        self._goto_log.append((url, wait_until))
+
+    def wait_for_selector(self, *args, **kwargs):  # noqa: D401 - behaviour mocked
+        return None
+
+    def query_selector_all(self, selector):  # noqa: D401 - behaviour mocked
+        return []
+
+    def wait_for_timeout(self, ms):  # noqa: D401 - behaviour mocked
+        return None
+
+    def evaluate(self, script):  # noqa: D401 - behaviour mocked
+        return "Rendered body text"
+
+
+class _FakeContext:
+    def __init__(self, options, timeout_log, goto_log, close_log):
+        self.options = options
+        self._timeout_log = timeout_log
+        self._goto_log = goto_log
+        self._close_log = close_log
+
+    def set_default_timeout(self, timeout):
+        self._timeout_log.append(timeout)
+
+    def new_page(self):
+        return _FakePage(self._goto_log)
+
+    def close(self):
+        self._close_log.append(True)
+
+
+class _FakeBrowser:
+    def __init__(self, context_log, timeout_log, goto_log, close_log):
+        self._context_log = context_log
+        self._timeout_log = timeout_log
+        self._goto_log = goto_log
+        self._close_log = close_log
+
+    def new_context(self, **kwargs):
+        options = dict(kwargs)
+        self._context_log.append(options)
+        return _FakeContext(options, self._timeout_log, self._goto_log, self._close_log)
+
+    def close(self):
+        return None
+
+
+class _FakeLauncher:
+    def __init__(self, launch_log, context_log, timeout_log, goto_log, close_log):
+        self._launch_log = launch_log
+        self._context_log = context_log
+        self._timeout_log = timeout_log
+        self._goto_log = goto_log
+        self._close_log = close_log
+
+    def launch(self, **kwargs):
+        self._launch_log.append(dict(kwargs))
+        return _FakeBrowser(self._context_log, self._timeout_log, self._goto_log, self._close_log)
+
+
+class _FakePlaywright:
+    def __init__(self, launcher):
+        self.chromium = launcher
+
+
+def _build_sync_playwright(launcher):
+    class _Manager:
+        def __enter__(self):
+            return _FakePlaywright(launcher)
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def _sync_playwright():
+        return _Manager()
+
+    return _sync_playwright
+
+
+def test_playwright_client_applies_proxy_and_incognito(monkeypatch):
+    launch_log: list[dict] = []
+    context_log: list[dict] = []
+    timeout_log: list[int] = []
+    goto_log: list[tuple[str, str | None]] = []
+    close_log: list[bool] = []
+
+    launcher = _FakeLauncher(launch_log, context_log, timeout_log, goto_log, close_log)
+    monkeypatch.setattr(module, "sync_playwright", _build_sync_playwright(launcher))
+
+    client = module.PlaywrightWebClient(
+        timeout_ms=3210,
+        user_agent_pool=["UA-A", "UA-B"],
+        proxy={"server": "http://proxy.local:8888"},
+        random_seed=0,
+    )
+
+    client.collect_search_results("example query", max_results=1)
+    text = client.render_page_text("https://example.com")
+
+    assert text == "Rendered body text"
+    assert launch_log and launch_log[0]["proxy"] == {"server": "http://proxy.local:8888"}
+    assert any(entry.get("user_agent") in {"UA-A", "UA-B"} for entry in context_log)
+    assert timeout_log == [3210, 3210]
+    assert len(close_log) == 2, "Expected a fresh incognito context per call"
+    assert goto_log and goto_log[0][0].startswith("https://duckduckgo.com")


### PR DESCRIPTION
## Summary
- allow WebRAG to accept proxy routing, user-agent rotation, and incognito context options via parameters and environment variables
- propagate the new options to the Playwright helper and exercise them with targeted unit tests
- document the anonymous browsing knobs available to callers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68e53de8d9b4832f92b98fb36eb65ee4