### PR TITLE
Add research agent with caching and manager integration

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -51,6 +51,11 @@ from .runner import (
     RunReport,
     RunnerAgent,
 )
+from .research import (
+    ResearchAgent,
+    ResearchResult,
+    ResearchSnippet,
+)
 
 __all__.extend([
     "ManagerAgent",
@@ -95,6 +100,14 @@ __all__.extend(
     [
         "RunnerAgent",
         "RunReport",
+    ]
+)
+
+__all__.extend(
+    [
+        "ResearchAgent",
+        "ResearchResult",
+        "ResearchSnippet",
     ]
 )
 

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -18,6 +18,7 @@ from .repo_context import (
 )
 
 if TYPE_CHECKING:
+    from .research import ResearchAgent, ResearchResult, ResearchSnippet
     from .tester import CriticStatusEvent, TestCriticAgent, TestCriticReport
 
 __all__ = [
@@ -108,6 +109,7 @@ class ManagerResult:
     plan: list[dict[str, Any]]
     budgets: dict[str, TaskBudget]
     status_updates: list[ManagerStatusUpdate]
+    evidence: Mapping[str, tuple["ResearchSnippet", ...]] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -117,6 +119,13 @@ class ManagerResult:
             "plan": [dict(step) for step in self.plan],
             "budgets": {name: budget.as_dict() for name, budget in self.budgets.items()},
             "status_updates": [update.as_dict() for update in self.status_updates],
+            "evidence": {
+                key: [
+                    snippet.to_dict() if hasattr(snippet, "to_dict") else snippet
+                    for snippet in value
+                ]
+                for key, value in self.evidence.items()
+            },
         }
 
 
@@ -134,6 +143,8 @@ class ManagerAgent:
         task_retry_limit: int = 0,
         repo_context: RepoContextAgent | None = None,
         test_critic: "TestCriticAgent" | None = None,
+        research_agent: "ResearchAgent" | None = None,
+        external_browsing_default: bool = False,
     ) -> None:
         if session is None:
             if session_factory is None:
@@ -158,6 +169,10 @@ class ManagerAgent:
         self.test_critic: "TestCriticAgent" | None = None
         self._gate_report: "TestCriticReport" | None = None
         self._gate_blocked: bool = False
+        self.research_agent: "ResearchAgent" | None = research_agent
+        self._external_browsing_default = bool(external_browsing_default)
+        self._external_browsing_enabled = self._external_browsing_default
+        self._shared_evidence: dict[str, list["ResearchSnippet"]] = {}
         if test_critic is not None:
             self.attach_test_critic(test_critic)
 
@@ -174,6 +189,20 @@ class ManagerAgent:
 
         self._reset_runtime_state()
         self._runtime_metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
+        requested_browsing = None
+        for key in ("external_browsing", "allow_external_browsing", "enable_external_browsing"):
+            if key in self._runtime_metadata:
+                requested_browsing = self._runtime_metadata[key]
+                break
+        if requested_browsing is not None:
+            self._external_browsing_enabled = bool(requested_browsing)
+        if self.research_agent is not None:
+            self._publish_status(
+                "External browsing "
+                + ("enabled" if self._external_browsing_enabled else "disabled"),
+                kind="browsing",
+                payload={"enabled": self._external_browsing_enabled},
+            )
         self._publish_status(
             f"Received user request ({len(user_message)} characters)",
             kind="info",
@@ -207,6 +236,7 @@ class ManagerAgent:
             plan=[dict(step) for step in self._active_plan],
             budgets={name: budget.copy() for name, budget in self._budgets.items()},
             status_updates=list(self._status_log),
+            evidence=self._evidence_snapshot(),
         )
 
     # ------------------------------------------------------------------
@@ -263,6 +293,118 @@ class ManagerAgent:
             include_untracked=include_untracked,
         )
         return bundle.to_dict()
