### PR TITLE
Add dependency build agent and manager integration

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -30,6 +30,12 @@ from .coder import (
     CoderResult,
     MinimalPatch,
 )
+from .dependency import (
+    DependencyBuildAgent,
+    DependencyCacheDirective,
+    DependencyResolution,
+    LockfileDiffSummary,
+)
 
 from .repo_context import (
     DiffBundle,
@@ -63,6 +69,15 @@ __all__.extend([
     "ManagerStatusUpdate",
     "TaskBudget",
 ])
+
+__all__.extend(
+    [
+        "DependencyBuildAgent",
+        "DependencyCacheDirective",
+        "DependencyResolution",
+        "LockfileDiffSummary",
+    ]
+)
 
 __all__.extend(
     [

--- a/agents/dependency.py
+++ b/agents/dependency.py
@@ -1,0 +1,413 @@
+"""Dependency resolution helpers leveraging :class:`RunnerAgent`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import difflib
+import os
+from pathlib import Path
+import re
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from .runner import RunReport, RunnerAgent
+
+__all__ = [
+    "DependencyCacheDirective",
+    "DependencyResolution",
+    "DependencyBuildAgent",
+    "LockfileDiffSummary",
+]
+
+
+_JSON_KEY_RE = re.compile(r'"(?P<name>[^"\\]+)"\s*:\s*"(?P<version>[^"\\]+)"')
+_REQUIREMENT_RE = re.compile(r"(?P<name>[A-Za-z0-9_.\-]+)==(?P<version>[A-Za-z0-9_.\-]+)")
+_POETRY_NAME_RE = re.compile(r"name\s*=\s*\"(?P<name>[^\"]+)\"")
+_POETRY_VERSION_RE = re.compile(r"version\s*=\s*\"(?P<version>[^\"]+)\"")
+
+
+@dataclass(slots=True)
+class LockfileDiffSummary:
+    """Summary of dependency changes extracted from a lockfile diff."""
+
+    path: str
+    added: tuple[str, ...] = ()
+    removed: tuple[str, ...] = ()
+    updated: tuple[str, ...] = ()
+    raw_diff: str | None = None
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.added or self.removed or self.updated)
+
+    def describe(self) -> str:
+        parts: list[str] = []
+        if self.added:
+            parts.append(f"added {', '.join(self.added)}")
+        if self.removed:
+            parts.append(f"removed {', '.join(self.removed)}")
+        if self.updated:
+            parts.append(f"updated {', '.join(self.updated)}")
+        if not parts:
+            return f"{self.path}: no substantive changes"
+        return f"{self.path}: " + "; ".join(parts)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "added": list(self.added),
+            "removed": list(self.removed),
+            "updated": list(self.updated),
+            "raw_diff": self.raw_diff,
+        }
+
+    @classmethod
+    def from_contents(
+        cls,
+        path: str | os.PathLike[str],
+        before: str | None,
+        after: str | None,
+    ) -> "LockfileDiffSummary" | None:
+        before_lines = (before.splitlines() if before is not None else [])
+        after_lines = (after.splitlines() if after is not None else [])
+        if before_lines == after_lines:
+            return None
+        diff_lines = list(
+            difflib.unified_diff(
+                before_lines,
+                after_lines,
+                fromfile=str(path),
+                tofile=str(path),
+                lineterm="",
+            )
+        )
+        diff_text = "\n".join(diff_lines)
+        return cls.from_unified_diff(path=str(path), diff_text=diff_text)
+
+    @classmethod
+    def from_unified_diff(cls, path: str, diff_text: str) -> "LockfileDiffSummary":
+        added: dict[str, str | None] = {}
+        removed: dict[str, str | None] = {}
+        pending_poetry_name: str | None = None
+        pending_poetry_removed_name: str | None = None
+        for line in diff_text.splitlines():
+            if not line or line.startswith("+++") or line.startswith("---") or line.startswith("@@"):
+                continue
+            prefix = line[0]
+            if prefix not in "+-":
+                continue
+            content = line[1:].strip()
+            parsed_name, parsed_version = cls._parse_dependency_line(content)
+            if parsed_name:
+                target = added if prefix == "+" else removed
+                target.setdefault(parsed_name, parsed_version)
+                pending_poetry_name = parsed_name if prefix == "+" else pending_poetry_name
+                pending_poetry_removed_name = (
+                    parsed_name if prefix == "-" else pending_poetry_removed_name
+                )
+                continue
+            if prefix == "+":
+                version_match = _POETRY_VERSION_RE.search(content)
+                if version_match and pending_poetry_name:
+                    added[pending_poetry_name] = version_match.group("version")
+                    pending_poetry_name = None
+            elif prefix == "-":
+                version_match = _POETRY_VERSION_RE.search(content)
+                if version_match and pending_poetry_removed_name:
+                    removed[pending_poetry_removed_name] = version_match.group("version")
+                    pending_poetry_removed_name = None
+        updated: list[str] = []
+        for name in sorted(set(added) & set(removed)):
+            new_version = added.pop(name)
+            old_version = removed.pop(name)
+            updated.append(_format_update(name, old_version, new_version))
+        added_entries = [_format_entry(name, version) for name, version in sorted(added.items())]
+        removed_entries = [_format_entry(name, version) for name, version in sorted(removed.items())]
+        updated_entries = sorted(updated)
+        return cls(
+            path=path,
+            added=tuple(added_entries),
+            removed=tuple(removed_entries),
+            updated=tuple(updated_entries),
+            raw_diff=diff_text,
+        )
+
+    @staticmethod
+    def _parse_dependency_line(content: str) -> tuple[str | None, str | None]:
+        match = _JSON_KEY_RE.search(content)
+        if match:
+            return match.group("name"), match.group("version")
+        if content and ":" in content:
+            token = content.split(":", 1)[0].strip('"')
+            if token:
+                if "@" in token:
+                    name, version = token.rsplit("@", 1)
+                    if name:
+                        return name, version or None
+                return token, None
+        match = _REQUIREMENT_RE.search(content)
+        if match:
+            return match.group("name"), match.group("version")
+        match = _POETRY_NAME_RE.search(content)
+        if match:
+            return match.group("name"), None
+        return None, None
+
+
+def _format_entry(name: str, version: str | None) -> str:
+    if version:
+        return f"{name}@{version}"
+    return name
+
+
+def _format_update(name: str, old: str | None, new: str | None) -> str:
+    old_display = old or "?"
+    new_display = new or "?"
+    return f"{name} {old_display} → {new_display}"
+
+
+@dataclass(slots=True)
+class DependencyCacheDirective:
+    """Hint to persist package-manager specific caches between runs."""
+
+    manager: str
+    paths: tuple[str, ...]
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manager": self.manager,
+            "paths": list(self.paths),
+            "description": self.description,
+        }
+
+    @property
+    def hint(self) -> str:
+        if not self.paths:
+            return self.description or ""
+        joined = ", ".join(self.paths)
+        if self.description:
+            return f"{self.description}: {joined}"
+        return joined
+
+
+@dataclass(slots=True)
+class DependencyResolution:
+    """Outcome of executing a dependency management command."""
+
+    manager: str
+    command: tuple[str, ...]
+    report: RunReport
+    lockfile_summaries: tuple[LockfileDiffSummary, ...] = ()
+    cache_directive: DependencyCacheDirective | None = None
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.report.ok)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "manager": self.manager,
+            "command": list(self.command),
+            "status": self.report.status,
+            "ok": self.ok,
+            "exit_code": self.report.exit_code,
+            "stdout": self.report.stdout,
+            "stderr": self.report.stderr,
+            "lockfiles": [summary.to_dict() for summary in self.lockfile_summaries],
+        }
+        if self.cache_directive is not None:
+            payload["cache_directive"] = self.cache_directive.to_dict()
+        return payload
+
+    def describe(self) -> str:
+        status = "succeeded" if self.ok else "failed"
+        command_display = " ".join(self.command) if self.command else self.manager
+        lines = [f"{self.manager} command '{command_display}' {status}."]
+        for summary in self.lockfile_summaries:
+            lines.append(summary.describe())
+        if self.cache_directive:
+            lines.append(f"Cache hint: {self.cache_directive.hint}")
+        if not self.ok and self.report.stderr:
+            lines.append(self.report.stderr.strip())
+        return "\n".join(lines)
+
+
+class DependencyBuildAgent:
+    """Utility agent orchestrating dependency related build actions."""
+
+    _DEFAULT_COMMANDS: Mapping[str, tuple[str, ...]] = {
+        "npm": ("npm", "install"),
+        "pnpm": ("pnpm", "install"),
+        "yarn": ("yarn", "install"),
+        "pip": ("pip", "install"),
+        "pipenv": ("pipenv", "install"),
+        "poetry": ("poetry", "install"),
+        "cargo": ("cargo", "fetch"),
+    }
+
+    _DEFAULT_LOCKFILES: Mapping[str, tuple[str, ...]] = {
+        "npm": ("package-lock.json", "package.json"),
+        "pnpm": ("pnpm-lock.yaml", "package.json"),
+        "yarn": ("yarn.lock", "package.json"),
+        "pip": ("requirements.txt", "requirements-dev.txt"),
+        "pipenv": ("Pipfile.lock", "Pipfile"),
+        "poetry": ("poetry.lock", "pyproject.toml"),
+        "cargo": ("Cargo.lock", "Cargo.toml"),
+    }
+
+    _CACHE_HINTS: Mapping[str, tuple[str, ...]] = {
+        "npm": ("node_modules", "~/.npm"),
+        "pnpm": ("node_modules", "~/.pnpm-store"),
+        "yarn": ("node_modules", "~/.cache/yarn"),
+        "pip": (".venv", "~/.cache/pip"),
+        "pipenv": (".venv", "~/.cache/pipenv"),
+        "poetry": (".venv", "~/.cache/pypoetry"),
+        "cargo": ("target", "~/.cargo"),
+    }
+
+    def __init__(
+        self,
+        *,
+        runner: RunnerAgent | None = None,
+        repo_root: str | os.PathLike[str] | None = None,
+    ) -> None:
+        if runner is None:
+            self.runner = RunnerAgent(repo_root=repo_root)
+            root_hint = self.runner.repo_root
+        else:
+            self.runner = runner
+            if repo_root is not None:
+                root_hint = repo_root
+            else:
+                root_hint = getattr(runner, "repo_root", os.getcwd())
+        self.repo_root = Path(root_hint).resolve()
+
+    def run_task(
+        self,
+        *,
+        manager: str,
+        command: Sequence[str] | str | None = None,
+        packages: Sequence[str] | None = None,
+        lockfiles: Sequence[str | os.PathLike[str]] | None = None,
+        workdir: str | os.PathLike[str] | None = None,
+        env: Mapping[str, str] | None = None,
+        status_callback: Callable[[str, str, Mapping[str, Any] | None], None] | None = None,
+    ) -> DependencyResolution:
+        manager_key = manager.lower()
+        resolved_command = self._resolve_command(manager_key, command, packages)
+        resolved_lockfiles = tuple(self._resolve_lockfiles(manager_key, lockfiles))
+        cwd = self._resolve_workdir(workdir)
+        before_snapshots = self._snapshot_lockfiles(cwd, resolved_lockfiles)
+        self._emit_status(
+            status_callback,
+            f"Running {manager_key} command",
+            kind="dependency_start",
+            payload={"command": list(resolved_command), "lockfiles": list(resolved_lockfiles)},
+        )
+        report = self.runner.run_shell(
+            resolved_command,
+            workdir=cwd,
+            env=env,
+            combine_output=True,
+        )
+        after_snapshots = self._snapshot_lockfiles(cwd, resolved_lockfiles)
+        summaries: list[LockfileDiffSummary] = []
+        for path in resolved_lockfiles:
+            summary = LockfileDiffSummary.from_contents(
+                path,
+                before_snapshots.get(path),
+                after_snapshots.get(path),
+            )
+            if summary and summary.has_changes:
+                summaries.append(summary)
+        cache_directive = self._cache_directive(manager_key)
+        resolution = DependencyResolution(
+            manager=manager_key,
+            command=tuple(resolved_command),
+            report=report,
+            lockfile_summaries=tuple(summaries),
+            cache_directive=cache_directive,
+        )
+        self._emit_status(
+            status_callback,
+            f"{manager_key} command completed",
+            kind="dependency_complete",
+            payload=resolution.to_dict(),
+        )
+        return resolution
+
+    def format_resolution(self, resolution: DependencyResolution) -> str:
+        return resolution.describe()
+
+    def _resolve_command(
+        self,
+        manager: str,
+        command: Sequence[str] | str | None,
+        packages: Sequence[str] | None,
+    ) -> tuple[str, ...]:
+        if command is not None:
+            if isinstance(command, str):
+                return tuple(command.split())
+            return tuple(str(part) for part in command)
+        base = self._DEFAULT_COMMANDS.get(manager)
+        if base is None:
+            base = (manager, "install")
+        parts: list[str] = [*base]
+        if packages:
+            parts.extend(str(item) for item in packages)
+        return tuple(parts)
+
+    def _resolve_lockfiles(
+        self,
+        manager: str,
+        lockfiles: Sequence[str | os.PathLike[str]] | None,
+    ) -> Iterable[str]:
+        if lockfiles:
+            for item in lockfiles:
+                yield str(item)
+            return
+        defaults = self._DEFAULT_LOCKFILES.get(manager, ())
+        for item in defaults:
+            yield item
+
+    def _resolve_workdir(self, workdir: str | os.PathLike[str] | None) -> str:
+        if workdir is None:
+            return str(self.repo_root)
+        path = Path(workdir)
+        if not path.is_absolute():
+            path = self.repo_root / path
+        return str(path.resolve())
+
+    def _snapshot_lockfiles(
+        self,
+        workdir: str,
+        lockfiles: Sequence[str],
+    ) -> dict[str, str]:
+        snapshots: dict[str, str] = {}
+        base = Path(workdir)
+        for relative in lockfiles:
+            path = base / relative
+            try:
+                snapshots[relative] = path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                snapshots[relative] = ""
+        return snapshots
+
+    def _cache_directive(self, manager: str) -> DependencyCacheDirective | None:
+        paths = self._CACHE_HINTS.get(manager)
+        if not paths:
+            return None
+        description = "Persist dependency caches"
+        return DependencyCacheDirective(manager=manager, paths=paths, description=description)
+
+    @staticmethod
+    def _emit_status(
+        callback: Callable[[str, str, Mapping[str, Any] | None], None] | None,
+        message: str,
+        *,
+        kind: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        if callback is None:
+            return
+        callback(message, kind, payload)

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -10,6 +10,7 @@ from internal.DAG import DAG
 from internal.structures import StructuredResponse
 from session import AgentRound, AgentSession
 
+from .dependency import DependencyBuildAgent
 from .repo_context import (
     DiffBundle,
     RepoContextAgent,
@@ -145,6 +146,7 @@ class ManagerAgent:
         test_critic: "TestCriticAgent" | None = None,
         research_agent: "ResearchAgent" | None = None,
         external_browsing_default: bool = False,
+        dependency_agent: DependencyBuildAgent | None = None,
     ) -> None:
         if session is None:
             if session_factory is None:
@@ -173,6 +175,7 @@ class ManagerAgent:
         self._external_browsing_default = bool(external_browsing_default)
         self._external_browsing_enabled = self._external_browsing_default
         self._shared_evidence: dict[str, list["ResearchSnippet"]] = {}
+        self._dependency_agent: DependencyBuildAgent | None = dependency_agent
         if test_critic is not None:
             self.attach_test_critic(test_critic)
 
@@ -261,6 +264,11 @@ class ManagerAgent:
 
         critic.set_status_callback(self._relay_critic_status)
         self.test_critic = critic
+
+    def attach_dependency_agent(self, agent: DependencyBuildAgent | None) -> None:
+        """Attach or detach the dependency build helper."""
+
+        self._dependency_agent = agent
 
     def request_focused_files(self, query: str, *, top_k: int = 5) -> list[dict[str, Any]]:
         """Return serialized search results for the given query."""
@@ -558,6 +566,12 @@ class ManagerAgent:
         if budget:
             metadata["budget"] = budget.as_dict()
 
+        task_kind_raw = metadata.get("kind") or task.get("kind")
+        task_kind = str(task_kind_raw).lower() if isinstance(task_kind_raw, str) else None
+        if task_kind == "dependency":
+            metadata.pop("kind", None)
+            return self._run_dependency_task(name, task, metadata, budget=budget)
+
         research_spec = task.get("research")
         audience_hint = None
         raw_queries: Any = None
@@ -619,6 +633,80 @@ class ManagerAgent:
             return text, structured
         finally:
             self._current_task = None
+
+    def _run_dependency_task(
+        self,
+        name: str,
+        task: Mapping[str, Any],
+        metadata: MutableMapping[str, Any],
+        *,
+        budget: TaskBudget | None,
+    ) -> tuple[str, StructuredResponse | None]:
+        agent = self._ensure_dependency_agent()
+        spec: dict[str, Any] = {}
+        dependency_spec = task.get("dependency")
+        if isinstance(dependency_spec, Mapping):
+            spec.update(dependency_spec)
+        for key in ("manager", "command", "packages", "lockfiles", "workdir", "env"):
+            if key in task and key not in spec:
+                spec[key] = task[key]
+            if key in metadata and key not in spec:
+                spec[key] = metadata[key]
+
+        manager_value = spec.get("manager")
+        if manager_value is None:
+            return self._handle_task_failure(
+                name,
+                ValueError("Dependency task missing 'manager' value"),
+            )
+
+        def status_callback(message: str, kind: str, payload: Mapping[str, Any] | None) -> None:
+            self._publish_status(message, kind=kind, task=name, payload=payload)
+
+        try:
+            resolution = agent.run_task(
+                manager=str(manager_value),
+                command=spec.get("command"),
+                packages=spec.get("packages"),
+                lockfiles=spec.get("lockfiles"),
+                workdir=spec.get("workdir"),
+                env=spec.get("env"),
+                status_callback=status_callback,
+            )
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        summary_text = agent.format_resolution(resolution)
+        structured_payload = resolution.to_dict()
+        structured = StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": summary_text,
+                            "parsed": structured_payload,
+                        }
+                    }
+                ]
+            },
+            content=summary_text,
+            parsed=structured_payload,
+            schema={"name": "DependencyResolution"},
+            structured=True,
+        )
+        if budget is not None:
+            budget.consume()
+        self._publish_status(
+            f"Dependency task '{name}' completed",
+            kind="dependency_summary",
+            task=name,
+            payload=structured_payload,
+        )
+        self._mark_task_complete(name)
+        self._last_response_text = summary_text
+        self._last_structured = structured
+        return summary_text, structured
 
     def _handle_task_failure(
         self,
@@ -728,3 +816,8 @@ class ManagerAgent:
         self._status_log.append(update)
         if self._status_callback is not None:
             self._status_callback(update)
+
+    def _ensure_dependency_agent(self) -> DependencyBuildAgent:
+        if self._dependency_agent is None:
+            self._dependency_agent = DependencyBuildAgent()
+        return self._dependency_agent

--- a/tests/test_dependency_agent.py
+++ b/tests/test_dependency_agent.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import importlib.machinery
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+if "lmstudio" not in sys.modules:
+    class _DummyChat:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.messages: list[Any] = []
+
+        @classmethod
+        def from_history(cls, history: Mapping[str, Any] | None) -> "_DummyChat":
+            instance = cls()
+            if isinstance(history, Mapping):
+                instance.messages = list(history.get("messages", []))
+            return instance
+
+        def append(self, message: Any) -> None:
+            self.messages.append(message)
+
+    class _DummyModel:
+        def respond(self, *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+            return {"choices": [{"message": {"content": ""}}]}
+
+        def respond_stream(self, *args: Any, **kwargs: Any):  # pragma: no cover - streaming unused
+            return iter(())
+
+    def _dummy_llm(*args: Any, **kwargs: Any) -> _DummyModel:
+        return _DummyModel()
+
+    class ToolFunctionDef:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            self.args = args
+            self.kwargs = kwargs
+            self.name = kwargs.get("name")
+    sys.modules["lmstudio"] = types.SimpleNamespace(
+        Chat=_DummyChat,
+        llm=_dummy_llm,
+        ToolFunctionDef=ToolFunctionDef,
+    )
+
+if "psutil" not in sys.modules:
+    class _DummyPsutil(types.SimpleNamespace):
+        class NoSuchProcess(Exception):
+            pass
+
+        class TimeoutExpired(Exception):
+            pass
+
+        def Process(self, pid: int):  # pragma: no cover - simple stub
+            raise self.NoSuchProcess()
+
+        def process_iter(self, attrs: Any):  # pragma: no cover - process listing unused
+            return []
+
+    sys.modules["psutil"] = _DummyPsutil()
+
+if "tooling" not in sys.modules:
+    class ToolSpec:
+        def __init__(self, func: Any, name: str | None = None) -> None:
+            self.func = func
+            self.name = name or getattr(func, "__name__", "tool")
+
+    class ToolRegistry:
+        def __init__(self) -> None:
+            self._tools: dict[str, ToolSpec] = {}
+
+        def register(self, tool: Any, replace: bool = False) -> ToolSpec:
+            spec = tool if isinstance(tool, ToolSpec) else ToolSpec(tool)
+            if not replace and spec.name in self._tools:
+                raise ValueError(f"Tool '{spec.name}' already registered")
+            self._tools[spec.name] = spec
+            return spec
+
+    def resolve_tools(*args: Any, **kwargs: Any) -> list[ToolSpec]:  # pragma: no cover - unused
+        return []
+
+    sys.modules["tooling"] = types.SimpleNamespace(
+        ToolSpec=ToolSpec,
+        ToolRegistry=ToolRegistry,
+        resolve_tools=resolve_tools,
+    )
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+if "agents" not in sys.modules:
+    agents_pkg = types.ModuleType("agents")
+    agents_pkg.__path__ = [str(PROJECT_ROOT / "agents")]
+    agents_pkg.__spec__ = importlib.machinery.ModuleSpec("agents", loader=None, is_package=True)
+    sys.modules["agents"] = agents_pkg
+
+if "chat" not in sys.modules:
+    class _StubChatSession:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - not exercised in tests
+            self.model = None
+            self.tools = []
+            self.system_prompt = None
+            self.chat = types.SimpleNamespace(messages=[])
+
+        @classmethod
+        def create(cls, **kwargs: Any) -> "_StubChatSession":
+            return cls()
+
+        def set_tools(self, *args: Any, **kwargs: Any) -> None:
+            return
+
+        def append_user_input(self, content: str) -> None:
+            return
+
+        def append_tool_response(self, *args: Any, **kwargs: Any) -> None:
+            return
+
+    CallbackMap = Mapping[str, Callable[..., Any]]
+
+    sys.modules["chat"] = types.SimpleNamespace(
+        CallbackMap=CallbackMap,
+        ChatSession=_StubChatSession,
+    )
+
+from agents.dependency import (
+    DependencyBuildAgent,
+    DependencyCacheDirective,
+    DependencyResolution,
+    LockfileDiffSummary,
+)
+from agents.manager import ManagerAgent
+from agents.runner import RunReport
+from internal.structures import StructuredResponse
+
+
+def _build_run_report(command: tuple[str, ...], workdir: str) -> RunReport:
+    command_display = " ".join(command)
+    return RunReport(
+        identifier=1,
+        runner="test",
+        command=command,
+        command_display=command_display,
+        workdir=workdir,
+        env={},
+        status="success",
+        ok=True,
+        exit_code=0,
+        pid=123,
+        stdout="ok",
+        stderr="",
+        combined_output="ok",
+        error=None,
+        start_time=0.0,
+        end_time=0.1,
+        duration=0.1,
+        artifacts=(),
+        metadata={},
+        raw={},
+    )
+
+
+def test_lockfile_diff_summary_identifies_changes() -> None:
+    before = "\n".join(
+        [
+            "{",
+            "  \"dependencies\": {",
+            "    \"left-pad\": \"1.0.0\",",
+            "    \"lodash\": \"4.17.21\"",
+            "  }",
+            "}",
+        ]
+    )
+    after = "\n".join(
+        [
+            "{",
+            "  \"dependencies\": {",
+            "    \"left-pad\": \"1.2.0\",",
+            "    \"chalk\": \"5.0.0\"",
+            "  }",
+            "}",
+        ]
+    )
+
+    summary = LockfileDiffSummary.from_contents("package-lock.json", before, after)
+    assert summary is not None
+    assert summary.has_changes
+    assert summary.added == ("chalk@5.0.0",)
+    assert summary.removed == ("lodash@4.17.21",)
+    assert summary.updated == ("left-pad 1.0.0 → 1.2.0",)
+    description = summary.describe()
+    assert "package-lock.json" in description
+    assert "chalk@5.0.0" in description
+    assert "left-pad" in description
+
+
+def test_dependency_agent_runs_and_summarises_lockfile(tmp_path: Path) -> None:
+    lockfile = tmp_path / "package-lock.json"
+    before = "\n".join(
+        [
+            "{",
+            "  \"dependencies\": {",
+            "    \"left-pad\": \"1.0.0\",",
+            "    \"lodash\": \"4.17.21\"",
+            "  }",
+            "}",
+        ]
+    )
+    after = "\n".join(
+        [
+            "{",
+            "  \"dependencies\": {",
+            "    \"left-pad\": \"1.2.0\",",
+            "    \"chalk\": \"5.0.0\"",
+            "  }",
+            "}",
+        ]
+    )
+    lockfile.write_text(before)
+
+    class FakeRunner:
+        def __init__(self) -> None:
+            self.calls: list[tuple[tuple[str, ...], Mapping[str, Any]]] = []
+            self.repo_root = str(tmp_path)
+
+        def run_shell(self, command: tuple[str, ...], **kwargs: Any) -> RunReport:
+            self.calls.append((tuple(command), kwargs))
+            lockfile.write_text(after)
+            workdir = kwargs.get("workdir", str(tmp_path))
+            return _build_run_report(tuple(command), workdir)
+
+    runner = FakeRunner()
+    agent = DependencyBuildAgent(runner=runner, repo_root=tmp_path)
+    status_events: list[tuple[str, str, Mapping[str, Any] | None]] = []
+
+    def capture(message: str, kind: str, payload: Mapping[str, Any] | None) -> None:
+        status_events.append((message, kind, payload))
+
+    resolution = agent.run_task(
+        manager="npm",
+        lockfiles=[lockfile.name],
+        status_callback=capture,
+    )
+
+    assert runner.calls, "runner should be invoked"
+    assert resolution.ok
+    assert resolution.lockfile_summaries
+    summary = resolution.lockfile_summaries[0]
+    assert summary.added == ("chalk@5.0.0",)
+    assert summary.removed == ("lodash@4.17.21",)
+    assert summary.updated == ("left-pad 1.0.0 → 1.2.0",)
+    assert resolution.cache_directive is not None
+    assert "node_modules" in resolution.cache_directive.paths
+    formatted = agent.format_resolution(resolution)
+    assert "npm command" in formatted
+    assert any(event[1] == "dependency_start" for event in status_events)
+    assert any(event[1] == "dependency_complete" for event in status_events)
+
+
+def test_manager_delegates_dependency_tasks(tmp_path: Path) -> None:
+    class DummySession:
+        def __init__(self) -> None:
+            self.rounds: list[Any] = []
+
+        def add_round_hooks(self, **_: Any) -> None:  # pragma: no cover - interface compliance
+            return
+
+        def act(self, *args: Any, **kwargs: Any) -> tuple[str, StructuredResponse]:  # pragma: no cover
+            raise AssertionError("Dependency tasks should not call session.act")
+
+    @dataclass
+    class StubDependencyAgent:
+        resolution: DependencyResolution
+
+        def run_task(self, **_: Any) -> DependencyResolution:
+            return self.resolution
+
+        def format_resolution(self, result: DependencyResolution) -> str:
+            return result.describe()
+
+    lock_summary = LockfileDiffSummary(
+        path="package-lock.json",
+        added=("chalk@5.0.0",),
+        removed=(),
+        updated=(),
+        raw_diff="",
+    )
+    resolution = DependencyResolution(
+        manager="npm",
+        command=("npm", "install"),
+        report=_build_run_report(("npm", "install"), str(tmp_path)),
+        lockfile_summaries=(lock_summary,),
+        cache_directive=DependencyCacheDirective(manager="npm", paths=("node_modules",), description="cache"),
+    )
+    stub_agent = StubDependencyAgent(resolution)
+    captured: list[Any] = []
+    manager = ManagerAgent(
+        session=DummySession(),
+        status_callback=captured.append,
+        dependency_agent=stub_agent,  # type: ignore[arg-type]
+    )
+    task = {
+        "name": "deps",
+        "metadata": {"kind": "dependency", "manager": "npm"},
+    }
+
+    text, structured = manager._execute_task(task, user_message="update dependencies")
+
+    assert text
+    assert isinstance(structured, StructuredResponse)
+    assert structured.parsed is not None
+    assert structured.parsed["manager"] == "npm"
+    assert any(update.kind == "dependency_summary" for update in captured)
+    assert manager._last_response_text == text


### PR DESCRIPTION
## Summary
- add dependency orchestration helpers, including lockfile diff summaries and cache hints
- integrate dependency execution into ManagerAgent task handling with status updates
- cover the new behavior with dependency-focused unit tests

## Testing
- `pytest tests/test_dependency_agent.py`


------
https://chatgpt.com/codex/tasks/task_b_68e5e6ba6e10832f8561e2614bad7b7e