### PR TITLE
Add manager orchestrator and update workflows

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -17,6 +17,20 @@ __all__ = [
     "clear_default_toolsets",
 ]
 
+from .manager import (
+    ManagerAgent,
+    ManagerResult,
+    ManagerStatusUpdate,
+    TaskBudget,
+)
+
+__all__.extend([
+    "ManagerAgent",
+    "ManagerResult",
+    "ManagerStatusUpdate",
+    "TaskBudget",
+])
+
 
 _DEFAULT_TOOL_REGISTRY = ToolRegistry()
 _DEFAULT_TOOLSETS: dict[str, tuple[ToolSpec, ...]] = {}

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -1,0 +1,416 @@
+"""High-level manager agent orchestrating DAG-driven task workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+from internal.DAG import DAG
+from internal.structures import StructuredResponse
+from session import AgentRound, AgentSession
+
+__all__ = [
+    "TaskBudget",
+    "ManagerStatusUpdate",
+    "ManagerResult",
+    "ManagerAgent",
+]
+
+
+@dataclass(slots=True)
+class TaskBudget:
+    """Track quota consumption for an individual task."""
+
+    name: str
+    limit: float | None = 1.0
+    unit: str = "rounds"
+    consumed: float = 0.0
+
+    def consume(self, amount: float = 1.0) -> None:
+        if amount <= 0:
+            return
+        self.consumed += float(amount)
+        if self.limit is not None and self.consumed > self.limit:
+            self.consumed = self.limit
+
+    @property
+    def remaining(self) -> float | None:
+        if self.limit is None:
+            return None
+        return max(self.limit - self.consumed, 0.0)
+
+    @property
+    def progress(self) -> float | None:
+        if self.limit in (None, 0):
+            return None
+        return min(self.consumed / self.limit, 1.0)
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "consumed": self.consumed,
+            "unit": self.unit,
+        }
+        if self.limit is not None:
+            payload["limit"] = self.limit
+            payload["remaining"] = self.remaining
+            payload["progress"] = self.progress
+        else:
+            payload["limit"] = None
+            payload["remaining"] = None
+            payload["progress"] = None
+        return payload
+
+    def copy(self) -> "TaskBudget":
+        return TaskBudget(name=self.name, limit=self.limit, unit=self.unit, consumed=self.consumed)
+
+
+@dataclass(slots=True)
+class ManagerStatusUpdate:
+    """Message surfaced to users describing manager workflow progress."""
+
+    message: str
+    kind: str = "info"
+    task: str | None = None
+    payload: Mapping[str, Any] | None = None
+    timestamp: float = field(default_factory=lambda: time.time())
+
+    def as_dict(self) -> dict[str, Any]:
+        data = {
+            "message": self.message,
+            "kind": self.kind,
+            "task": self.task,
+            "timestamp": self.timestamp,
+        }
+        if self.payload is not None:
+            data["payload"] = dict(self.payload)
+        return data
+
+
+@dataclass(slots=True)
+class ManagerResult:
+    """Aggregate output returned after the manager completes a workflow."""
+
+    response_text: str
+    structured_response: StructuredResponse | None
+    rounds: list[AgentRound]
+    plan: list[dict[str, Any]]
+    budgets: dict[str, TaskBudget]
+    status_updates: list[ManagerStatusUpdate]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "response_text": self.response_text,
+            "structured_response": self.structured_response,
+            "rounds": [round_record.to_dict() for round_record in self.rounds],
+            "plan": [dict(step) for step in self.plan],
+            "budgets": {name: budget.as_dict() for name, budget in self.budgets.items()},
+            "status_updates": [update.as_dict() for update in self.status_updates],
+        }
+
+
+class ManagerAgent:
+    """Top-level orchestrator for user-facing conversations."""
+
+    def __init__(
+        self,
+        *,
+        session: AgentSession | None = None,
+        session_factory: Callable[[], AgentSession] | None = None,
+        status_callback: Callable[[ManagerStatusUpdate], None] | None = None,
+        plan_builder: Callable[[str], Sequence[Mapping[str, Any]]] | None = None,
+        plan_retries: int = 1,
+        task_retry_limit: int = 0,
+    ) -> None:
+        if session is None:
+            if session_factory is None:
+                raise ValueError("ManagerAgent requires a session or session_factory")
+            session = session_factory()
+        self.session = session
+        self._status_callback = status_callback
+        self._plan_builder = plan_builder or self._default_plan_builder
+        self.plan_retries = max(0, plan_retries)
+        self.task_retry_limit = max(0, task_retry_limit)
+
+        self._active_plan: list[dict[str, Any]] = []
+        self._budgets: dict[str, TaskBudget] = {}
+        self._status_log: list[ManagerStatusUpdate] = []
+        self._current_task: str | None = None
+        self._current_round_task: str | None = None
+        self._last_response_text: str = ""
+        self._last_structured: StructuredResponse | None = None
+        self._initial_round_index: int = len(self.session.rounds)
+        self._runtime_metadata: dict[str, Any] = {}
+
+        self.session.add_round_hooks(
+            on_round_start=self._handle_round_start,
+            on_round_end=self._handle_round_end,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self, user_message: str, *, metadata: Mapping[str, Any] | None = None) -> ManagerResult:
+        """Execute the manager workflow for a new user input."""
+
+        self._reset_runtime_state()
+        self._runtime_metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
+        self._publish_status(
+            f"Received user request ({len(user_message)} characters)",
+            kind="info",
+            payload={"user_message": user_message, "metadata": dict(self._runtime_metadata)},
+        )
+
+        dag = self._build_workflow()
+        dag.set_constant("user_input", user_message)
+        dag.run(targets=["execute"])
+
+        response_text = self._last_response_text
+        structured_response = self._last_structured
+        self._publish_status("Workflow completed", kind="success")
+
+        new_rounds = self.session.rounds[self._initial_round_index :]
+        return ManagerResult(
+            response_text=response_text,
+            structured_response=structured_response,
+            rounds=new_rounds,
+            plan=[dict(step) for step in self._active_plan],
+            budgets={name: budget.copy() for name, budget in self._budgets.items()},
+            status_updates=list(self._status_log),
+        )
+
+    # ------------------------------------------------------------------
+    # DAG lifecycle
+    # ------------------------------------------------------------------
+    def _build_workflow(self) -> DAG:
+        dag = DAG()
+        dag.add_node("user_input", value="", is_constant=True)
+        dag.add_node(
+            "plan",
+            func=self._dag_plan,
+            deps=["user_input"],
+            retries=self.plan_retries,
+            metadata={"stage": "planning"},
+        )
+        dag.add_node(
+            "prepare",
+            func=self._dag_prepare,
+            deps=["plan"],
+            metadata={"stage": "budgeting"},
+        )
+        dag.add_node(
+            "execute",
+            func=self._dag_execute,
+            deps=["prepare", "user_input"],
+            retries=self.task_retry_limit,
+            metadata={"stage": "execution"},
+        )
+        return dag
+
+    def _dag_plan(self, inputs: Mapping[str, Any]) -> list[dict[str, Any]]:
+        user_message = str(inputs.get("user_input", ""))
+        planned = self._call_plan_builder(user_message)
+        tasks: list[dict[str, Any]] = []
+        for index, item in enumerate(planned, start=1):
+            payload = dict(item)
+            payload.setdefault("name", f"task-{index}")
+            payload.setdefault("prompt", user_message)
+            tasks.append(payload)
+        self._active_plan = [dict(task) for task in tasks]
+        self._publish_status(
+            f"Planner produced {len(tasks)} task(s)",
+            kind="planning",
+            payload={"tasks": [task["name"] for task in tasks]},
+        )
+        return tasks
+
+    def _dag_prepare(self, inputs: Mapping[str, Any]) -> list[dict[str, Any]]:
+        tasks: Iterable[Mapping[str, Any]] = inputs.get("plan", [])
+        self._allocate_budgets(tasks)
+        return [dict(task) for task in tasks]
+
+    def _dag_execute(self, inputs: Mapping[str, Any]) -> dict[str, Any]:
+        tasks: Sequence[Mapping[str, Any]] = inputs.get("prepare", [])
+        user_message = str(inputs.get("user_input", ""))
+        response_text = ""
+        structured: StructuredResponse | None = None
+        for task in tasks:
+            response_text, structured = self._execute_task(task, user_message=user_message)
+        return {"response_text": response_text, "structured_response": structured}
+
+    # ------------------------------------------------------------------
+    # Planning helpers
+    # ------------------------------------------------------------------
+    def _default_plan_builder(self, user_message: str) -> Sequence[Mapping[str, Any]]:
+        cleaned = user_message.strip()
+        description = "Respond to the user's request"
+        if not cleaned:
+            description = "Prompt the user for additional details"
+        return [
+            {
+                "name": "task-1",
+                "description": description,
+                "prompt": user_message,
+                "budget": {"limit": 1.0, "unit": "rounds"},
+            }
+        ]
+
+    def _call_plan_builder(self, user_message: str) -> Sequence[Mapping[str, Any]]:
+        builder = self._plan_builder
+        runtime_metadata = dict(self._runtime_metadata)
+        try:
+            return builder(user_message, metadata=runtime_metadata)
+        except TypeError:
+            return builder(user_message)
+
+    def _allocate_budgets(self, tasks: Iterable[Mapping[str, Any]]) -> None:
+        self._budgets.clear()
+        for index, task in enumerate(tasks, start=1):
+            name = str(task.get("name") or f"task-{index}")
+            budget_info = task.get("budget") or {}
+            limit_value = budget_info.get("limit", 1.0)
+            unit = budget_info.get("unit", "rounds")
+            limit: float | None
+            if limit_value is None:
+                limit = None
+            else:
+                try:
+                    limit = float(limit_value)
+                except (TypeError, ValueError):
+                    limit = 1.0
+            budget = TaskBudget(name=name, limit=limit, unit=str(unit))
+            self._budgets[name] = budget
+            self._publish_status(
+                f"Allocated budget for {name}",
+                kind="budget",
+                task=name,
+                payload={"budget": budget.as_dict()},
+            )
+
+    # ------------------------------------------------------------------
+    # Execution helpers
+    # ------------------------------------------------------------------
+    def _execute_task(
+        self,
+        task: Mapping[str, Any],
+        *,
+        user_message: str,
+    ) -> tuple[str, StructuredResponse | None]:
+        name = str(task.get("name") or "task")
+        self._current_task = name
+        prompt = str(task.get("prompt", user_message))
+        budget = self._budgets.get(name)
+        metadata: MutableMapping[str, Any] = dict(task.get("metadata", {}))
+        metadata.setdefault("task", name)
+        if budget:
+            metadata["budget"] = budget.as_dict()
+
+        act_kwargs: dict[str, Any] = dict(task.get("act_kwargs", {}))
+        try:
+            text, structured = self.session.act(
+                prompt,
+                tools=task.get("tools"),
+                tool_names=task.get("tool_names"),
+                config=task.get("config"),
+                callbacks=task.get("callbacks"),
+                metadata=metadata,
+                **act_kwargs,
+            )
+        except Exception as exc:  # pragma: no cover - safeguard for downstream errors
+            return self._handle_task_failure(name, exc)
+        else:
+            self._mark_task_complete(name)
+            self._last_response_text = text
+            self._last_structured = structured
+            return text, structured
+        finally:
+            self._current_task = None
+
+    def _handle_task_failure(
+        self,
+        task_name: str,
+        exc: Exception,
+    ) -> tuple[str, StructuredResponse | None]:
+        message = f"Task '{task_name}' failed: {exc}"
+        self._publish_status(message, kind="error", task=task_name, payload={"error": str(exc)})
+        fallback = f"Unable to complete {task_name}: {exc}"
+        self._last_response_text = fallback
+        self._last_structured = None
+        return fallback, None
+
+    def _mark_task_complete(self, task_name: str) -> None:
+        budget = self._budgets.get(task_name)
+        payload = {"budget": budget.as_dict()} if budget else None
+        self._publish_status(
+            f"Task '{task_name}' completed",
+            kind="success",
+            task=task_name,
+            payload=payload,
+        )
+
+    # ------------------------------------------------------------------
+    # AgentSession hooks
+    # ------------------------------------------------------------------
+    def _handle_round_start(self, payload: Mapping[str, Any]) -> None:
+        metadata = payload.get("metadata") or {}
+        task_name = metadata.get("task") if isinstance(metadata, Mapping) else None
+        if task_name is None:
+            task_name = self._current_task
+        self._current_round_task = task_name
+        if task_name:
+            self._publish_status(
+                f"Starting round {payload.get('index', 0)} for {task_name}",
+                kind="round_start",
+                task=task_name,
+                payload={"round_index": payload.get("index"), "metadata": metadata},
+            )
+
+    def _handle_round_end(self, round_record: AgentRound) -> None:
+        task_name = self._current_round_task or self._current_task
+        budget = self._budgets.get(task_name) if task_name else None
+        if budget:
+            budget.consume()
+            metadata: dict[str, Any] = dict(round_record.metadata or {})
+            metadata["task"] = task_name
+            metadata["budget"] = budget.as_dict()
+            metadata["progress"] = budget.progress
+            if self._runtime_metadata:
+                metadata.setdefault("run_metadata", dict(self._runtime_metadata))
+            round_record.metadata = metadata
+            self._publish_status(
+                f"{task_name} progress: {budget.consumed} {budget.unit}",
+                kind="progress",
+                task=task_name,
+                payload={
+                    "budget": budget.as_dict(),
+                    "round_index": round_record.index,
+                    "run_metadata": dict(self._runtime_metadata) if self._runtime_metadata else None,
+                },
+            )
+        self._current_round_task = None
+        self._runtime_metadata = {}
+
+    # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+    def _reset_runtime_state(self) -> None:
+        self._status_log.clear()
+        self._initial_round_index = len(self.session.rounds)
+        self._last_response_text = ""
+        self._last_structured = None
+        self._current_task = None
+        self._current_round_task = None
+
+    def _publish_status(
+        self,
+        message: str,
+        *,
+        kind: str = "info",
+        task: str | None = None,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        update = ManagerStatusUpdate(message=message, kind=kind, task=task, payload=payload)
+        self._status_log.append(update)
+        if self._status_callback is not None:
+            self._status_callback(update)

--- a/internal/STT.py
+++ b/internal/STT.py
@@ -24,21 +24,47 @@ Usage
 from __future__ import annotations
 
 from dataclasses import dataclass
+import importlib.machinery
+import importlib.util
+import sys
 from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
+if "psutil" in sys.modules and getattr(sys.modules["psutil"], "__spec__", None) is None:  # pragma: no cover - test environment fix
+    sys.modules["psutil"].__spec__ = importlib.machinery.ModuleSpec("psutil", loader=None)
+
+_transformers_exc: Exception | None = None
+if importlib.util.find_spec("torch") is None:
+    _transformers_exc = ImportError("PyTorch backend is required for transformers ASR models")
+
 try:
+    if _transformers_exc is not None:
+        raise _transformers_exc
     from transformers import (
         AutoModelForSpeechSeq2Seq,
         AutoProcessor,
         pipeline as hf_pipeline,
     )
 except Exception as exc:  # pragma: no cover
-    raise RuntimeError(
-        "transformers is required for STT functionality.\n"
-        "Install with: pip install -U transformers"
-    ) from exc
+    _missing_cause = exc
+
+    class _MissingTransformerDependency:
+        _ERROR_MESSAGE = (
+            "transformers is required for STT functionality.\n"
+            "Install with: pip install -U transformers"
+        )
+        _CAUSE = _missing_cause
+
+        @classmethod
+        def from_pretrained(cls, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError(cls._ERROR_MESSAGE) from cls._CAUSE
+
+    AutoModelForSpeechSeq2Seq = _MissingTransformerDependency  # type: ignore[assignment]
+    AutoProcessor = _MissingTransformerDependency  # type: ignore[assignment]
+
+    def hf_pipeline(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(_MissingTransformerDependency._ERROR_MESSAGE) from _missing_cause
 
 
 AudioInput = Union[str, np.ndarray]

--- a/internal/TTS.py
+++ b/internal/TTS.py
@@ -20,11 +20,23 @@ Usage
 from __future__ import annotations
 
 from dataclasses import dataclass
+import importlib.machinery
+import importlib.util
+import sys
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 
+if "psutil" in sys.modules and getattr(sys.modules["psutil"], "__spec__", None) is None:  # pragma: no cover - test environment fix
+    sys.modules["psutil"].__spec__ = importlib.machinery.ModuleSpec("psutil", loader=None)
+
+_transformers_exc: Exception | None = None
+if importlib.util.find_spec("torch") is None:
+    _transformers_exc = ImportError("PyTorch backend is required for transformers TTS models")
+
 try:
+    if _transformers_exc is not None:
+        raise _transformers_exc
     from transformers import (
         SpeechT5ForTextToSpeech,
         SpeechT5Processor,
@@ -32,10 +44,25 @@ try:
         pipeline as hf_pipeline,
     )
 except Exception as exc:  # pragma: no cover
-    raise RuntimeError(
-        "transformers is required for TTS functionality.\n"
-        "Install with: pip install -U transformers"
-    ) from exc
+    _missing_cause = exc
+
+    class _MissingTransformerDependency:
+        _ERROR_MESSAGE = (
+            "transformers is required for TTS functionality.\n"
+            "Install with: pip install -U transformers"
+        )
+        _CAUSE = _missing_cause
+
+        @classmethod
+        def from_pretrained(cls, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError(cls._ERROR_MESSAGE) from cls._CAUSE
+
+    SpeechT5ForTextToSpeech = _MissingTransformerDependency  # type: ignore[assignment]
+    SpeechT5Processor = _MissingTransformerDependency  # type: ignore[assignment]
+    SpeechT5HifiGan = _MissingTransformerDependency  # type: ignore[assignment]
+
+    def hf_pipeline(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(_MissingTransformerDependency._ERROR_MESSAGE) from _missing_cause
 
 
 @dataclass
@@ -73,7 +100,8 @@ class TTS:
         self.config = config or TTSConfig()
         if model_id:
             self.config.model_id = model_id
-        self._pipeline = self._build_pipeline()
+        self._pipeline = None
+        self._pipeline_error: Exception | None = None
 
     def _build_pipeline(self):
         load_kwargs: Dict[str, Any] = {}
@@ -110,6 +138,16 @@ class TTS:
 
         return hf_pipeline("text-to-speech", **pipe_kwargs)
 
+    def _ensure_pipeline(self):
+        if self._pipeline is not None:
+            return self._pipeline
+        try:
+            self._pipeline = self._build_pipeline()
+        except Exception as exc:  # pragma: no cover - surfaced to caller
+            self._pipeline_error = exc
+            raise
+        return self._pipeline
+
     def synthesize(
         self,
         text: str,
@@ -132,8 +170,8 @@ class TTS:
             pipe_kwargs["speaker_embeddings"] = speaker_embedding
         if language:
             pipe_kwargs["language"] = language
-
-        out = self._pipeline(text, **pipe_kwargs)
+        pipeline = self._ensure_pipeline()
+        out = pipeline(text, **pipe_kwargs)
 
         # HF returns dict with 'audio' and 'sampling_rate'
         if isinstance(out, dict) and "audio" in out:

--- a/main.py
+++ b/main.py
@@ -1,1 +1,60 @@
-# main.py
+"""Command-line entry point bootstrapping the manager agent."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Callable
+
+from agents import AgentBuilder
+from agents.manager import ManagerAgent, ManagerResult, ManagerStatusUpdate
+
+
+def _build_manager() -> ManagerAgent:
+    builder = AgentBuilder()
+    session = builder.build()
+
+    def status_printer(update: ManagerStatusUpdate) -> None:
+        prefix = update.kind.upper()
+        task_label = f" [{update.task}]" if update.task else ""
+        print(f"[{prefix}{task_label}] {update.message}")
+
+    return ManagerAgent(session=session, status_callback=status_printer)
+
+
+def _interactive_loop(manager_factory: Callable[[], ManagerAgent]) -> int:
+    manager = manager_factory()
+    print("Auto-Coder manager ready. Type 'exit' or 'quit' to stop.")
+    while True:
+        try:
+            user_input = input("You: ")
+        except EOFError:
+            print()
+            break
+        if not user_input.strip():
+            continue
+        if user_input.strip().lower() in {"exit", "quit"}:
+            break
+        result = manager.run(user_input)
+        _render_result(result)
+    return 0
+
+
+def _render_result(result: ManagerResult) -> None:
+    for update in result.status_updates:
+        if update.kind in {"info", "success", "progress", "round_start", "budget", "planning"}:
+            continue  # already surfaced live via callback
+        prefix = update.kind.upper()
+        task_label = f" [{update.task}]" if update.task else ""
+        print(f"[{prefix}{task_label}] {update.message}")
+    print(f"Manager: {result.response_text}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Start the Auto-Coder manager agent")
+    _ = parser.parse_args(argv)
+    return _interactive_loop(_build_manager)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 playwright>=1.42.0
+numpy>=2.3.0
+psutil>=7.1.0
+transformers>=4.57.0

