### PR TITLE
Add security scanning agent and integrate with manager

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -70,6 +70,14 @@ from .runner import (
     RunReport,
     RunnerAgent,
 )
+from .security import (
+    SecurityAgent,
+    SecurityCacheDirective,
+    SecurityScanFinding,
+    SecurityScanReport,
+    SecurityScanResult,
+    SecurityToolchain,
+)
 from .research import (
     ResearchAgent,
     ResearchResult,
@@ -155,6 +163,17 @@ __all__.extend(
         "ResearchAgent",
         "ResearchResult",
         "ResearchSnippet",
+    ]
+)
+
+__all__.extend(
+    [
+        "SecurityAgent",
+        "SecurityCacheDirective",
+        "SecurityScanFinding",
+        "SecurityScanReport",
+        "SecurityScanResult",
+        "SecurityToolchain",
     ]
 )
 

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -19,6 +19,7 @@ from .repo_context import (
     RepoSearchResult,
     RepoSymbolResult,
 )
+from .security import SecurityAgent, SecurityScanResult
 
 if TYPE_CHECKING:
     from .research import ResearchAgent, ResearchResult, ResearchSnippet
@@ -154,6 +155,7 @@ class ManagerAgent:
         dependency_agent: DependencyBuildAgent | None = None,
         db_migration_agent: DBMigrationAgent | None = None,
         eval_agent: EvalAgent | None = None,
+        security_agent: SecurityAgent | None = None,
     ) -> None:
         if session is None:
             if session_factory is None:
@@ -185,6 +187,9 @@ class ManagerAgent:
         self._dependency_agent: DependencyBuildAgent | None = dependency_agent
         self._db_migration_agent: DBMigrationAgent | None = db_migration_agent
         self.eval_agent: EvalAgent | None = None
+        self._security_agent: SecurityAgent | None = security_agent
+        self._security_report: SecurityScanResult | None = None
+        self._gate_source: str | None = None
         self._last_eval_summary: RegressionSummary | None = None
         self._completed_evaluations: list[RegressionSummary] = []
         if test_critic is not None:
@@ -230,15 +235,19 @@ class ManagerAgent:
         dag.run(targets=["execute"])
 
         if self._gate_blocked:
-            response_text = self._last_response_text or "Test critic blocked completion due to failing suites."
-            structured_response = None
-            payload = self._gate_report.to_status_payload() if self._gate_report else None
-            summary_payload = {"critic": payload} if payload is not None else None
-            self._publish_status(
-                "Workflow blocked by critic failures",
-                kind="error",
-                payload=summary_payload,
-            )
+            response_text = self._last_response_text or "Workflow blocked by a gating task."
+            structured_response = self._last_structured
+            payload: Mapping[str, Any] | None = None
+            message = "Workflow blocked"
+            if self._gate_source == "critic" and self._gate_report is not None:
+                critic_payload = self._gate_report.to_status_payload()
+                payload = {"critic": critic_payload}
+                message = "Workflow blocked by critic failures"
+                structured_response = None
+            elif self._gate_source == "security" and self._security_report is not None:
+                payload = {"security": self._security_report.to_dict()}
+                message = "Workflow blocked by security findings"
+            self._publish_status(message, kind="error", payload=payload)
         else:
             response_text = self._last_response_text
             structured_response = self._last_structured
@@ -490,8 +499,10 @@ class ManagerAgent:
         structured: StructuredResponse | None = None
         for task in tasks:
             response_text, structured = self._execute_task(task, user_message=user_message)
+            if self._gate_blocked:
+                break
 
-        if self.test_critic is not None:
+        if self.test_critic is not None and not self._gate_blocked:
             report = self.test_critic.run_and_report()
             self._gate_report = report
             if not self.test_critic.has_status_callback:
@@ -502,6 +513,7 @@ class ManagerAgent:
                 self._gate_blocked = True
                 self._last_response_text = report.build_block_message()
                 self._last_structured = None