+
+    # ------------------------------------------------------------------
+    # Research helpers
+    # ------------------------------------------------------------------
+    def attach_research_agent(self, agent: "ResearchAgent" | None) -> None:
+        """Attach or detach the research agent used for external browsing."""
+
+        self.research_agent = agent
+
+    def set_external_browsing_default(self, enabled: bool) -> None:
+        """Configure the default browsing behaviour for subsequent runs."""
+
+        self._external_browsing_default = bool(enabled)
+        self._external_browsing_enabled = bool(enabled)
+
+    def set_external_browsing(self, enabled: bool) -> None:
+        """Manually override the browsing toggle for the current workflow."""
+
+        self._external_browsing_enabled = bool(enabled)
+
+    def request_research(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        max_search_results: int = 20,
+        allow_rewrite: bool = True,
+        audience: str | None = None,
+        force_refresh: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return structured snippets for ``query`` and cache the evidence."""
+
+        if not query or not str(query).strip():
+            return []
+        if self.research_agent is None:
+            raise RuntimeError("Research agent is not configured")
+        if not self._external_browsing_enabled:
+            raise RuntimeError("External browsing is disabled for this request")
+
+        try:
+            sanitized_top_k = int(top_k)
+        except (TypeError, ValueError):
+            sanitized_top_k = 5
+        if sanitized_top_k <= 0:
+            sanitized_top_k = 5
+        audience_value = None
+        if audience is not None and str(audience).strip():
+            audience_value = str(audience).strip()
+        result = self.research_agent.search(
+            query,
+            top_k=sanitized_top_k,
+            max_search_results=max_search_results,
+            allow_rewrite=allow_rewrite,
+            audience=audience_value,
+            force_refresh=force_refresh,
+        )
+        self._record_research_evidence(audience_value, result)
+        return [snippet.to_dict() for snippet in result.snippets]
+
+    def get_research_evidence(self, audience: str | None = None) -> list[dict[str, Any]]:
+        """Return cached research evidence scoped to ``audience`` if provided."""
+
+        snapshot = self._evidence_snapshot()
+        if audience is None:
+            snippets: list[Any] = []
+            for items in snapshot.values():
+                snippets.extend(items)
+        else:
+            key = audience.lower()
+            snippets = list(snapshot.get(key, ()))
+        return [snippet.to_dict() if hasattr(snippet, "to_dict") else snippet for snippet in snippets]
+
+    def _record_research_evidence(
+        self,
+        audience: str | None,
+        result: "ResearchResult",
+    ) -> None:
+        key = (audience or "general").lower()
+        bucket = self._shared_evidence.setdefault(key, [])
+        seen = {snippet.url for snippet in bucket}
+        for snippet in result.snippets:
+            if snippet.url in seen:
+                continue
+            bucket.append(snippet)
+            seen.add(snippet.url)
+
+    def _build_evidence_payload(self) -> dict[str, list[dict[str, Any]]]:
+        snapshot = self._evidence_snapshot()
+        return {
+            key: [snippet.to_dict() if hasattr(snippet, "to_dict") else snippet for snippet in snippets]
+            for key, snippets in snapshot.items()
+        }
+
+    def _evidence_snapshot(self) -> dict[str, tuple["ResearchSnippet", ...]]:
+        return {key: tuple(values) for key, values in self._shared_evidence.items()}
+
+    @staticmethod
+    def _coerce_queries(value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple, set)):
+            items = value
+        else:
+            items = [value]
+        queries: list[str] = []
+        for item in items:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                queries.append(text)
+        return queries
 
     # ------------------------------------------------------------------
     # DAG lifecycle
@@ -416,6 +558,47 @@ class ManagerAgent:
         if budget:
             metadata["budget"] = budget.as_dict()
 
+        research_spec = task.get("research")
+        audience_hint = None
+        raw_queries: Any = None
+        if isinstance(research_spec, Mapping):
+            raw_queries = research_spec.get("queries")
+            if raw_queries is None and research_spec.get("query") is not None:
+                raw_queries = research_spec.get("query")
+            audience_hint = research_spec.get("audience")
+        else:
+            raw_queries = task.get("research_queries")
+            audience_hint = task.get("research_audience")
+        queries = self._coerce_queries(raw_queries)
+        audience_value = str(audience_hint).strip() if audience_hint is not None else None
+        if queries:
+            try:
+                top_k_raw = task.get("research_top_k", 5)
+                top_k = int(top_k_raw)
+            except (TypeError, ValueError):
+                top_k = 5
+            if top_k <= 0:
+                top_k = 5
+            metadata["requested_research"] = list(queries)
+            for query_text in queries:
+                try:
+                    self.request_research(
+                        query_text,
+                        top_k=top_k,
+                        audience=audience_value,
+                    )
+                except Exception as exc:
+                    self._publish_status(
+                        f"Research lookup failed for {name}: {exc}",
+                        kind="warning",
+                        task=name,
+                        payload={"query": query_text, "error": str(exc)},
+                    )
+
+        metadata["external_browsing_enabled"] = self._external_browsing_enabled
+        if self._shared_evidence:
+            metadata["external_evidence"] = self._build_evidence_payload()
+
         act_kwargs: dict[str, Any] = dict(task.get("act_kwargs", {}))
         try:
             text, structured = self.session.act(
@@ -530,6 +713,8 @@ class ManagerAgent:
         self._current_round_task = None
         self._gate_report = None
         self._gate_blocked = False
+        self._external_browsing_enabled = self._external_browsing_default
+        self._shared_evidence.clear()
 
     def _publish_status(
         self,

--- a/agents/research.py
+++ b/agents/research.py
@@ -1,0 +1,291 @@
+"""High-level research helper built on top of :class:`internal.RAG.WebRAG`."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+import re
+import threading
+import urllib.parse
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
+
+from internal.RAG import WebRAG
+
+__all__ = [
+    "ResearchSnippet",
+    "ResearchResult",
+    "ResearchAgent",
+]
+
+
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(slots=True)
+class ResearchSnippet:
+    """Structured excerpt extracted from a web source."""
+
+    url: str
+    title: str
+    quote: str
+    citation: str
+    score: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "url": self.url,
+            "title": self.title,
+            "quote": self.quote,
+            "citation": self.citation,
+        }
+        if self.score is not None:
+            payload["score"] = self.score
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class ResearchResult:
+    """Container bundling the snippets for a single research query."""
+
+    query: str
+    snippets: tuple[ResearchSnippet, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "query": self.query,
+            "snippets": [snippet.to_dict() for snippet in self.snippets],
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    def limit(self, top_k: int) -> "ResearchResult":
+        if top_k <= 0:
+            return ResearchResult(query=self.query, snippets=(), metadata=self.metadata)
+        if top_k >= len(self.snippets):
+            return self
+        return ResearchResult(query=self.query, snippets=self.snippets[:top_k], metadata=self.metadata)
+
+
+class ResearchAgent:
+    """Wrapper around :class:`WebRAG` providing caching and sanitisation."""
+
+    def __init__(
+        self,
+        *,
+        rag_factory: Callable[..., WebRAG] | None = None,
+        cache_size: int = 8,
+        cache_top_k: int = 8,
+        max_quote_chars: int = 320,
+        anonymous_browsing: bool | None = None,
+        **rag_kwargs: Any,
+    ) -> None:
+        self._rag_factory = rag_factory or WebRAG
+        self._rag_kwargs: dict[str, Any] = dict(rag_kwargs)
+        if anonymous_browsing is not None:
+            self._rag_kwargs["anonymous_browsing"] = anonymous_browsing
+        self._rag: WebRAG | None = None
+        self._cache_size = max(1, cache_size)
+        self._cache_top_k = max(1, cache_top_k)
+        self._max_quote_chars = max(80, max_quote_chars)
+        self._cache: "OrderedDict[str, ResearchResult]" = OrderedDict()
+        self._lock = threading.Lock()
+        self._url_cache: dict[str, MutableMapping[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def clear_cache(self) -> None:
+        """Invalidate cached query and source lookups."""
+
+        with self._lock:
+            self._cache.clear()
+            self._url_cache.clear()
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        max_search_results: int = 20,
+        allow_rewrite: bool = True,
+        audience: str | None = None,
+        force_refresh: bool = False,
+        alpha: float = 0.6,
+    ) -> ResearchResult:
+        """Return cached or freshly gathered research snippets for ``query``."""
+
+        cleaned_query = self._normalise_query(query)
+        if not cleaned_query:
+            return ResearchResult(query=query, snippets=())
+
+        cache_key = cleaned_query.lower()
+        with self._lock:
+            cached = None if force_refresh else self._cache.get(cache_key)
+            if cached is not None and top_k <= len(cached.snippets):
+                self._cache.move_to_end(cache_key)
+                return cached.limit(top_k)
+
+        rag = self._ensure_rag()
+        fetch_top_k = max(top_k, self._cache_top_k)
+        raw_results = rag.search(
+            cleaned_query,
+            top_k=fetch_top_k,
+            max_search_results=max_search_results,
+            allow_rewrite=allow_rewrite,
+            alpha=alpha,
+        )
+        source_meta = self._collect_source_metadata(rag, cleaned_query, max_search_results)
+
+        snippets: list[ResearchSnippet] = []
+        seen_urls: set[str] = set()
+        for item in raw_results:
+            url = str(item.get("path") or "").strip()
+            if not url:
+                continue
+            normalised = self._normalise_url(url)
+            if normalised in seen_urls:
+                continue
+            seen_urls.add(normalised)
+            cached_source = self._url_cache.get(normalised)
+            if cached_source is None:
+                title, snippet_hint = self._resolve_source_details(url, source_meta)
+                quote = self._build_quote(item.get("text", ""), snippet_hint)
+                if not quote:
+                    continue
+                cached_source = {
+                    "title": title,
+                    "quote": quote,
+                    "source_snippet": snippet_hint,
+                }
+                self._url_cache[normalised] = cached_source
+            else:
+                quote = str(cached_source.get("quote") or "")
+                if not quote:
+                    continue
+            citation = self._format_citation(len(snippets) + 1, url)
+            title = str(cached_source.get("title") or self._derive_title(url))
+            score = item.get("score")
+            snippet_metadata: dict[str, Any] = {"source_snippet": cached_source.get("source_snippet")}
+            if audience is not None:
+                snippet_metadata["audience"] = audience
+            if score is not None:
+                snippet_metadata["score"] = score
+            snippet = ResearchSnippet(
+                url=url,
+                title=title,
+                quote=quote,
+                citation=citation,
+                score=float(score) if score is not None else None,
+                metadata=snippet_metadata,
+            )
+            snippets.append(snippet)
+            if len(snippets) >= fetch_top_k:
+                break
+
+        result = ResearchResult(query=cleaned_query, snippets=tuple(snippets))
+        with self._lock:
+            self._cache[cache_key] = result
+            self._cache.move_to_end(cache_key)
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
+        return result.limit(top_k)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_rag(self) -> WebRAG:
+        if self._rag is None:
+            self._rag = self._rag_factory(**self._rag_kwargs)
+        return self._rag
+
+    def _normalise_query(self, query: str) -> str:
+        return _WHITESPACE_RE.sub(" ", query.strip())
+
+    def _normalise_url(self, url: str) -> str:
+        parsed = urllib.parse.urlsplit(url)
+        path = parsed.path.rstrip("/")
+        normalised = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, ""))
+        return normalised or url
+
+    def _collect_source_metadata(
+        self,
+        rag: WebRAG,
+        query: str,
+        max_results: int,
+    ) -> dict[str, Mapping[str, str]]:
+        meta: dict[str, Mapping[str, str]] = {}
+        results: Sequence[Mapping[str, str]] = []
+        client = getattr(rag, "_playwright_client", None)
+        if client is not None and callable(getattr(client, "is_available", None)):
+            try:
+                if client.is_available():
+                    results = client.collect_search_results(query, max_results=max_results)  # type: ignore[attr-defined]
+            except Exception:
+                results = []
+        if not results:
+            try:
+                results = rag._search_ddg(query, max_results=max_results)
+            except Exception:
+                results = []
+
+        for entry in results:
+            url = str(entry.get("url") or entry.get("href") or "").strip()
+            if not url:
+                continue
+            normalised = self._normalise_url(url)
+            if normalised in meta:
+                continue
+            title = entry.get("title") or entry.get("body") or ""
+            snippet = entry.get("snippet") or entry.get("body") or ""
+            meta[normalised] = {
+                "title": self._sanitize(title, max_chars=160) or self._derive_title(url),
+                "snippet": self._sanitize(snippet, max_chars=self._max_quote_chars),
+            }
+        return meta
+
+    def _resolve_source_details(
+        self,
+        url: str,
+        meta: Mapping[str, Mapping[str, str]],
+    ) -> tuple[str, str]:
+        normalised = self._normalise_url(url)
+        if normalised in meta:
+            entry = meta[normalised]
+            return entry.get("title", self._derive_title(url)), entry.get("snippet", "")
+        return self._derive_title(url), ""
+
+    def _derive_title(self, url: str) -> str:
+        parsed = urllib.parse.urlsplit(url)
+        host = parsed.netloc or parsed.path or url
+        host = host.split("@")[-1]
+        if parsed.path and parsed.path not in {"", "/"}:
+            parts = [segment for segment in parsed.path.split("/") if segment]
+            if parts:
+                return self._sanitize(parts[-1], max_chars=80)
+        return self._sanitize(host, max_chars=80)
+
+    def _build_quote(self, text: str, fallback: str) -> str:
+        primary = self._sanitize(text, max_chars=self._max_quote_chars)
+        if primary:
+            return primary
+        return self._sanitize(fallback, max_chars=self._max_quote_chars)
+
+    def _sanitize(self, text: str, *, max_chars: int) -> str:
+        cleaned = _CONTROL_RE.sub("", str(text))
+        cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
+        if not cleaned:
+            return ""
+        if len(cleaned) > max_chars:
+            truncated = cleaned[: max_chars - 1].rstrip(" ,;:\n")
+            return f"{truncated}…"
+        return cleaned
+
+    def _format_citation(self, index: int, url: str) -> str:
+        return f"[{index}]({url})"
+