--- a/session.py
+++ b/session.py
@@ -56,6 +56,7 @@ class AgentRound:
     transcript: list[Any]
     messages: list[Any] = field(default_factory=list)
     tool_history: dict[str, list[Any]] = field(default_factory=dict)
+    metadata: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -68,6 +69,7 @@ class AgentRound:
             "tool_history": {
                 key: list(values) for key, values in self.tool_history.items()
             },
+            "metadata": dict(self.metadata) if isinstance(self.metadata, Mapping) else self.metadata,
         }
 
 
@@ -227,6 +229,7 @@ class AgentSession:
         user_message: str | None,
         response_text: str,
         result: StructuredResponse,
+        metadata: Mapping[str, Any] | None,
     ) -> AgentRound:
         transcript_snapshot = self.transcript
         tool_calls = list(self._current_tool_calls)
@@ -240,6 +243,12 @@ class AgentSession:
         if result_results:
             tool_results.extend(item for item in result_results if item not in tool_results)
 
+        metadata_payload: dict[str, Any] | None = None
+        if isinstance(metadata, Mapping):
+            metadata_payload = dict(metadata)
+        elif metadata is None:
+            metadata_payload = None
+
         round_record = AgentRound(
             index=index,
             user_message=user_message,
@@ -251,6 +260,7 @@ class AgentSession:
                 "calls": tool_calls,
                 "results": tool_results,
             },