+                self._gate_source = self._gate_source or "critic"
                 response_text = self._last_response_text
                 structured = None
                 self._publish_status(
@@ -596,6 +608,9 @@ class ManagerAgent:
         if task_kind == "eval":
             metadata.pop("kind", None)
             return self._run_eval_task(name, task, metadata, budget=budget)
+        if task_kind == "security":
+            metadata.pop("kind", None)
+            return self._run_security_task(name, task, metadata, budget=budget)
 
         research_spec = task.get("research")
         audience_hint = None
@@ -907,6 +922,113 @@ class ManagerAgent:
             self._last_structured = structured
         return text, structured
 
+    def _run_security_task(
+        self,
+        name: str,
+        task: Mapping[str, Any],
+        metadata: MutableMapping[str, Any],
+        *,
+        budget: TaskBudget | None,
+    ) -> tuple[str, StructuredResponse | None]:
+        try:
+            agent = self._ensure_security_agent()
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        spec: dict[str, Any] = {}
+        security_spec = task.get("security")
+        if isinstance(security_spec, Mapping):
+            spec.update(security_spec)
+        for key in (
+            "toolchains",
+            "severity_threshold",
+            "threshold",
+            "stop_on_failure",
+            "workdir",
+            "env",
+        ):
+            if key in task and key not in spec:
+                spec[key] = task[key]
+            if key in metadata and key not in spec:
+                spec[key] = metadata[key]
+
+        sequence_value = spec.get("toolchains")
+        if isinstance(sequence_value, (str, bytes)):
+            requested_sequence = [str(sequence_value)]
+        elif isinstance(sequence_value, Sequence):
+            requested_sequence = [str(item) for item in sequence_value]
+        else:
+            requested_sequence = None
+
+        severity_threshold = spec.get("severity_threshold") or spec.get("threshold")
+        stop_on_failure = bool(spec.get("stop_on_failure", True))
+        workdir_value = spec.get("workdir")
+        env_value = spec.get("env")
+        env_spec = env_value if isinstance(env_value, Mapping) else None
+
+        start_payload: dict[str, Any] = {
+            "toolchains": list(requested_sequence or agent.DEFAULT_SEQUENCE),
+            "severity_threshold": severity_threshold,
+            "stop_on_failure": stop_on_failure,
+        }
+        self._publish_status(
+            f"Running security scans for '{name}'",
+            kind="security_start",
+            task=name,
+            payload=start_payload,
+        )
+
+        try:
+            result = agent.run_scans(
+                toolchains=requested_sequence,
+                severity_threshold=severity_threshold,
+                stop_on_failure=stop_on_failure,
+                workdir=workdir_value,
+                env=env_spec,
+            )
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        summary_text = result.summary or agent.format_result(result)
+        structured_payload = result.to_dict()
+        structured = StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": summary_text,
+                            "parsed": structured_payload,
+                        }
+                    }
+                ]
+            },
+            content=summary_text,
+            parsed=structured_payload,
+            schema={"name": "SecurityScanResult"},
+            structured=True,
+        )
+
+        if budget is not None:
+            budget.consume()
+
+        self._security_report = result
+        status_kind = "security_blocked" if result.blocked else "security_summary"
+        message = (
+            f"Security scans for '{name}' blocked the workflow"
+            if result.blocked
+            else f"Security scans for '{name}' completed"
+        )
+        self._publish_status(message, kind=status_kind, task=name, payload=structured_payload)
+
+        self._last_response_text = summary_text
+        self._last_structured = structured
+        if result.blocked:
+            self._gate_blocked = True
+            self._gate_source = "security"
+        self._mark_task_complete(name)
+        return summary_text, structured
+
     def _handle_task_failure(
         self,
         task_name: str,
@@ -999,7 +1121,9 @@ class ManagerAgent:
         self._current_task = None
         self._current_round_task = None
         self._gate_report = None
+        self._security_report = None
         self._gate_blocked = False
+        self._gate_source = None
         self._external_browsing_enabled = self._external_browsing_default
         self._shared_evidence.clear()
         self._last_eval_summary = None
@@ -1034,3 +1158,8 @@ class ManagerAgent:
         if self.eval_agent is None:
             raise RuntimeError("Evaluation tasks require an EvalAgent to be attached")
         return self.eval_agent
+
+    def _ensure_security_agent(self) -> SecurityAgent:
+        if self._security_agent is None:
+            self._security_agent = SecurityAgent()
+        return self._security_agent

--- a/agents/security.py
+++ b/agents/security.py
@@ -1,0 +1,543 @@
+"""Security scanning orchestration utilities."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+from .runner import RunReport, RunnerAgent
+
+__all__ = [
+    "SecurityCacheDirective",
+    "SecurityScanFinding",
+    "SecurityScanReport",
+    "SecurityScanResult",
+    "SecurityToolchain",
+    "SecurityAgent",
+]
+
+_SEVERITY_ORDER = {
+    "critical": 5,
+    "high": 4,
+    "medium": 3,
+    "moderate": 3,
+    "low": 2,
+    "info": 1,
+    "informational": 1,
+    "none": 0,
+    "unknown": 0,
+}
+
+
+def _normalize_severity(value: Any) -> str:
+    if value is None:
+        return "info"
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric >= 4:
+            return "critical"
+        if numeric >= 3:
+            return "high"
+        if numeric >= 2:
+            return "medium"
+        if numeric >= 1:
+            return "low"
+        return "info"
+    text = str(value).strip().lower()
+    if not text:
+        return "info"
+    if text in _SEVERITY_ORDER:
+        if text == "informational":
+            return "info"
+        if text == "moderate":
+            return "medium"
+        return text
+    return text
+
+
+@dataclass(slots=True)
+class SecurityCacheDirective:
+    """Hint describing cache paths that should be persisted between scans."""
+
+    tool: str
+    paths: tuple[str, ...]
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "paths": list(self.paths),
+            "description": self.description,
+        }
+
+    @property
+    def hint(self) -> str:
+        if not self.paths:
+            return self.description or ""
+        joined = ", ".join(self.paths)
+        if self.description:
+            return f"{self.description}: {joined}"
+        return joined
+
+
+@dataclass(slots=True)
+class SecurityScanFinding:
+    """Individual issue discovered by a security scan."""
+
+    tool: str
+    message: str
+    severity: str
+    category: str | None = None
+    location: str | None = None
+    rule_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def normalized_severity(self) -> str:
+        return _normalize_severity(self.severity)
+
+    @property
+    def severity_rank(self) -> int:
+        return _SEVERITY_ORDER.get(self.normalized_severity, 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "tool": self.tool,
+            "message": self.message,
+            "severity": self.normalized_severity,
+        }
+        if self.category is not None:
+            payload["category"] = self.category
+        if self.location is not None:
+            payload["location"] = self.location
+        if self.rule_id is not None:
+            payload["rule_id"] = self.rule_id
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    def describe(self) -> str:
+        severity = self.normalized_severity.upper()
+        location = f" ({self.location})" if self.location else ""
+        rule = f" [{self.rule_id}]" if self.rule_id else ""
+        return f"{severity}{rule}{location}: {self.message}"
+
+
+@dataclass(slots=True)
+class SecurityScanReport:
+    """Structured representation of a single toolchain run."""
+
+    toolchain: str
+    category: str
+    command: tuple[str, ...]
+    report: RunReport
+    findings: tuple[SecurityScanFinding, ...] = ()
+    cache_directive: SecurityCacheDirective | None = None
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.report.ok)
+
+    @property
+    def artifacts(self) -> tuple[str, ...]:
+        return tuple(self.report.artifacts or ())
+
+    @property
+    def highest_severity(self) -> str | None:
+        if not self.findings:
+            return None
+        return max(self.findings, key=lambda finding: finding.severity_rank).normalized_severity
+
+    @property
+    def severity_counts(self) -> Mapping[str, int]:
+        counter: Counter[str] = Counter(
+            finding.normalized_severity for finding in self.findings
+        )
+        return dict(counter)
+
+    def describe(self, *, limit: int = 3) -> str:
+        title = f"{self.toolchain} ({self.category})"
+        if not self.findings:
+            return f"{title}: no findings"
+        counts = ", ".join(
+            f"{severity.upper()}×{count}" for severity, count in sorted(self.severity_counts.items())
+        )
+        lines = [f"{title}: {len(self.findings)} findings ({counts})"]
+        for finding in self.findings[:limit]:
+            lines.append(f" - {finding.describe()}")
+        if len(self.findings) > limit:
+            lines.append(f" - … {len(self.findings) - limit} more findings")
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "toolchain": self.toolchain,
+            "category": self.category,
+            "command": list(self.command),
+            "status": self.report.status,
+            "ok": self.ok,
+            "exit_code": self.report.exit_code,
+            "highest_severity": self.highest_severity,
+            "severity_counts": dict(self.severity_counts),
+            "findings": [finding.to_dict() for finding in self.findings],
+            "artifacts": list(self.artifacts),
+        }
+        if self.cache_directive is not None:
+            payload["cache_directive"] = self.cache_directive.to_dict()
+        return payload
+
+
+@dataclass(slots=True)
+class SecurityScanResult:
+    """Aggregate outcome for a set of security scans."""
+
+    reports: tuple[SecurityScanReport, ...]
+    threshold: str | None = None
+    blocked: bool = False
+    summary: str | None = None
+
+    @property
+    def highest_severity(self) -> str | None:
+        best: SecurityScanFinding | None = None
+        for report in self.reports:
+            if not report.findings:
+                continue
+            candidate = max(report.findings, key=lambda finding: finding.severity_rank)
+            if best is None or candidate.severity_rank > best.severity_rank:
+                best = candidate
+        return best.normalized_severity if best is not None else None
+
+    @property
+    def artifacts(self) -> tuple[str, ...]:
+        collected: list[str] = []
+        for report in self.reports:
+            for path in report.artifacts:
+                if path not in collected:
+                    collected.append(path)
+        return tuple(collected)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reports": [report.to_dict() for report in self.reports],
+            "threshold": self.threshold,
+            "blocked": self.blocked,
+            "highest_severity": self.highest_severity,
+            "summary": self.summary,
+            "artifacts": list(self.artifacts),
+        }
+
+
+@dataclass(slots=True)
+class SecurityToolchain:
+    """Configuration describing how to invoke and parse a scan tool."""
+
+    name: str
+    category: str
+    command: tuple[str, ...]
+    parser: Callable[[RunReport], Iterable[SecurityScanFinding]] | None = None
+    workdir: str | os.PathLike[str] | None = None
+    env: Mapping[str, str] = field(default_factory=dict)
+    artifacts: tuple[str, ...] = ()
+    cache_paths: tuple[str, ...] = ()
+    cache_description: str | None = None
+
+    def with_overrides(self, **overrides: Any) -> "SecurityToolchain":
+        payload: MutableMapping[str, Any] = {
+            "name": self.name,
+            "category": self.category,
+            "command": self.command,
+            "parser": self.parser,
+            "workdir": self.workdir,
+            "env": dict(self.env),
+            "artifacts": self.artifacts,
+            "cache_paths": self.cache_paths,
+            "cache_description": self.cache_description,
+        }
+        payload.update(overrides)
+        return SecurityToolchain(**payload)
+
+
+class SecurityAgent:
+    """Coordinate multiple security scanning toolchains via :class:`RunnerAgent`."""
+
+    DEFAULT_SEQUENCE: tuple[str, ...] = ("dependencies", "static", "secrets", "sbom")
+
+    def __init__(
+        self,
+        *,
+        runner: RunnerAgent | None = None,
+        toolchains: Mapping[str, SecurityToolchain | Mapping[str, Any]] | None = None,
+    ) -> None:
+        self.runner = runner or RunnerAgent()
+        self._toolchains: dict[str, SecurityToolchain] = self._build_default_toolchains()
+        if toolchains:
+            for name, spec in toolchains.items():
+                self.configure_toolchain(name, spec)
+
+    # ------------------------------------------------------------------
+    # Configuration helpers
+    # ------------------------------------------------------------------
+    def configure_toolchain(
+        self,
+        name: str,
+        spec: SecurityToolchain | Mapping[str, Any],
+    ) -> None:
+        if isinstance(spec, SecurityToolchain):
+            toolchain = spec
+        else:
+            payload = dict(spec)
+            payload.setdefault("name", name)
+            payload.setdefault("category", name)
+            command = payload.get("command")
+            if not command:
+                raise ValueError(f"Security toolchain '{name}' missing command configuration")
+            if isinstance(command, (str, bytes)):
+                payload["command"] = tuple(str(command).split())
+            elif isinstance(command, Sequence):
+                payload["command"] = tuple(str(part) for part in command)
+            else:
+                raise TypeError("Command must be a string or sequence of strings")
+            parser = payload.get("parser")
+            if parser is not None and not callable(parser):
+                raise TypeError("Toolchain parser must be callable")
+            env = payload.get("env")
+            if env is not None and not isinstance(env, Mapping):
+                raise TypeError("Toolchain env must be a mapping")
+            cache_paths = payload.get("cache_paths")
+            if isinstance(cache_paths, (str, bytes, os.PathLike)):
+                payload["cache_paths"] = (str(cache_paths),)
+            elif cache_paths is not None:
+                payload["cache_paths"] = tuple(str(path) for path in cache_paths)
+            artifacts = payload.get("artifacts")
+            if isinstance(artifacts, (str, bytes, os.PathLike)):
+                payload["artifacts"] = (str(artifacts),)
+            elif artifacts is not None:
+                payload["artifacts"] = tuple(str(path) for path in artifacts)
+            toolchain = SecurityToolchain(**payload)
+        self._toolchains[name] = toolchain
+
+    def get_toolchain(self, name: str) -> SecurityToolchain:
+        try:
+            return self._toolchains[name]
+        except KeyError as exc:  # pragma: no cover - defensive programming
+            raise KeyError(f"Security toolchain '{name}' is not configured") from exc
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+    def run_scans(
+        self,
+        *,
+        toolchains: Sequence[str] | None = None,
+        severity_threshold: str | None = "high",
+        stop_on_failure: bool = True,
+        workdir: str | os.PathLike[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> SecurityScanResult:
+        sequence = list(toolchains) if toolchains else list(self.DEFAULT_SEQUENCE)
+        reports: list[SecurityScanReport] = []
+        blocked = False
+        normalized_threshold = _normalize_severity(severity_threshold) if severity_threshold else None
+        threshold_rank = (
+            _SEVERITY_ORDER.get(normalized_threshold, 0)
+            if normalized_threshold is not None
+            else None
+        )
+
+        for name in sequence:
+            if name not in self._toolchains:
+                continue
+            toolchain = self._toolchains[name]
+            report = self._run_toolchain(toolchain, workdir=workdir, env=env)
+            reports.append(report)
+            highest = report.highest_severity
+            if highest is None or threshold_rank is None:
+                continue
+            if _SEVERITY_ORDER.get(highest, 0) >= threshold_rank:
+                blocked = True
+                if stop_on_failure:
+                    break
+
+        summary = self._build_summary(reports, normalized_threshold, blocked)
+        result = SecurityScanResult(
+            reports=tuple(reports),
+            threshold=normalized_threshold,
+            blocked=blocked,
+            summary=summary,
+        )
+        return result
+
+    def format_result(self, result: SecurityScanResult) -> str:
+        return result.summary or self._build_summary(list(result.reports), result.threshold, result.blocked)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _run_toolchain(
+        self,
+        toolchain: SecurityToolchain,
+        *,
+        workdir: str | os.PathLike[str] | None,
+        env: Mapping[str, str] | None,
+    ) -> SecurityScanReport:
+        effective_workdir = Path(workdir or toolchain.workdir or self.runner.default_workdir)
+        if toolchain.workdir is not None and workdir is not None:
+            effective_workdir = Path(workdir)
+        env_payload: dict[str, str] = {}
+        if isinstance(toolchain.env, Mapping):
+            env_payload.update({str(key): str(value) for key, value in toolchain.env.items()})
+        if env:
+            env_payload.update({str(key): str(value) for key, value in env.items()})
+        report = self.runner.run_shell(
+            toolchain.command,
+            workdir=str(effective_workdir),
+            env=env_payload,
+            artifacts=toolchain.artifacts,
+            metadata={
+                "toolchain": toolchain.name,
+                "category": toolchain.category,
+            },
+        )
+        findings = tuple(self._parse_findings(report, toolchain=toolchain))
+        cache_directive = None
+        if toolchain.cache_paths:
+            cache_directive = SecurityCacheDirective(
+                tool=toolchain.name,
+                paths=tuple(str(Path(path)) for path in toolchain.cache_paths),
+                description=toolchain.cache_description,
+            )
+        return SecurityScanReport(
+            toolchain=toolchain.name,
+            category=toolchain.category,
+            command=toolchain.command,
+            report=report,
+            findings=findings,
+            cache_directive=cache_directive,
+        )
+
+    def _parse_findings(
+        self,
+        report: RunReport,
+        *,
+        toolchain: SecurityToolchain,
+    ) -> Iterable[SecurityScanFinding]:
+        parser = toolchain.parser or self._default_parser
+        parsed = parser(report)
+        if parsed is None:
+            return ()
+        if isinstance(parsed, SecurityScanFinding):
+            return (parsed,)
+        if not isinstance(parsed, Iterable):  # pragma: no cover - defensive guard
+            raise TypeError("Security toolchain parser must return an iterable of findings")
+        return tuple(parsed)
+
+    @staticmethod
+    def _default_parser(report: RunReport) -> Iterable[SecurityScanFinding]:
+        sources: list[Mapping[str, Any]] = []
+        if isinstance(report.metadata, Mapping):
+            sources.append(report.metadata)
+        if isinstance(report.raw, Mapping):
+            sources.append(report.raw)
+        metadata_source = report.metadata if isinstance(report.metadata, Mapping) else {}
+        collected: list[SecurityScanFinding] = []
+        for source in sources:
+            findings = source.get("findings") if isinstance(source, Mapping) else None
+            if not findings:
+                continue
+            for item in findings:
+                if not isinstance(item, Mapping):
+                    continue
+                tool_name = item.get("tool") or source.get("tool") or metadata_source.get("toolchain")
+                category = item.get("category") or source.get("category") or metadata_source.get("category")
+                message = item.get("message") or item.get("detail") or ""
+                finding = SecurityScanFinding(
+                    tool=str(tool_name or "unknown"),
+                    message=str(message),
+                    severity=_normalize_severity(item.get("severity")),
+                    category=str(category) if category is not None else None,
+                    location=item.get("location"),
+                    rule_id=item.get("rule") or item.get("rule_id"),
+                    metadata={
+                        key: value
+                        for key, value in item.items()
+                        if key
+                        not in {"tool", "message", "detail", "severity", "category", "location", "rule", "rule_id"}
+                    },
+                )
+                collected.append(finding)
+            if collected:
+                break
+        return collected
+
+    def _build_summary(
+        self,
+        reports: Sequence[SecurityScanReport],
+        threshold: str | None,
+        blocked: bool,
+    ) -> str:
+        if not reports:
+            return "No security toolchains executed."
+        lines: list[str] = []
+        for report in reports:
+            lines.append(report.describe())
+        highest = None
+        for report in reports:
+            if report.highest_severity is None:
+                continue
+            if highest is None or _SEVERITY_ORDER.get(report.highest_severity, 0) > _SEVERITY_ORDER.get(highest, 0):
+                highest = report.highest_severity
+        threshold_display = threshold.upper() if threshold else "NONE"
+        highest_display = highest.upper() if highest else "NONE"
+        conclusion = f"Highest severity detected: {highest_display}."
+        if threshold:
+            conclusion += f" Threshold for blocking: {threshold_display}."
+        if blocked:
+            conclusion += " Blocking workflow.";
+        lines.append(conclusion)
+        return "\n".join(lines)
+
+    def _build_default_toolchains(self) -> dict[str, SecurityToolchain]:
+        toolchains: dict[str, SecurityToolchain] = {}
+        toolchains["dependencies"] = SecurityToolchain(
+            name="dependencies",
+            category="dependency_scan",
+            command=(
+                "trivy",
+                "fs",
+                "--security-checks",
+                "vuln",
+                "--format",
+                "json",
+                ".",
+            ),
+            cache_paths=("~/.cache/trivy",),
+            cache_description="Trivy vulnerability database",
+        )
+        toolchains["static"] = SecurityToolchain(
+            name="static",
+            category="static_analysis",
+            command=("semgrep", "--config", "auto", "--json"),
+        )
+        toolchains["secrets"] = SecurityToolchain(
+            name="secrets",
+            category="secret_scanning",
+            command=("gitleaks", "detect", "--report-format", "json", "--no-git"),
+        )
+        toolchains["sbom"] = SecurityToolchain(
+            name="sbom",
+            category="sbom_export",
+            command=(
+                "trivy",
+                "sbom",
+                "--format",
+                "cyclonedx",
+                "--output",
+                "sbom.json",
+                ".",
+            ),
+            artifacts=("sbom.json",),
+        )
+        return toolchains

--- a/tests/test_security_agent.py
+++ b/tests/test_security_agent.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import sys
+import types
+import importlib.util
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+lmstudio_stub = types.ModuleType("lmstudio")
+
+
+class _ToolFunctionDef:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.name = kwargs.get("name")
+        self.description = kwargs.get("description")
+        self.parameters = kwargs.get("parameters")
+        self.required = kwargs.get("required")
+        self.handler = kwargs.get("handler")
+
+
+lmstudio_stub.ToolFunctionDef = _ToolFunctionDef
+
+
+class _Chat:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+lmstudio_stub.Chat = _Chat
+sys.modules.setdefault("lmstudio", lmstudio_stub)
+
+psutil_stub = types.ModuleType("psutil")
+
+class _PsProcess:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+    def kill(self) -> None:
+        return None
+
+    def terminate(self) -> None:
+        return None
+
+    def wait(self, timeout: Any | None = None) -> int:
+        return 0
+
+    def children(self, recursive: bool = False):
+        return []
+
+psutil_stub.Process = _PsProcess
+psutil_stub.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+psutil_stub.AccessDenied = type("AccessDenied", (Exception,), {})
+psutil_stub.TimeoutExpired = type("TimeoutExpired", (Exception,), {})
+psutil_stub.process_iter = lambda *args, **kwargs: []
+sys.modules.setdefault("psutil", psutil_stub)
+
+tooling_stub = types.ModuleType("tooling")
+
+
+@dataclass
+class ToolSpec:
+    name: str
+    description: str | None = None
+    parameters: dict[str, Any] | None = None
+
+
+class ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolSpec] = {}
+
+    def register(self, spec: ToolSpec) -> ToolSpec:
+        self._tools[spec.name] = spec
+        return spec
+
+    def get(self, name: str) -> ToolSpec | None:
+        return self._tools.get(name)
+
+
+def resolve_tools(*args: Any, **kwargs: Any) -> list[ToolSpec]:
+    return []
+
+
+tooling_stub.ToolSpec = ToolSpec
+tooling_stub.ToolRegistry = ToolRegistry
+tooling_stub.resolve_tools = resolve_tools
+sys.modules.setdefault("tooling", tooling_stub)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+agents_pkg = types.ModuleType("agents")
+agents_pkg.__path__ = [str(REPO_ROOT / "agents")]
+sys.modules["agents"] = agents_pkg
+
+def _load_agent_module(name: str, relative: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / relative)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    setattr(agents_pkg, name.split(".")[-1], module)
+    return module
+
+runner_module = _load_agent_module("agents.runner", "agents/runner.py")
+dependency_module = _load_agent_module("agents.dependency", "agents/dependency.py")
+db_module = _load_agent_module("agents.db_migration", "agents/db_migration.py")
+eval_module = _load_agent_module("agents.eval", "agents/eval.py")
+repo_module = _load_agent_module("agents.repo_context", "agents/repo_context.py")
+security_module = _load_agent_module("agents.security", "agents/security.py")
+manager_module = _load_agent_module("agents.manager", "agents/manager.py")
+
+ManagerAgent = manager_module.ManagerAgent
+ManagerStatusUpdate = manager_module.ManagerStatusUpdate
+RunReport = runner_module.RunReport
+SecurityAgent = security_module.SecurityAgent
+SecurityScanFinding = security_module.SecurityScanFinding
+SecurityScanReport = security_module.SecurityScanReport
+SecurityScanResult = security_module.SecurityScanResult
+SecurityToolchain = security_module.SecurityToolchain
+from internal.structures import StructuredResponse
+
+
+def _build_report(
+    command: Sequence[str],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+    raw: Mapping[str, Any] | None = None,
+    artifacts: Sequence[str] | None = None,
+) -> RunReport:
+    return RunReport(
+        identifier=1,
+        runner="shell",
+        command=tuple(command),
+        command_display=" ".join(command),
+        workdir=".",
+        env={},
+        status="success",
+        ok=True,
+        exit_code=0,
+        pid=100,
+        stdout="",
+        stderr="",
+        combined_output="",
+        error=None,
+        start_time=0.0,
+        end_time=0.1,
+        duration=0.1,
+        artifacts=tuple(artifacts or ()),
+        metadata=dict(metadata or {}),
+        raw=dict(raw or {}),
+    )
+
+
+class DummyRunner:
+    def __init__(self, reports: Sequence[RunReport]):
+        self._reports = list(reports)
+        self.calls: list[tuple[Sequence[str], dict[str, Any]]] = []
+        self.default_workdir = "."
+
+    def run_shell(self, command: Sequence[str], **kwargs: Any) -> RunReport:
+        if not self._reports:
+            raise AssertionError("No more reports configured for DummyRunner")
+        self.calls.append((tuple(command), dict(kwargs)))
+        return self._reports.pop(0)
+
+
+def test_security_agent_collects_findings_and_blocks_on_threshold() -> None:
+    report = _build_report(
+        ("semgrep", "--json"),
+        metadata={
+            "tool": "semgrep",
+            "category": "static_analysis",
+            "findings": [
+                {
+                    "tool": "semgrep",
+                    "severity": "HIGH",
+                    "message": "Sensitive pattern detected",
+                    "location": "app.py:10",
+                    "rule_id": "SG001",
+                },
+            ],
+        },
+    )
+    runner = DummyRunner([report])
+    agent = SecurityAgent(runner=runner)
+
+    result = agent.run_scans(toolchains=("static",), severity_threshold="medium")
+
+    assert runner.calls, "SecurityAgent should invoke the configured runner"
+    assert result.blocked is True
+    assert result.highest_severity == "high"
+    assert "HIGH" in (result.summary or "")
+    assert result.reports[0].findings[0].location == "app.py:10"
+    assert result.reports[0].command[0] == "semgrep"
+
+
+def test_security_agent_respects_cache_directives() -> None:
+    finding = SecurityScanFinding(
+        tool="custom",
+        message="Issue",
+        severity="low",
+    )
+    custom_chain = SecurityToolchain(
+        name="custom",
+        category="custom_scan",
+        command=("custom", "scan"),
+        parser=lambda report: (finding,),
+        cache_paths=("~/.cache/custom",),
+        cache_description="Custom cache",
+    )
+    runner = DummyRunner([_build_report(("custom", "scan"))])
+    agent = SecurityAgent(runner=runner, toolchains={"custom": custom_chain})
+
+    result = agent.run_scans(toolchains=("custom",), severity_threshold="critical")
+
+    report = result.reports[0]
+    assert report.cache_directive is not None
+    assert "Custom cache" in report.cache_directive.hint
+    assert result.blocked is False
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.rounds: list[Any] = []
+        self._on_round_start = None
+        self._on_round_end = None
+
+    def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:
+        self._on_round_start = on_round_start
+        self._on_round_end = on_round_end
+
+    def act(self, user_message: str | None = None, *, metadata: Mapping[str, Any] | None = None, **_: Any):
+        index = len(self.rounds)
+        round_record = StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "content": "done",
+                            "parsed": {"ok": True},
+                        }
+                    }
+                ]
+            },
+            content="done",
+            parsed={"ok": True},
+            schema=None,
+            structured=False,
+        )
+        return "done", round_record
+
+
+@dataclass
+class StubSecurityAgent:
+    result: SecurityScanResult
+    DEFAULT_SEQUENCE: tuple[str, ...] = ("stub",)
+
+    def __post_init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def run_scans(self, **kwargs: Any) -> SecurityScanResult:
+        self.calls.append(dict(kwargs))
+        return self.result
+
+    def format_result(self, result: SecurityScanResult) -> str:
+        return result.summary or ""
+
+
+def test_manager_security_task_blocks_workflow() -> None:
+    finding = SecurityScanFinding(tool="semgrep", message="Critical", severity="high")
+    run_report = _build_report(("semgrep", "--json"))
+    scan_report = SecurityScanReport(
+        toolchain="static",
+        category="static_analysis",
+        command=("semgrep", "--json"),
+        report=run_report,
+        findings=(finding,),
+    )
+    scan_result = SecurityScanResult(
+        reports=(scan_report,),
+        threshold="high",
+        blocked=True,
+        summary="Security block summary",
+    )
+    security_agent = StubSecurityAgent(result=scan_result)
+
+    def plan_builder(_: str, **__: Any) -> Sequence[Mapping[str, Any]]:
+        return [
+            {
+                "name": "security-task",
+                "kind": "security",
+                "security": {"toolchains": ["static"], "severity_threshold": "high"},
+                "budget": {"limit": 1.0, "unit": "rounds"},
+            }
+        ]
+
+    session = DummySession()
+    captured: list[ManagerStatusUpdate] = []
+    manager = ManagerAgent(
+        session=session,
+        plan_builder=plan_builder,
+        security_agent=security_agent,
+        status_callback=captured.append,
+    )
+
+    result = manager.run("audit the project")
+
+    assert result.response_text == "Security block summary"
+    assert result.structured_response is not None
+    assert result.structured_response.parsed["blocked"] is True
+    assert manager._gate_blocked is True
+    assert security_agent.calls and security_agent.calls[0]["toolchains"] == ["static"]
+
+    kinds = {update.kind for update in captured}
+    assert "security_start" in kinds
+    assert "security_blocked" in kinds
+    assert captured[-1].kind == "error"
+    assert captured[-1].message.lower().startswith("workflow blocked by security")
+
+    # The manager should not schedule any assistant rounds for security tasks.
+    assert result.rounds == []


### PR DESCRIPTION
## Summary
- add a dedicated `SecurityAgent` that coordinates dependency, static analysis, and SBOM scans, tracks cache hints, and aggregates findings with severity metadata
- extend `ManagerAgent` to run security tasks, publish scan summaries, and block workflows when findings exceed configurable thresholds
- add unit tests with stubbed runners verifying security result parsing, cache directives, and manager integration hooks

## Testing
- pytest tests/test_security_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68e60cf8eb04832f8be91f66ebc2168c