--- a/tests/test_manager_research.py
+++ b/tests/test_manager_research.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from agents.manager import ManagerAgent
+from agents.research import ResearchResult, ResearchSnippet
+from internal.structures import StructuredResponse
+from session import AgentRound
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.rounds: list[AgentRound] = []
+        self._on_round_start = None
+        self._on_round_end = None
+        self.next_response_text = "done"
+        self.last_metadata: Mapping[str, Any] | None = None
+
+    def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:
+        self._on_round_start = on_round_start
+        self._on_round_end = on_round_end
+
+    def act(
+        self,
+        user_message: str | None = None,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        **_: Any,
+    ):
+        index = len(self.rounds)
+        if self._on_round_start is not None:
+            self._on_round_start(
+                {
+                    "index": index,
+                    "user_message": user_message,
+                    "session": self,
+                    "metadata": dict(metadata) if metadata else None,
+                }
+            )
+        structured = StructuredResponse(
+            raw_response={"choices": [{"message": {"content": self.next_response_text, "parsed": {"ok": True}}}]},
+            content=self.next_response_text,
+            parsed={"ok": True},
+            schema=None,
+            structured=False,
+        )
+        record_metadata = dict(metadata) if metadata else None
+        round_record = AgentRound(
+            index=index,
+            user_message=user_message,
+            response_text=self.next_response_text,
+            result=structured,
+            transcript=[],
+            metadata=record_metadata,
+            messages=[],
+            tool_history={"calls": [], "results": []},
+        )
+        self.last_metadata = round_record.metadata
+        self.rounds.append(round_record)
+        if self._on_round_end is not None:
+            self._on_round_end(round_record)
+        return self.next_response_text, structured
+
+
+class StubResearchAgent:
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, int, str | None]] = []
+        snippet = ResearchSnippet(
+            url="https://example.com/doc",
+            title="Example",
+            quote="Example quote",
+            citation="[1](https://example.com/doc)",
+        )
+        self._result = ResearchResult(query="", snippets=(snippet,))
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        max_search_results: int = 20,
+        allow_rewrite: bool = True,
+        audience: str | None = None,
+        force_refresh: bool = False,
+        alpha: float = 0.6,
+    ) -> ResearchResult:
+        self.queries.append((query, top_k, audience))
+        return ResearchResult(query=query, snippets=self._result.snippets)
+
+
+def test_manager_routes_research_into_metadata() -> None:
+    session = DummySession()
+    research = StubResearchAgent()
+
+    def plan_builder(_: str, metadata: Mapping[str, Any] | None = None) -> list[Mapping[str, Any]]:
+        return [
+            {
+                "name": "task-1",
+                "prompt": "do work",
+                "research": {"queries": ["python testing"], "audience": "coder"},
+            }
+        ]
+
+    manager = ManagerAgent(
+        session=session,
+        plan_builder=plan_builder,
+        research_agent=research,
+        external_browsing_default=False,
+    )
+
+    result = manager.run("do work", metadata={"external_browsing": True})
+
+    assert research.queries[0][0] == "python testing"
+    assert "external_evidence" in session.last_metadata
+    evidence = session.last_metadata["external_evidence"]
+    assert evidence["coder"][0]["url"] == "https://example.com/doc"
+    assert result.evidence["coder"][0].url == "https://example.com/doc"
+
+
+def test_manager_respects_external_browsing_toggle() -> None:
+    session = DummySession()
+    research = StubResearchAgent()
+    manager = ManagerAgent(session=session, research_agent=research, external_browsing_default=False)
+
+    manager.run("task", metadata={"external_browsing": True})
+    manager.request_research("first")
+
+    manager.run("task", metadata={"external_browsing": False})
+    with pytest.raises(RuntimeError):
+        manager.request_research("second")