+            metadata=metadata_payload,
         )
         return round_record
 
@@ -263,6 +273,7 @@ class AgentSession:
         config: Optional[Mapping[str, Any]] = None,
         callbacks: Optional[CallbackMap] = None,
         handle_invalid_tool_request: Any | None = None,
+        metadata: Mapping[str, Any] | None = None,
         **act_kwargs: Any,
     ) -> tuple[str, StructuredResponse]:
         self._current_messages = []
@@ -270,12 +281,16 @@ class AgentSession:
         self._current_tool_results = []
 
         round_index = len(self.rounds)
+        metadata_payload = dict(metadata) if isinstance(metadata, Mapping) else None
+
         if self._on_round_start:
-            self._on_round_start({
+            payload = {
                 "index": round_index,
                 "user_message": user_message,
                 "session": self,
-            })
+                "metadata": metadata_payload,
+            }
+            self._on_round_start(payload)
 
         composed_callbacks = self._compose_callbacks(callbacks)
         text, result = self.chat_session.act(
@@ -293,6 +308,7 @@ class AgentSession:
             user_message=user_message,
             response_text=text,
             result=result,
+            metadata=metadata_payload,
         )
         self.rounds.append(round_record)
 
@@ -300,6 +316,40 @@ class AgentSession:
             self._on_round_end(round_record)
 
         return text, result
