### PR TITLE
Add DB migration agent support and tests

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -36,6 +36,13 @@ from .dependency import (
     DependencyResolution,
     LockfileDiffSummary,
 )
+from .db_migration import (
+    DBMigrationAgent,
+    EphemeralDatabaseSpec,
+    MigrationRecord,
+    MigrationResult,
+    SchemaMigrationPlan,
+)
 
 from .repo_context import (
     DiffBundle,
@@ -76,6 +83,16 @@ __all__.extend(
         "DependencyCacheDirective",
         "DependencyResolution",
         "LockfileDiffSummary",
+    ]
+)
+
+__all__.extend(
+    [
+        "DBMigrationAgent",
+        "SchemaMigrationPlan",
+        "MigrationResult",
+        "MigrationRecord",
+        "EphemeralDatabaseSpec",
     ]
 )
 

--- a/agents/db_migration.py
+++ b/agents/db_migration.py
@@ -1,0 +1,436 @@
+"""Database migration orchestration utilities and agent implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .repo_context import RepoContextAgent
+from .runner import RunReport, RunnerAgent
+
+__all__ = [
+    "MigrationRecord",
+    "SchemaMigrationPlan",
+    "EphemeralDatabaseSpec",
+    "MigrationResult",
+    "DBMigrationAgent",
+]
+
+
+@dataclass(slots=True)
+class MigrationRecord:
+    """Representation of a migration file tracked inside a framework."""
+
+    path: str
+    name: str
+    order_key: str
+    created: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "name": self.name,
+            "order_key": self.order_key,
+            "created": self.created,
+        }
+
+
+@dataclass(slots=True)
+class SchemaMigrationPlan:
+    """Plan describing how to generate migrations for a framework."""
+
+    framework: str
+    migrations_dir: str
+    workdir: str
+    env: Mapping[str, str]
+    command_template: tuple[str, ...]
+    apply_template: tuple[str, ...] | None
+    existing: tuple[MigrationRecord, ...]
+    artifact_paths: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "framework": self.framework,
+            "migrations_dir": self.migrations_dir,
+            "workdir": self.workdir,
+            "env": dict(self.env),
+            "command_template": list(self.command_template),
+            "apply_template": list(self.apply_template) if self.apply_template else None,
+            "existing": [record.to_dict() for record in self.existing],
+            "artifact_paths": list(self.artifact_paths),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(slots=True)
+class EphemeralDatabaseSpec:
+    """Lifecycle hooks for provisioning an ephemeral database runtime."""
+
+    name: str
+    setup: Sequence[str] | str
+    teardown: Sequence[str] | str | None = None
+    workdir: str | None = None
+    env: Mapping[str, str] = field(default_factory=dict)
+    setup_timeout_ms: int | None = None
+    teardown_timeout_ms: int | None = None
+    artifacts: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "setup": list(self.setup) if isinstance(self.setup, Sequence) and not isinstance(self.setup, str) else self.setup,
+            "teardown": list(self.teardown) if isinstance(self.teardown, Sequence) and not isinstance(self.teardown, str) else self.teardown,
+            "workdir": self.workdir,
+            "env": dict(self.env),
+            "setup_timeout_ms": self.setup_timeout_ms,
+            "teardown_timeout_ms": self.teardown_timeout_ms,
+            "artifacts": list(self.artifacts),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(slots=True)
+class MigrationResult:
+    """Outcome of running a migration generation workflow."""
+
+    framework: str
+    plan: SchemaMigrationPlan
+    generated: tuple[str, ...]
+    final_state: tuple[MigrationRecord, ...]
+    applied: bool
+    reports: tuple[RunReport, ...]
+    artifacts: tuple[str, ...]
+    ephemeral: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "framework": self.framework,
+            "plan": self.plan.to_dict(),
+            "generated": list(self.generated),
+            "final_state": [record.to_dict() for record in self.final_state],
+            "applied": self.applied,
+            "reports": [report.to_dict() for report in self.reports],
+            "artifacts": list(self.artifacts),
+            "ephemeral": self.ephemeral,
+            "metadata": dict(self.metadata),
+        }
+
+
+class DBMigrationAgent:
+    """Orchestrates schema migration generation across multiple frameworks."""
+
+    _DEFAULT_FRAMEWORKS: Mapping[str, Mapping[str, Any]] = {
+        "alembic": {
+            "migrations_dir": "migrations",
+            "generate": ("alembic", "revision", "--autogenerate", "-m", "{name}"),
+            "apply": ("alembic", "upgrade", "head"),
+        },
+        "prisma": {
+            "migrations_dir": "prisma/migrations",
+            "generate": ("npx", "prisma", "migrate", "dev", "--name", "{name}"),
+            "apply": ("npx", "prisma", "migrate", "deploy"),
+        },
+        "drizzle": {
+            "migrations_dir": "drizzle",
+            "generate": ("pnpm", "drizzle-kit", "generate"),
+            "apply": None,
+        },
+    }
+
+    def __init__(
+        self,
+        repo_context: RepoContextAgent,
+        *,
+        runner: RunnerAgent | None = None,
+        frameworks: Mapping[str, Mapping[str, Any]] | None = None,
+    ) -> None:
+        self.repo_context = repo_context
+        self.runner = runner or RunnerAgent(repo_root=self.repo_context.repo_root)
+        payload: dict[str, Mapping[str, Any]] = dict(self._DEFAULT_FRAMEWORKS)
+        if frameworks:
+            for name, spec in frameworks.items():
+                payload[name.lower()] = dict(spec)
+        self._frameworks: dict[str, Mapping[str, Any]] = payload
+        self._ephemeral_specs: dict[str, EphemeralDatabaseSpec] = {}
+
+    # ------------------------------------------------------------------
+    # Framework discovery & planning
+    # ------------------------------------------------------------------
+    def plan_migration(
+        self,
+        framework: str,
+        *,
+        migrations_dir: str | os.PathLike[str] | None = None,
+        workdir: str | os.PathLike[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> SchemaMigrationPlan:
+        """Construct a migration plan for the requested framework."""
+
+        config = self._get_framework_config(framework)
+        framework_name = framework.lower()
+        migrations_path = self._resolve_path(
+            migrations_dir or config.get("migrations_dir") or "migrations"
+        )
+        workdir_path = self._resolve_path(workdir or config.get("workdir") or self.repo_context.repo_root)
+        command_template = self._coerce_command(config.get("generate"))
+        if not command_template:
+            raise ValueError(f"Framework '{framework_name}' is missing a generate command")
+        apply_template = self._coerce_command(config.get("apply"))
+
+        env_payload: dict[str, str] = {}
+        config_env = config.get("env")
+        if isinstance(config_env, Mapping):
+            env_payload.update({str(k): str(v) for k, v in config_env.items()})
+        if env:
+            env_payload.update({str(k): str(v) for k, v in env.items()})
+
+        migrations_path.mkdir(parents=True, exist_ok=True)
+        records = tuple(self._collect_migrations(migrations_path))
+        artifact_set = {str(self._relative_to_repo(migrations_path))}
+        for item in config.get("artifacts", ()):
+            artifact_set.add(str(item))
+        artifact_paths = tuple(sorted(artifact_set))
+
+        metadata: dict[str, Any] = {
+            "framework": framework_name,
+            "config": {
+                key: value
+                for key, value in config.items()
+                if key not in {"generate", "apply"}
+            },
+        }
+
+        plan = SchemaMigrationPlan(
+            framework=framework_name,
+            migrations_dir=str(migrations_path),
+            workdir=str(workdir_path),
+            env=env_payload,
+            command_template=command_template,
+            apply_template=apply_template,
+            existing=records,
+            artifact_paths=artifact_paths,
+            metadata=metadata,
+        )
+        return plan
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+    def run_migration(
+        self,
+        plan: SchemaMigrationPlan,
+        *,
+        migration_name: str,
+        apply: bool = False,
+        extra_args: Sequence[str] | None = None,
+        ephemeral: str | EphemeralDatabaseSpec | None = None,
+    ) -> MigrationResult:
+        """Execute a migration plan and capture the resulting artefacts."""
+
+        if not migration_name:
+            raise ValueError("migration_name must be provided")
+
+        migrations_path = Path(plan.migrations_dir)
+        before_records = {record.name for record in plan.existing}
+        reports: list[RunReport] = []
+        artifacts: list[str] = list(plan.artifact_paths)
+        ephemeral_name: str | None = None
+        ephemeral_spec = self._resolve_ephemeral(ephemeral)
+        teardown_error: Exception | None = None
+        error: Exception | None = None
+
+        try:
+            if ephemeral_spec is not None:
+                setup_report = self.runner.run_shell(
+                    ephemeral_spec.setup,
+                    workdir=ephemeral_spec.workdir or plan.workdir,
+                    env=self._merge_env(plan.env, ephemeral_spec.env),
+                    timeout_ms=ephemeral_spec.setup_timeout_ms,
+                )
+                reports.append(setup_report)
+                if not setup_report.ok:
+                    raise RuntimeError(
+                        f"Ephemeral database setup '{ephemeral_spec.name}' failed"
+                    )
+                ephemeral_name = ephemeral_spec.name
+                artifacts.extend(str(item) for item in ephemeral_spec.artifacts)
+
+            command = self._render_command(plan.command_template, migration_name, extra_args)
+            generate_report = self.runner.run_shell(
+                command,
+                workdir=plan.workdir,
+                env=plan.env,
+            )
+            reports.append(generate_report)
+            if not generate_report.ok:
+                raise RuntimeError("Migration generation command failed")
+
+            if apply and plan.apply_template:
+                apply_command = self._render_command(plan.apply_template, migration_name, None)
+                apply_report = self.runner.run_shell(
+                    apply_command,
+                    workdir=plan.workdir,
+                    env=plan.env,
+                )
+                reports.append(apply_report)
+                if not apply_report.ok:
+                    raise RuntimeError("Migration apply command failed")
+            applied = bool(apply and plan.apply_template)
+
+            final_records = tuple(self._collect_migrations(migrations_path))
+            generated = tuple(
+                sorted(
+                    str(self._relative_to_repo(Path(plan.migrations_dir) / name))
+                    for name in {record.name for record in final_records} - before_records
+                )
+            )
+            result = MigrationResult(
+                framework=plan.framework,
+                plan=plan,
+                generated=generated,
+                final_state=final_records,
+                applied=applied,
+                reports=tuple(reports),
+                artifacts=tuple(dict.fromkeys(artifacts)),
+                ephemeral=ephemeral_name,
+            )
+            return result
+        except Exception as exc:
+            error = exc
+            raise
+        finally:
+            if ephemeral_spec is not None and ephemeral_spec.teardown is not None:
+                teardown_report = self.runner.run_shell(
+                    ephemeral_spec.teardown,
+                    workdir=ephemeral_spec.workdir or plan.workdir,
+                    env=self._merge_env(plan.env, ephemeral_spec.env),
+                    timeout_ms=ephemeral_spec.teardown_timeout_ms,
+                )
+                reports.append(teardown_report)
+                if not teardown_report.ok and teardown_error is None and error is None:
+                    teardown_error = RuntimeError(
+                        f"Ephemeral database teardown '{ephemeral_spec.name}' failed"
+                    )
+            if teardown_error is not None and error is None:
+                raise teardown_error
+
+    # ------------------------------------------------------------------
+    # Ephemeral database helpers
+    # ------------------------------------------------------------------
+    def register_ephemeral_database(self, spec: EphemeralDatabaseSpec) -> None:
+        """Register an ephemeral database specification for later reuse."""
+
+        self._ephemeral_specs[spec.name] = spec
+
+    def get_ephemeral_specs(self) -> tuple[EphemeralDatabaseSpec, ...]:
+        return tuple(self._ephemeral_specs.values())
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+    def format_result(self, result: MigrationResult) -> str:
+        """Create a concise textual summary for a migration result."""
+
+        generated = ", ".join(result.generated) if result.generated else "no new files"
+        applied = "applied" if result.applied else "not applied"
+        ephemeral = (
+            f" (ephemeral runtime: {result.ephemeral})" if result.ephemeral else ""
+        )
+        return (
+            f"Framework '{result.framework}' generated {generated} and {applied} migrations"
+            f"{ephemeral}."
+        )
+
+    # ------------------------------------------------------------------
+    # Internal utilities
+    # ------------------------------------------------------------------
+    def _get_framework_config(self, framework: str) -> Mapping[str, Any]:
+        key = framework.lower()
+        if key not in self._frameworks:
+            raise ValueError(f"Unsupported migration framework '{framework}'")
+        return self._frameworks[key]
+
+    def _resolve_path(self, value: str | os.PathLike[str]) -> Path:
+        path = Path(value)
+        if not path.is_absolute():
+            path = Path(self.repo_context.repo_root) / path
+        return path
+
+    def _relative_to_repo(self, value: Path) -> Path:
+        try:
+            return value.relative_to(self.repo_context.repo_root)
+        except ValueError:
+            return value
+
+    def _collect_migrations(self, path: Path) -> list[MigrationRecord]:
+        records: list[MigrationRecord] = []
+        if not path.exists():
+            return records
+        for entry in sorted(path.iterdir()):
+            if entry.is_file():
+                stat = entry.stat()
+                relative = self._relative_to_repo(entry)
+                records.append(
+                    MigrationRecord(
+                        path=str(relative),
+                        name=entry.name,
+                        order_key=self._build_order_key(entry.name),
+                        created=stat.st_mtime,
+                    )
+                )
+        records.sort(key=lambda item: (item.order_key, item.created, item.name))
+        return records
+
+    @staticmethod
+    def _build_order_key(name: str) -> str:
+        prefix = name.split("_", 1)[0]
+        return prefix.zfill(4)
+
+    @staticmethod
+    def _coerce_command(command: Any) -> tuple[str, ...] | None:
+        if command is None:
+            return None
+        if isinstance(command, (list, tuple)):
+            return tuple(str(part) for part in command)
+        if isinstance(command, str):
+            return (command,)
+        raise TypeError("Command must be a sequence or string")
+
+    @staticmethod
+    def _merge_env(base: Mapping[str, str], extra: Mapping[str, str]) -> dict[str, str]:
+        payload = dict(base)
+        payload.update({str(k): str(v) for k, v in extra.items()})
+        return payload
+
+    def _render_command(
+        self,
+        template: tuple[str, ...],
+        migration_name: str,
+        extra_args: Sequence[str] | None,
+    ) -> Sequence[str] | str:
+        if len(template) == 1:
+            command = template[0].format(name=migration_name)
+            if extra_args:
+                command = " ".join([command, *map(str, extra_args)])
+            return command
+        rendered = [part.format(name=migration_name) for part in template]
+        if extra_args:
+            rendered.extend(str(arg) for arg in extra_args)
+        return rendered
+
+    def _resolve_ephemeral(
+        self, value: str | EphemeralDatabaseSpec | None
+    ) -> EphemeralDatabaseSpec | None:
+        if value is None:
+            return None
+        if isinstance(value, EphemeralDatabaseSpec):
+            return value
+        spec = self._ephemeral_specs.get(value)
+        if spec is None:
+            raise KeyError(f"Unknown ephemeral database spec '{value}'")
+        return spec

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -11,6 +11,7 @@ from internal.structures import StructuredResponse
 from session import AgentRound, AgentSession
 
 from .dependency import DependencyBuildAgent
+from .db_migration import DBMigrationAgent
 from .repo_context import (
     DiffBundle,
     RepoContextAgent,
@@ -147,6 +148,7 @@ class ManagerAgent:
         research_agent: "ResearchAgent" | None = None,
         external_browsing_default: bool = False,
         dependency_agent: DependencyBuildAgent | None = None,
+        db_migration_agent: DBMigrationAgent | None = None,
     ) -> None:
         if session is None:
             if session_factory is None:
@@ -176,6 +178,7 @@ class ManagerAgent:
         self._external_browsing_enabled = self._external_browsing_default
         self._shared_evidence: dict[str, list["ResearchSnippet"]] = {}
         self._dependency_agent: DependencyBuildAgent | None = dependency_agent
+        self._db_migration_agent: DBMigrationAgent | None = db_migration_agent
         if test_critic is not None:
             self.attach_test_critic(test_critic)
 
@@ -571,6 +574,9 @@ class ManagerAgent:
         if task_kind == "dependency":
             metadata.pop("kind", None)
             return self._run_dependency_task(name, task, metadata, budget=budget)
+        if task_kind == "db_migration":
+            metadata.pop("kind", None)
+            return self._run_db_migration_task(name, task, metadata, budget=budget)
 
         research_spec = task.get("research")
         audience_hint = None
@@ -708,6 +714,120 @@ class ManagerAgent:
         self._last_structured = structured
         return summary_text, structured
 
+    def _run_db_migration_task(
+        self,
+        name: str,
+        task: Mapping[str, Any],
+        metadata: MutableMapping[str, Any],
+        *,
+        budget: TaskBudget | None,
+    ) -> tuple[str, StructuredResponse | None]:
+        try:
+            agent = self._ensure_db_migration_agent()
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        spec: dict[str, Any] = {}
+        migration_spec = task.get("db_migration") or task.get("migration")
+        if isinstance(migration_spec, Mapping):
+            spec.update(migration_spec)
+        for key in (
+            "framework",
+            "migrations_dir",
+            "workdir",
+            "env",
+            "apply",
+            "migration_name",
+            "extra_args",
+            "ephemeral",
+            "ephemeral_db",
+        ):
+            if key in task and key not in spec:
+                spec[key] = task[key]
+            if key in metadata and key not in spec:
+                spec[key] = metadata[key]
+
+        framework_value = spec.get("framework")
+        if framework_value is None:
+            return self._handle_task_failure(
+                name,
+                ValueError("DB migration task missing 'framework' value"),
+            )
+
+        try:
+            env_payload = spec.get("env") if isinstance(spec.get("env"), Mapping) else None
+            plan = agent.plan_migration(
+                str(framework_value),
+                migrations_dir=spec.get("migrations_dir"),
+                workdir=spec.get("workdir"),
+                env=env_payload,
+            )
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        self._publish_status(
+            f"Prepared migration plan for framework '{plan.framework}'",
+            kind="db_migration_plan",
+            task=name,
+            payload={"plan": plan.to_dict()},
+        )
+
+        migration_name = spec.get("migration_name") or name
+        apply_flag = bool(spec.get("apply", False))
+        extra_args = spec.get("extra_args")
+        if isinstance(extra_args, (str, bytes)):
+            extra_args = [extra_args]
+        elif extra_args is not None and not isinstance(extra_args, Sequence):
+            extra_args = [extra_args]
+        if extra_args is not None:
+            extra_args = [str(arg) for arg in extra_args]
+        ephemeral_key = spec.get("ephemeral") or spec.get("ephemeral_db")
+
+        try:
+            result = agent.run_migration(
+                plan,
+                migration_name=str(migration_name),
+                apply=apply_flag,
+                extra_args=extra_args,
+                ephemeral=ephemeral_key,
+            )
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        if budget is not None:
+            budget.consume()
+
+        payload = result.to_dict()
+        self._publish_status(
+            f"Database migration '{name}' completed",
+            kind="db_migration_result",
+            task=name,
+            payload=payload,
+        )
+
+        summary_text = agent.format_result(result)
+        structured = StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": summary_text,
+                            "parsed": payload,
+                        }
+                    }
+                ]
+            },
+            content=summary_text,
+            parsed=payload,
+            schema={"name": "MigrationResult"},
+            structured=True,
+        )
+        self._mark_task_complete(name)
+        self._last_response_text = summary_text
+        self._last_structured = structured
+        return summary_text, structured
+
     def _handle_task_failure(
         self,
         task_name: str,
@@ -821,3 +941,10 @@ class ManagerAgent:
         if self._dependency_agent is None:
             self._dependency_agent = DependencyBuildAgent()
         return self._dependency_agent
+
+    def _ensure_db_migration_agent(self) -> DBMigrationAgent:
+        if self._db_migration_agent is None:
+            if self.repo_context is None:
+                raise RuntimeError("DB migration tasks require a RepoContextAgent")
+            self._db_migration_agent = DBMigrationAgent(repo_context=self.repo_context)
+        return self._db_migration_agent

--- a/tests/test_db_migration_agent.py
+++ b/tests/test_db_migration_agent.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+from typing import Any, Mapping
+
+import pytest
+
+# Seed a lightweight lmstudio stub before importing the agent package.
+_lmstudio_stub = types.ModuleType("lmstudio")
+
+
+class _StubChat:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - bootstrap only
+        self.messages: list[Any] = []
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":  # pragma: no cover - bootstrap only
+        chat = cls()
+        if isinstance(history, list):
+            chat.messages = list(history)
+        return chat
+
+
+class _StubToolDef:
+    def __init__(
+        self,
+        name: str,
+        description: str = "",
+        parameters: Mapping[str, Any] | None = None,
+        implementation: Any | None = None,
+    ) -> None:  # pragma: no cover - bootstrap only
+        self.name = name
+        self.description = description
+        self.parameters = parameters or {}
+        self.implementation = implementation
+
+
+def _stub_llm(*_: Any, **__: Any) -> None:  # pragma: no cover - bootstrap only
+    raise RuntimeError("lmstudio stub should be overridden by fixtures")
+
+
+_lmstudio_stub.Chat = _StubChat
+_lmstudio_stub.ToolFunctionDef = _StubToolDef
+_lmstudio_stub.llm = _stub_llm
+sys.modules.setdefault("lmstudio", _lmstudio_stub)
+
+_psutil_stub = types.ModuleType("psutil")
+
+
+class _StubProcess:
+    def __init__(self, *_: Any, **__: Any) -> None:  # pragma: no cover - bootstrap only
+        self.pid = 0
+
+    def kill(self) -> None:  # pragma: no cover - bootstrap only
+        raise RuntimeError("psutil stub")
+
+    def terminate(self) -> None:  # pragma: no cover - bootstrap only
+        raise RuntimeError("psutil stub")
+
+    def wait(self, timeout: float | None = None) -> int:  # pragma: no cover - bootstrap only
+        raise RuntimeError("psutil stub")
+
+    def as_dict(self, attrs: list[str] | None = None) -> dict[str, Any]:  # pragma: no cover - bootstrap only
+        return {}
+
+    def is_running(self) -> bool:  # pragma: no cover - bootstrap only
+        return False
+
+    def children(self, recursive: bool = False) -> list["_StubProcess"]:  # pragma: no cover - bootstrap only
+        return []
+
+
+class _PsutilNoSuchProcess(RuntimeError):  # pragma: no cover - bootstrap only
+    pass
+
+
+class _PsutilTimeout(RuntimeError):  # pragma: no cover - bootstrap only
+    pass
+
+
+def _process_iter(*_: Any, **__: Any):  # pragma: no cover - bootstrap only
+    return []
+
+
+_psutil_stub.Process = _StubProcess
+_psutil_stub.NoSuchProcess = _PsutilNoSuchProcess
+_psutil_stub.TimeoutExpired = _PsutilTimeout
+_psutil_stub.process_iter = _process_iter
+sys.modules.setdefault("psutil", _psutil_stub)
+
+from agents.db_migration import DBMigrationAgent, EphemeralDatabaseSpec
+from agents.manager import ManagerAgent, TaskBudget
+from agents.repo_context import RepoContextAgent
+from agents.runner import RunnerAgent
+
+
+class SessionStub:
+    def __init__(self) -> None:
+        self.rounds = []
+
+    def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:  # noqa: D401 - test stub
+        self._on_round_start = on_round_start
+        self._on_round_end = on_round_end
+
+
+@pytest.fixture()
+def dummy_framework() -> Mapping[str, Any]:
+    generate_script = (
+        "import pathlib, sys; "
+        "root = pathlib.Path('migrations'); "
+        "root.mkdir(exist_ok=True); "
+        "(root / (sys.argv[1] + '.sql')).write_text('generated')"
+    )
+    apply_script = (
+        "import pathlib, sys; "
+        "pathlib.Path('applied.log').write_text(sys.argv[1])"
+    )
+    return {
+        "migrations_dir": "migrations",
+        "generate": ("python", "-c", generate_script, "{name}"),
+        "apply": ("python", "-c", apply_script, "{name}"),
+    }
+
+
+@pytest.fixture()
+def repo_context(tmp_path: Path) -> RepoContextAgent:
+    rc = RepoContextAgent(str(tmp_path), auto_refresh=False)
+    yield rc
+    rc.stop_background_refresh()
+
+
+def build_agent(repo_context: RepoContextAgent, framework: Mapping[str, Any]) -> DBMigrationAgent:
+    runner = RunnerAgent(repo_root=repo_context.repo_root)
+    return DBMigrationAgent(repo_context, runner=runner, frameworks={"dummy": framework})
+
+
+def test_plan_discovers_existing_migrations(repo_context: RepoContextAgent, dummy_framework: Mapping[str, Any]) -> None:
+    migrations = Path(repo_context.repo_root) / "migrations"
+    migrations.mkdir(parents=True, exist_ok=True)
+    (migrations / "001_initial.sql").write_text("create table")
+    (migrations / "010_second.sql").write_text("alter table")
+
+    agent = build_agent(repo_context, dummy_framework)
+    plan = agent.plan_migration("dummy")
+
+    assert plan.framework == "dummy"
+    assert [record.name for record in plan.existing] == [
+        "001_initial.sql",
+        "010_second.sql",
+    ]
+    assert plan.command_template[0] == "python"
+
+
+def test_run_migration_generates_and_applies(repo_context: RepoContextAgent, dummy_framework: Mapping[str, Any]) -> None:
+    migrations = Path(repo_context.repo_root) / "migrations"
+    migrations.mkdir(parents=True, exist_ok=True)
+    (migrations / "000_base.sql").write_text("baseline")
+
+    agent = build_agent(repo_context, dummy_framework)
+    plan = agent.plan_migration("dummy")
+    result = agent.run_migration(plan, migration_name="feature", apply=True)
+
+    assert (migrations / "feature.sql").exists()
+    assert result.generated == ("migrations/feature.sql",)
+    assert result.applied is True
+    assert Path(repo_context.repo_root, "applied.log").read_text() == "feature"
+    summary = agent.format_result(result)
+    assert "feature.sql" in summary
+
+
+def test_ephemeral_cleanup_on_failure(repo_context: RepoContextAgent) -> None:
+    failing_framework = {
+        "migrations_dir": "migrations",
+        "generate": ("python", "-c", "import sys; sys.exit(1)"),
+    }
+    agent = build_agent(repo_context, failing_framework)
+    agent.register_ephemeral_database(
+        EphemeralDatabaseSpec(
+            name="compose",
+            setup=(
+                "python",
+                "-c",
+                "import pathlib; pathlib.Path('db.lock').write_text('lock')",
+            ),
+            teardown=(
+                "python",
+                "-c",
+                "import pathlib; path = pathlib.Path('db.lock'); "
+                "path.exists() and path.unlink()",
+            ),
+        )
+    )
+    plan = agent.plan_migration("dummy")
+
+    with pytest.raises(RuntimeError):
+        agent.run_migration(plan, migration_name="broken", ephemeral="compose")
+
+    assert not Path(repo_context.repo_root, "db.lock").exists()
+
+
+def test_manager_db_migration_dispatch(repo_context: RepoContextAgent, dummy_framework: Mapping[str, Any]) -> None:
+    agent = build_agent(repo_context, dummy_framework)
+    budget = TaskBudget(name="migration", limit=2)
+    captured = []
+    manager = ManagerAgent(
+        session=SessionStub(),
+        status_callback=captured.append,
+        repo_context=repo_context,
+        db_migration_agent=agent,
+    )
+
+    task = {"framework": "dummy", "apply": True, "migration_name": "manager"}
+    summary, structured = manager._run_db_migration_task("migration", task, {}, budget=budget)
+
+    assert "manager.sql" in summary
+    assert structured is not None
+    assert budget.consumed == pytest.approx(1.0)
+    assert any(update.kind == "db_migration_plan" for update in captured)
+    assert any(update.kind == "db_migration_result" for update in captured)
+    assert Path(repo_context.repo_root, "migrations", "manager.sql").exists()


### PR DESCRIPTION
## Summary
- introduce a database migration agent with schema planning, execution, and ephemeral runtime hooks
- expose the new agent via the package exports and integrate manager dispatch for `db_migration` tasks
- cover migration planning, execution, cleanup, and manager wiring with dedicated unit tests

## Testing
- pytest tests/test_db_migration_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68e5f0c63550832f83422579942a9e97