--- a/tests/test_research_agent.py
+++ b/tests/test_research_agent.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from agents.research import ResearchAgent
+
+
+class DummyPlaywrightClient:
+    def is_available(self) -> bool:
+        return False
+
+
+class DummyRag:
+    def __init__(self) -> None:
+        self.search_calls: list[tuple[str, int, int, bool, float]] = []
+        self.ddg_calls: list[tuple[str, int]] = []
+        self._playwright_client = DummyPlaywrightClient()
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 10,
+        max_search_results: int = 20,
+        allow_rewrite: bool = True,
+        alpha: float = 0.6,
+    ) -> list[Mapping[str, Any]]:
+        self.search_calls.append((query, top_k, max_search_results, allow_rewrite, alpha))
+        return [
+            {"path": "https://example.com/page#section", "text": "Line one\nLine two", "score": 0.9},
+            {"path": "https://example.com/page", "text": "Duplicate", "score": 0.8},
+        ]
+
+    def _search_ddg(self, query: str, max_results: int = 10) -> Sequence[Mapping[str, str]]:
+        self.ddg_calls.append((query, max_results))
+        return [
+            {"url": "https://example.com/page", "title": "Example Title", "snippet": "Line one snippet"},
+        ]
+
+
+def _build_agent(dummy: DummyRag) -> ResearchAgent:
+    return ResearchAgent(rag_factory=lambda **_: dummy, cache_size=4, cache_top_k=4, max_quote_chars=120)
+
+
+def test_research_agent_caches_and_deduplicates_results() -> None:
+    dummy = DummyRag()
+    agent = _build_agent(dummy)
+
+    first = agent.search("Test Query", top_k=3, allow_rewrite=False)
+    second = agent.search("  Test   Query  ", top_k=1, allow_rewrite=False)
+
+    assert dummy.search_calls == [("Test Query", 4, 20, False, 0.6)]
+    assert dummy.ddg_calls == [("Test Query", 20)]
+    assert len(first.snippets) == 1
+    assert len(second.snippets) == 1
+    snippet = second.snippets[0]
+    assert snippet.url == "https://example.com/page#section"
+    assert snippet.citation == "[1](https://example.com/page#section)"
+    assert "\n" not in snippet.quote
+    assert snippet.quote.startswith("Line one")
+
+
+def test_research_agent_respects_force_refresh_and_sanitizes_title() -> None:
+    dummy = DummyRag()
+    agent = _build_agent(dummy)
+
+    result = agent.search("Another", top_k=2, allow_rewrite=False)
+    assert result.snippets[0].title == "Example Title"
+
+    refreshed = agent.search("Another", top_k=2, allow_rewrite=False, force_refresh=True)
+    assert len(dummy.search_calls) == 2
+    assert refreshed.snippets[0].quote == result.snippets[0].quote


### PR DESCRIPTION
## Summary
- add a ResearchAgent helper that wraps WebRAG with caching, source deduplication, and sanitized snippets for downstream agents
- extend ManagerAgent with external browsing toggles, research evidence routing, and metadata injection for tasks
- cover the new behaviour with unit tests for the research helper and the manager integration

## Testing
- pytest *(fails: missing optional dependency `numpy` required by existing STT/TTS tests)*

------
https://chatgpt.com/codex/tasks/task_b_68e5d29b1470832fb79df93c6c646845