+
+    def add_round_hooks(
+        self,
+        *,
+        on_round_start: Hook | None = None,
+        on_round_end: Hook | None = None,
+    ) -> None:
+        """Append round lifecycle hooks without overriding existing callbacks."""
+
+        if on_round_start is not None:
+            existing = self._on_round_start
+
+            if existing is None:
+                self._on_round_start = on_round_start
+            else:
+
+                def chained_start(payload: Mapping[str, Any]) -> None:
+                    existing(payload)
+                    on_round_start(payload)
+
+                self._on_round_start = chained_start
+
+        if on_round_end is not None:
+            existing_end = self._on_round_end
+
+            if existing_end is None:
+                self._on_round_end = on_round_end
+            else:
+
+                def chained_end(round_record: AgentRound) -> None:
+                    existing_end(round_record)
+                    on_round_end(round_record)
+
+                self._on_round_end = chained_end
 
     def last_round(self) -> AgentRound | None:
         return self.rounds[-1] if self.rounds else None

--- a/tests/test_manager_agent.py
+++ b/tests/test_manager_agent.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from agents.manager import ManagerAgent, ManagerStatusUpdate
+from internal.structures import StructuredResponse
+from session import AgentRound
+
+
+class DummySession:
+    """Lightweight stub mimicking :class:`AgentSession` for manager tests."""
+
+    def __init__(self) -> None:
+        self.rounds: list[AgentRound] = []
+        self._on_round_start = None
+        self._on_round_end = None
+        self.next_response_text = "done"
+
+    def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:
+        self._on_round_start = on_round_start
+        self._on_round_end = on_round_end
+
+    def act(self, user_message: str | None = None, *, metadata: Mapping[str, Any] | None = None, **_: Any):
+        index = len(self.rounds)
+        if self._on_round_start is not None:
+            self._on_round_start(
+                {
+                    "index": index,
+                    "user_message": user_message,
+                    "session": self,
+                    "metadata": dict(metadata) if metadata else None,
+                }
+            )
+        structured = StructuredResponse(
+            raw_response={"choices": [{"message": {"content": self.next_response_text, "parsed": {"ok": True}}}]},
+            content=self.next_response_text,
+            parsed={"ok": True},
+            schema=None,
+            structured=False,
+        )
+        round_record = AgentRound(
+            index=index,
+            user_message=user_message,
+            response_text=self.next_response_text,
+            result=structured,
+            transcript=[],
+            messages=[],
+            tool_history={"calls": [], "results": []},
+            metadata=dict(metadata) if metadata else None,
+        )
+        self.rounds.append(round_record)
+        if self._on_round_end is not None:
+            self._on_round_end(round_record)
+        return self.next_response_text, structured
+
+
+@pytest.mark.parametrize("message", ["solve this", ""])
+def test_manager_tracks_budget_progress(message: str) -> None:
+    session = DummySession()
+    captured: list[ManagerStatusUpdate] = []
+    manager = ManagerAgent(session=session, status_callback=captured.append)
+
+    result = manager.run(message)
+
+    assert result.response_text == session.next_response_text
+    assert result.plan, "planner should produce at least one task"
+    first_task = result.plan[0]
+    assert "name" in first_task
+    assert "task-1" in result.budgets
+    budget = result.budgets["task-1"]
+    assert pytest.approx(budget.consumed) == 1.0
+    assert budget.remaining in (0.0, None)
+    assert result.rounds
+    last_round = result.rounds[-1]
+    assert last_round.metadata is not None
+    assert last_round.metadata["budget"]["consumed"] == pytest.approx(1.0)
+    assert any(update.kind == "progress" for update in captured)


### PR DESCRIPTION
## Summary
- refactor the agents module into a package and introduce a ManagerAgent orchestrator that drives DAG-based planning with budget tracking and status surfacing
- wire the manager through the command-line entry point and extend AgentSession metadata hooks so planner state flows back through rounds
- harden STT/TTS imports for environments without full transformer backends, lazily build the TTS pipeline, and add targeted manager tests plus required dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e5b85af9e4832fbb99c51525bf4c59