### PR TITLE
Add documentation drafting agent and tests

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -49,6 +49,14 @@ from .db_migration import (
     MigrationResult,
     SchemaMigrationPlan,
 )
+from .doc import (
+    DocAgent,
+    DocumentationResult,
+    DocumentationSummary,
+    ReadmeDraft,
+    ChangelogDraft,
+    WalkthroughSection,
+)
 
 from .repo_context import (
     DiffBundle,
@@ -116,6 +124,17 @@ __all__.extend(
         "MigrationResult",
         "MigrationRecord",
         "EphemeralDatabaseSpec",
+    ]
+)
+
+__all__.extend(
+    [
+        "DocAgent",
+        "DocumentationResult",
+        "DocumentationSummary",
+        "ReadmeDraft",
+        "ChangelogDraft",
+        "WalkthroughSection",
     ]
 )
 

--- a/agents/doc.py
+++ b/agents/doc.py
@@ -1,0 +1,617 @@
+"""Documentation drafting helpers for README, changelog, and walkthrough updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import difflib
+from pathlib import Path
+import re
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+from internal.structures import StructuredResponse
+
+from .repo_context import DiffBundle, DiffFileStat, FileSummary, RepoContextAgent, RepoSearchResult
+from .research import ResearchAgent, ResearchResult, ResearchSnippet
+
+__all__ = [
+    "DocumentationSummary",
+    "ReadmeDraft",
+    "ChangelogDraft",
+    "WalkthroughSection",
+    "DocumentationResult",
+    "DocAgent",
+]
+
+
+@dataclass(slots=True)
+class DocumentationSummary:
+    """Aggregate overview constructed from relevant repository modules."""
+
+    overview: str
+    modules: tuple[FileSummary, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "overview": self.overview,
+            "modules": [summary.to_dict() for summary in self.modules],
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(slots=True)
+class ReadmeDraft:
+    """README snippet drafted by :class:`DocAgent`."""
+
+    content: str
+    section: str
+    highlights: tuple[str, ...] = ()
+    artifact_path: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "content": self.content,
+            "section": self.section,
+            "highlights": list(self.highlights),
+        }
+        if self.artifact_path:
+            payload["artifact_path"] = self.artifact_path
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class ChangelogDraft:
+    """Structured changelog entry generated for a release."""
+
+    version: str | None
+    content: str
+    highlights: tuple[str, ...]
+    artifact_path: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "content": self.content,
+            "highlights": list(self.highlights),
+        }
+        if self.artifact_path:
+            payload["artifact_path"] = self.artifact_path
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class WalkthroughSection:
+    """Walkthrough segment describing an important module or workflow."""
+
+    title: str
+    body: str
+    path: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "title": self.title,
+            "body": self.body,
+        }
+        if self.path is not None:
+            payload["path"] = self.path
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class DocumentationResult:
+    """Container bundling the full documentation draft output."""
+
+    summary: DocumentationSummary
+    readme: ReadmeDraft | None
+    changelog: ChangelogDraft | None
+    walkthrough: tuple[WalkthroughSection, ...]
+    evidence: tuple[ResearchSnippet, ...] = ()
+    diff_bundle: DiffBundle | None = None
+    artifacts: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "summary": self.summary.to_dict(),
+            "walkthrough": [section.to_dict() for section in self.walkthrough],
+            "evidence": [snippet.to_dict() for snippet in self.evidence],
+            "artifacts": list(self.artifacts),
+            "metadata": dict(self.metadata),
+        }
+        if self.readme is not None:
+            payload["readme"] = self.readme.to_dict()
+        if self.changelog is not None:
+            payload["changelog"] = self.changelog.to_dict()
+        if self.diff_bundle is not None:
+            payload["diff_bundle"] = self.diff_bundle.to_dict()
+        return payload
+
+
+class DocAgent:
+    """Generate documentation updates grounded in repository state."""
+
+    _DEFAULT_ARTIFACT_DIR = ".doc_artifacts"
+
+    def __init__(
+        self,
+        repo_context: RepoContextAgent,
+        *,
+        research_agent: ResearchAgent | None = None,
+        artifact_dir: str | Path | None = None,
+    ) -> None:
+        self.repo_context = repo_context
+        self.research_agent = research_agent
+        self._artifact_dir = self._resolve_artifact_dir(artifact_dir)
+        self._artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def attach_research_agent(self, agent: ResearchAgent | None) -> None:
+        """Attach or detach the research agent used for evidence gathering."""
+
+        self.research_agent = agent
+
+    def draft_updates(
+        self,
+        *,
+        highlights: Sequence[str] | None = None,
+        version: str | None = None,
+        walkthrough_topics: Sequence[str] | None = None,
+        summary_paths: Sequence[str] | None = None,
+        summary_queries: Sequence[str] | None = None,
+        research_queries: Sequence[str] | None = None,
+        include_readme: bool = True,
+        include_changelog: bool = True,
+        top_k: int = 5,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> DocumentationResult:
+        """Draft documentation snippets derived from repository context."""
+
+        code_diff = self._safe_diff_bundle()
+        module_paths = self._collect_paths(code_diff, summary_paths, summary_queries, top_k=top_k)
+        module_summaries = self._summarize_modules(module_paths)
+        overview = self._build_overview(module_summaries)
+        summary_meta: dict[str, Any] = {
+            "path_count": len(module_paths),
+            "queries": list(self._to_sequence(summary_queries)),
+        }
+        summary = DocumentationSummary(
+            overview=overview,
+            modules=tuple(module_summaries),
+            metadata=summary_meta,
+        )
+
+        research_snippets = self._gather_research(research_queries, top_k=top_k)
+
+        auto_highlights = self._generate_highlights(summary.modules)
+        requested_highlights = tuple(self._normalise_highlights(highlights) or auto_highlights)
+        if not requested_highlights:
+            requested_highlights = auto_highlights
+
+        readme_draft: ReadmeDraft | None = None
+        changelog_draft: ChangelogDraft | None = None
+        artifacts: list[str] = []
+
+        doc_targets: MutableMapping[str, str] = {}
+
+        if include_readme:
+            readme_content = self._compose_readme(summary, requested_highlights, research_snippets)
+            artifact_path = self._write_artifact("README_update.md", readme_content)
+            readme_draft = ReadmeDraft(
+                content=readme_content,
+                section="## What's New",
+                highlights=requested_highlights,
+                artifact_path=artifact_path,
+            )
+            artifacts.append(artifact_path)
+            doc_targets["README.md"] = readme_content
+
+        if include_changelog:
+            changelog_content = self._compose_changelog(summary, version, requested_highlights, research_snippets)
+            filename = "CHANGELOG_update.md" if version is None else f"CHANGELOG_{self._slugify(version)}.md"
+            artifact_path = self._write_artifact(filename, changelog_content)
+            changelog_draft = ChangelogDraft(
+                version=version,
+                content=changelog_content,
+                highlights=requested_highlights,
+                artifact_path=artifact_path,
+                metadata={"version": version},
+            )
+            artifacts.append(artifact_path)
+            doc_targets["CHANGELOG.md"] = changelog_content
+
+        walkthrough_sections = self._compose_walkthrough(walkthrough_topics, top_k=top_k)
+
+        doc_diff = self._build_doc_diff(doc_targets)
+        diff_bundle = doc_diff or code_diff
+
+        result_metadata: dict[str, Any] = {
+            "version": version,
+        }
+        if code_diff is not None:
+            result_metadata["code_diff"] = code_diff.to_dict()
+        if metadata:
+            result_metadata.update(dict(metadata))
+
+        result = DocumentationResult(
+            summary=summary,
+            readme=readme_draft,
+            changelog=changelog_draft,
+            walkthrough=tuple(walkthrough_sections),
+            evidence=research_snippets,
+            diff_bundle=diff_bundle,
+            artifacts=tuple(dict.fromkeys(artifacts)),
+            metadata=result_metadata,
+        )
+        return result
+
+    def format_result(self, result: DocumentationResult) -> str:
+        """Render a human-readable summary of the documentation drafts."""
+
+        lines: list[str] = ["# Documentation Update", ""]
+        lines.append("## Overview")
+        lines.append(result.summary.overview or "No repository changes detected.")
+        lines.append("")
+        if result.readme is not None:
+            lines.append("## README Draft")
+            lines.append(result.readme.content.strip())
+            lines.append("")
+        if result.changelog is not None:
+            version_label = result.changelog.version or "Unreleased"
+            lines.append(f"## Changelog ({version_label})")
+            lines.append(result.changelog.content.strip())
+            lines.append("")
+        if result.walkthrough:
+            lines.append("## Walkthrough")
+            for section in result.walkthrough:
+                lines.append(f"### {section.title}")
+                lines.append(section.body.strip())
+                lines.append("")
+        if result.evidence:
+            lines.append("## References")
+            for snippet in result.evidence:
+                lines.append(f"- [{snippet.title}]({snippet.url}): {snippet.quote}")
+        return "\n".join(line.rstrip() for line in lines).strip()
+
+    def to_structured_response(self, result: DocumentationResult) -> StructuredResponse:
+        """Convert the draft into a :class:`StructuredResponse`."""
+
+        payload = result.to_dict()
+        content = self.format_result(result)
+        return StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": content,
+                            "parsed": payload,
+                        }
+                    }
+                ]
+            },
+            content=content,
+            parsed=payload,
+            schema={"name": "DocumentationResult"},
+            structured=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_artifact_dir(self, artifact_dir: str | Path | None) -> Path:
+        base = Path(self.repo_context.repo_root)
+        if artifact_dir is None:
+            return base / self._DEFAULT_ARTIFACT_DIR
+        artifact_path = Path(artifact_dir)
+        if not artifact_path.is_absolute():
+            artifact_path = (base / artifact_path).resolve()
+        return artifact_path
+
+    def _write_artifact(self, filename: str, content: str) -> str:
+        path = self._artifact_dir / filename
+        path.write_text(content, encoding="utf-8")
+        try:
+            relative = path.relative_to(self.repo_context.repo_root)
+            return str(relative)
+        except ValueError:
+            return str(path)
+
+    def _build_doc_diff(self, targets: Mapping[str, str]) -> DiffBundle | None:
+        if not targets:
+            return None
+        patch_parts: list[str] = []
+        stats: list[DiffFileStat] = []
+        for rel_path, snippet in targets.items():
+            existing = self._read_existing(rel_path)
+            proposed = self._merge_snippet(existing, snippet)
+            diff_lines = list(
+                difflib.unified_diff(
+                    existing.splitlines(),
+                    proposed.splitlines(),
+                    fromfile=rel_path,
+                    tofile=rel_path,
+                    lineterm="",
+                )
+            )
+            if not diff_lines:
+                continue
+            patch_parts.append("\n".join(diff_lines))
+            additions = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+            deletions = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+            stats.append(
+                DiffFileStat(
+                    path=rel_path,
+                    additions=additions,
+                    deletions=deletions,
+                    status="proposed",
+                )
+            )
+        if not patch_parts:
+            return None
+        patch = "\n".join(patch_parts) + "\n"
+        provenance: dict[str, Any] = {"source": "doc-agent"}
+        return DiffBundle(
+            patch=patch,
+            stats=tuple(stats),
+            staged=False,
+            include_untracked=False,
+            provenance=provenance,
+        )
+
+    def _merge_snippet(self, existing: str, snippet: str) -> str:
+        merged = existing.rstrip()
+        addition = snippet.strip()
+        if not merged:
+            result = addition
+        else:
+            result = f"{merged}\n\n{addition}"
+        return result.rstrip() + "\n"
+
+    def _read_existing(self, rel_path: str) -> str:
+        path = Path(self.repo_context.repo_root) / rel_path
+        if not path.exists():
+            return ""
+        try:
+            return path.read_text(encoding="utf-8")
+        except Exception:
+            return ""
+
+    def _safe_diff_bundle(self) -> DiffBundle | None:
+        if not hasattr(self.repo_context, "focused_diffs"):
+            return None
+        try:
+            return self.repo_context.focused_diffs(include_untracked=True)
+        except Exception:
+            return None
+
+    def _collect_paths(
+        self,
+        diff_bundle: DiffBundle | None,
+        summary_paths: Sequence[str] | None,
+        summary_queries: Sequence[str] | None,
+        *,
+        top_k: int,
+    ) -> list[str]:
+        paths: list[str] = []
+        if diff_bundle is not None:
+            for stat in diff_bundle.stats:
+                if stat.path not in paths:
+                    paths.append(stat.path)
+        for path in self._to_sequence(summary_paths):
+            if path not in paths:
+                paths.append(path)
+        for query in self._to_sequence(summary_queries):
+            if not hasattr(self.repo_context, "focused_files"):
+                continue
+            try:
+                matches: Iterable[RepoSearchResult] = self.repo_context.focused_files(query, top_k=top_k)
+            except Exception:
+                continue
+            for match in matches:
+                if match.path not in paths:
+                    paths.append(match.path)
+        return paths
+
+    def _summarize_modules(self, paths: Iterable[str]) -> list[FileSummary]:
+        summaries: list[FileSummary] = []
+        for path in paths:
+            try:
+                summary = self._summarize_path(path)
+            except FileNotFoundError:
+                continue
+            if summary is not None:
+                summaries.append(summary)
+        return summaries
+
+    def _summarize_path(self, path: str) -> FileSummary | None:
+        if path.endswith(".py") and hasattr(self.repo_context, "summarize_ast"):
+            try:
+                return self.repo_context.summarize_ast(path)
+            except Exception:
+                pass
+        if hasattr(self.repo_context, "summarize_file"):
+            try:
+                return self.repo_context.summarize_file(path)
+            except Exception:
+                return None
+        return None
+
+    def _build_overview(self, summaries: Sequence[FileSummary]) -> str:
+        if not summaries:
+            return "No code changes detected in the current diff."
+        lines = ["Key modules impacted:"]
+        for summary in summaries:
+            language = summary.language or "text"
+            description = self._first_sentence(summary.summary)
+            lines.append(f"- {summary.path} ({language}, {summary.line_count} lines): {description}")
+        return "\n".join(lines)
+
+    def _generate_highlights(self, summaries: Sequence[FileSummary]) -> tuple[str, ...]:
+        highlights: list[str] = []
+        for summary in summaries:
+            description = self._first_sentence(summary.summary)
+            highlights.append(f"Update {summary.path}: {description}")
+        return tuple(highlights)
+
+    def _compose_readme(
+        self,
+        summary: DocumentationSummary,
+        highlights: Sequence[str],
+        evidence: Sequence[ResearchSnippet],
+    ) -> str:
+        lines: list[str] = ["## What's New", ""]
+        if highlights:
+            for item in highlights:
+                lines.append(f"- {item}")
+        else:
+            lines.append("- Repository updates captured in this release.")
+        if summary.modules:
+            lines.append("")
+            lines.append("### Key Modules")
+            lines.append("")
+            for module in summary.modules:
+                lines.append(
+                    f"- **{module.path}** ({module.language or 'text'}): {self._first_sentence(module.summary)}"
+                )
+        if evidence:
+            lines.append("")
+            lines.append("### References")
+            lines.append("")
+            for snippet in evidence:
+                lines.append(f"- {snippet.title}: {snippet.quote} ({snippet.url})")
+        return "\n".join(lines).strip() + "\n"
+
+    def _compose_changelog(
+        self,
+        summary: DocumentationSummary,
+        version: str | None,
+        highlights: Sequence[str],
+        evidence: Sequence[ResearchSnippet],
+    ) -> str:
+        header = version or "Unreleased"
+        lines: list[str] = [f"## {header}", ""]
+        if highlights:
+            lines.append("### Highlights")
+            lines.append("")
+            for item in highlights:
+                lines.append(f"- {item}")
+            lines.append("")
+        if summary.modules:
+            lines.append("### Modules")
+            lines.append("")
+            for module in summary.modules:
+                lines.append(f"- {module.path}: {self._first_sentence(module.summary)}")
+            lines.append("")
+        if evidence:
+            lines.append("### References")
+            lines.append("")
+            for snippet in evidence:
+                lines.append(f"- {snippet.citation}: {snippet.title}")
+        return "\n".join(line.rstrip() for line in lines if line is not None).strip() + "\n"
+
+    def _compose_walkthrough(
+        self,
+        walkthrough_topics: Sequence[str] | None,
+        *,
+        top_k: int,
+    ) -> list[WalkthroughSection]:
+        sections: list[WalkthroughSection] = []
+        seen_paths: set[str] = set()
+        for topic in self._to_sequence(walkthrough_topics):
+            matches: Iterable[RepoSearchResult]
+            if not hasattr(self.repo_context, "focused_files"):
+                continue
+            try:
+                matches = self.repo_context.focused_files(topic, top_k=top_k)
+            except Exception:
+                continue
+            for match in matches:
+                if match.path in seen_paths:
+                    continue
+                summary = self._summarize_path(match.path)
+                if summary is None:
+                    continue
+                title = self._title_from_path(summary.path)
+                body_lines = [f"**Path:** {summary.path}"]
+                description = summary.summary.strip() or "See source for details."
+                body_lines.append("")
+                body_lines.append(description)
+                metadata: dict[str, Any] = {
+                    "topic": topic,
+                    "score": match.score,
+                }
+                sections.append(
+                    WalkthroughSection(
+                        title=title,
+                        body="\n".join(body_lines).strip(),
+                        path=summary.path,
+                        metadata=metadata,
+                    )
+                )
+                seen_paths.add(summary.path)
+        return sections
+
+    def _gather_research(
+        self,
+        queries: Sequence[str] | None,
+        *,
+        top_k: int,
+    ) -> tuple[ResearchSnippet, ...]:
+        if not queries or self.research_agent is None:
+            return ()
+        snippets: list[ResearchSnippet] = []
+        for query in self._to_sequence(queries):
+            result: ResearchResult = self.research_agent.search(query, top_k=top_k)
+            snippets.extend(result.snippets)
+        return tuple(snippets)
+
+    @staticmethod
+    def _first_sentence(text: str) -> str:
+        clean = " ".join(text.strip().split())
+        if not clean:
+            return "Updates pending documentation."
+        match = re.search(r"([.!?])\s", clean)
+        if match:
+            return clean[: match.end(1)].strip()
+        return clean
+
+    @staticmethod
+    def _title_from_path(path: str) -> str:
+        name = Path(path).stem.replace("_", " ").title()
+        return name or path
+
+    @staticmethod
+    def _normalise_highlights(highlights: Sequence[str] | None) -> tuple[str, ...]:
+        if highlights is None:
+            return ()
+        items: list[str] = []
+        for item in highlights:
+            text = str(item).strip()
+            if text:
+                items.append(text)
+        return tuple(items)
+
+    @staticmethod
+    def _slugify(value: str) -> str:
+        slug = re.sub(r"[^a-zA-Z0-9]+", "-", value).strip("-")
+        return slug.lower() or "release"
+
+    @staticmethod
+    def _to_sequence(value: Sequence[str] | None) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            return (value,)
+        return tuple(str(item) for item in value)
+

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -11,6 +11,7 @@ from internal.structures import StructuredResponse
 from session import AgentRound, AgentSession
 
 from .dependency import DependencyBuildAgent
+from .doc import DocAgent
 from .db_migration import DBMigrationAgent
 from .eval import EvalAgent, RegressionSummary
 from .repo_context import (
@@ -156,6 +157,7 @@ class ManagerAgent:
         db_migration_agent: DBMigrationAgent | None = None,
         eval_agent: EvalAgent | None = None,
         security_agent: SecurityAgent | None = None,
+        doc_agent: DocAgent | None = None,
     ) -> None:
         if session is None:
             if session_factory is None:
@@ -189,6 +191,7 @@ class ManagerAgent:
         self.eval_agent: EvalAgent | None = None
         self._security_agent: SecurityAgent | None = security_agent
         self._security_report: SecurityScanResult | None = None
+        self._doc_agent: DocAgent | None = doc_agent
         self._gate_source: str | None = None
         self._last_eval_summary: RegressionSummary | None = None
         self._completed_evaluations: list[RegressionSummary] = []
@@ -196,6 +199,8 @@ class ManagerAgent:
             self.attach_test_critic(test_critic)
         if eval_agent is not None:
             self.attach_eval_agent(eval_agent)
+        if doc_agent is not None and self.research_agent is not None:
+            doc_agent.attach_research_agent(self.research_agent)
 
         self.session.add_round_hooks(
             on_round_start=self._handle_round_start,
@@ -337,6 +342,8 @@ class ManagerAgent:
         """Attach or detach the research agent used for external browsing."""
 
         self.research_agent = agent
+        if self._doc_agent is not None:
+            self._doc_agent.attach_research_agent(agent)
 
     def set_external_browsing_default(self, enabled: bool) -> None:
         """Configure the default browsing behaviour for subsequent runs."""
@@ -441,6 +448,23 @@ class ManagerAgent:
             if text:
                 queries.append(text)
         return queries
+
+    @staticmethod
+    def _ensure_sequence(value: Any | None) -> tuple[str, ...] | None:
+        if value is None:
+            return None
+        if isinstance(value, (list, tuple, set)):
+            items = value
+        else:
+            items = [value]
+        normalized: list[str] = []
+        for item in items:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                normalized.append(text)
+        return tuple(normalized)
 
     # ------------------------------------------------------------------
     # DAG lifecycle
@@ -611,6 +635,9 @@ class ManagerAgent:
         if task_kind == "security":
             metadata.pop("kind", None)
             return self._run_security_task(name, task, metadata, budget=budget)
+        if task_kind == "documentation":
+            metadata.pop("kind", None)
+            return self._run_documentation_task(name, task, metadata, budget=budget)
 
         research_spec = task.get("research")
         audience_hint = None
@@ -1029,6 +1056,103 @@ class ManagerAgent:
         self._mark_task_complete(name)
         return summary_text, structured
 
+    def _run_documentation_task(
+        self,
+        name: str,
+        task: Mapping[str, Any],
+        metadata: MutableMapping[str, Any],
+        *,
+        budget: TaskBudget | None,
+    ) -> tuple[str, StructuredResponse | None]:
+        try:
+            agent = self._ensure_doc_agent()
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        spec: dict[str, Any] = {}
+        doc_spec = task.get("documentation") or task.get("docs")
+        if isinstance(doc_spec, Mapping):
+            spec.update(doc_spec)
+
+        keys_to_copy = (
+            "highlights",
+            "version",
+            "walkthrough",
+            "walkthrough_topics",
+            "summary_paths",
+            "summary_queries",
+            "research_queries",
+            "research",
+            "include_readme",
+            "include_changelog",
+            "top_k",
+            "metadata",
+        )
+        for key in keys_to_copy:
+            if key in task and key not in spec:
+                spec[key] = task[key]
+            if key in metadata and key not in spec:
+                spec[key] = metadata[key]
+
+        highlights_value = spec.get("highlights")
+        version_value = spec.get("version")
+        walkthrough_value = spec.get("walkthrough_topics", spec.get("walkthrough"))
+        summary_paths_value = spec.get("summary_paths")
+        summary_queries_value = spec.get("summary_queries", spec.get("queries"))
+
+        research_value = spec.get("research_queries", spec.get("research"))
+        if research_value is None:
+            research_spec = task.get("research") or metadata.get("research")
+            if isinstance(research_spec, Mapping):
+                research_value = research_spec.get("queries") or research_spec.get("query")
+            elif research_spec is not None:
+                research_value = research_spec
+
+        metadata_value = spec.get("metadata") if isinstance(spec.get("metadata"), Mapping) else None
+
+        include_readme = bool(spec.get("include_readme", True))
+        include_changelog = bool(spec.get("include_changelog", True))
+        top_k_value = spec.get("top_k", 5)
+        try:
+            top_k = int(top_k_value)
+        except (TypeError, ValueError):
+            top_k = 5
+        if top_k <= 0:
+            top_k = 5
+
+        try:
+            result = agent.draft_updates(
+                highlights=self._ensure_sequence(highlights_value),
+                version=str(version_value) if version_value is not None else None,
+                walkthrough_topics=self._ensure_sequence(walkthrough_value),
+                summary_paths=self._ensure_sequence(summary_paths_value),
+                summary_queries=self._ensure_sequence(summary_queries_value),
+                research_queries=self._ensure_sequence(research_value),
+                include_readme=include_readme,
+                include_changelog=include_changelog,
+                top_k=top_k,
+                metadata=metadata_value,
+            )
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        payload = result.to_dict()
+        structured = agent.to_structured_response(result)
+        text = structured.content
+
+        if budget is not None:
+            budget.consume()
+        self._publish_status(
+            f"Documentation draft '{name}' prepared",
+            kind="documentation_summary",
+            task=name,
+            payload=payload,
+        )
+        self._mark_task_complete(name)
+        self._last_response_text = text
+        self._last_structured = structured
+        return text, structured
+
     def _handle_task_failure(
         self,
         task_name: str,
@@ -1163,3 +1287,13 @@ class ManagerAgent:
         if self._security_agent is None:
             self._security_agent = SecurityAgent()
         return self._security_agent
+
+    def _ensure_doc_agent(self) -> DocAgent:
+        if self._doc_agent is None:
+            if self.repo_context is None:
+                raise RuntimeError("Documentation tasks require a RepoContextAgent")
+            self._doc_agent = DocAgent(
+                repo_context=self.repo_context,
+                research_agent=self.research_agent,
+            )
+        return self._doc_agent

--- a/tests/test_doc_agent.py
+++ b/tests/test_doc_agent.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+import sys
+import types
+
+
+class _DummyChat:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.messages: list[Any] = []
+
+    @classmethod
+    def from_history(cls, history: Mapping[str, Any] | None) -> "_DummyChat":
+        instance = cls()
+        instance.history = history
+        return instance
+
+
+class _ToolFunctionDef:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _ToolSpec:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: dict[str, Any] = {}
+
+    def register(self, name: str, spec: Any | None = None) -> None:
+        self._tools[name] = spec
+
+    def clear(self) -> None:
+        self._tools.clear()
+
+    def list(self) -> list[str]:
+        return list(self._tools)
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *args, **kwargs: object(),
+        Chat=_DummyChat,
+        ToolFunctionDef=_ToolFunctionDef,
+    ),
+)
+
+sys.modules.setdefault("psutil", types.SimpleNamespace())
+sys.modules.setdefault(
+    "tooling",
+    types.SimpleNamespace(
+        ToolRegistry=_ToolRegistry,
+        ToolSpec=_ToolSpec,
+        resolve_tools=lambda *args, **kwargs: [],
+    ),
+)
+
+from agents.doc import DocAgent, DocumentationResult, DocumentationSummary, ReadmeDraft
+from agents.manager import ManagerAgent, ManagerStatusUpdate
+from agents.repo_context import DiffBundle, DiffFileStat, FileSummary, RepoSearchResult
+from agents.research import ResearchResult, ResearchSnippet
+from internal.structures import StructuredResponse
+
+
+class FakeRepoContext:
+    """Minimal stub providing the hooks used by :class:`DocAgent`."""
+
+    def __init__(
+        self,
+        repo_root: Path,
+        summaries: Mapping[str, FileSummary],
+        search: Mapping[str, Sequence[RepoSearchResult]],
+        diff_bundle: DiffBundle | None = None,
+    ) -> None:
+        self.repo_root = str(repo_root)
+        self._summaries = dict(summaries)
+        self._search = {key: list(value) for key, value in search.items()}
+        self._diff_bundle = diff_bundle or DiffBundle(
+            patch="",
+            stats=(),
+            staged=False,
+            include_untracked=False,
+            provenance={},
+        )
+
+    def focused_diffs(self, *, include_untracked: bool = False, staged: bool = False) -> DiffBundle:
+        return self._diff_bundle
+
+    def summarize_ast(self, path: str) -> FileSummary:
+        return self._summaries[path]
+
+    def summarize_file(self, path: str) -> FileSummary:
+        return self._summaries[path]
+
+    def focused_files(self, query: str, *, top_k: int = 5) -> list[RepoSearchResult]:
+        return list(self._search.get(query, [])[:top_k])
+
+
+class FakeResearchAgent:
+    """Captures incoming queries and returns seeded snippets."""
+
+    def __init__(self, responses: Mapping[str, ResearchResult]) -> None:
+        self._responses = dict(responses)
+        self.queries: list[tuple[str, int]] = []
+
+    def search(self, query: str, *, top_k: int = 5, **_: Any) -> ResearchResult:
+        self.queries.append((query, top_k))
+        return self._responses.get(query, ResearchResult(query=query, snippets=()))
+
+
+def _make_file_summary(path: str, summary: str = "" ) -> FileSummary:
+    return FileSummary(
+        path=path,
+        summary=summary or f"Summary for {path}.",
+        language="python" if path.endswith(".py") else "markdown",
+        line_count=42,
+        size=1024,
+        metadata={},
+        provenance={},
+    )
+
+
+def test_doc_agent_generates_drafts(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "README.md").write_text("# Project\n", encoding="utf-8")
+    (repo_root / "CHANGELOG.md").write_text("## Unreleased\n", encoding="utf-8")
+
+    summary = _make_file_summary("src/app.py", "Introduces CLI entry point and helpers.")
+    diff = DiffBundle(
+        patch="--- a/src/app.py\n+++ b/src/app.py\n",
+        stats=(DiffFileStat(path="src/app.py", additions=10, deletions=2, status="modified"),),
+        staged=False,
+        include_untracked=False,
+        provenance={"source": "test"},
+    )
+    search_map = {
+        "cli": [RepoSearchResult(path="src/app.py", offset=0, score=0.9, text="def main(): ...", provenance={})]
+    }
+    repo_context = FakeRepoContext(repo_root, {summary.path: summary}, search_map, diff)
+
+    snippet = ResearchSnippet(
+        url="https://example.com/cli",
+        title="CLI Overview",
+        quote="Document the new CLI commands.",
+        citation="[1]",
+        score=0.8,
+        metadata={},
+    )
+    research_agent = FakeResearchAgent({
+        "cli release": ResearchResult(query="cli release", snippets=(snippet,)),
+    })
+
+    agent = DocAgent(repo_context=repo_context, research_agent=research_agent)
+    result = agent.draft_updates(
+        highlights=["Introduce command line tooling"],
+        version="1.2.0",
+        walkthrough_topics=["cli"],
+        research_queries=["cli release"],
+        summary_paths=["src/app.py"],
+        include_readme=True,
+        include_changelog=True,
+    )
+
+    assert result.summary.modules and result.summary.modules[0].path == "src/app.py"
+    assert result.readme is not None
+    assert "Introduce command line tooling" in result.readme.content
+    assert result.changelog is not None and result.changelog.version == "1.2.0"
+    assert result.walkthrough and result.walkthrough[0].path == "src/app.py"
+    assert result.evidence and result.evidence[0].url == snippet.url
+    assert result.diff_bundle is not None and "README.md" in result.diff_bundle.patch
+    assert result.artifacts
+    for artifact in result.artifacts:
+        assert (repo_root / artifact).exists()
+    assert ("cli release", 5) in research_agent.queries
+
+    formatted = agent.format_result(result)
+    assert "Documentation Update" in formatted
+
+    structured = agent.to_structured_response(result)
+    assert structured.structured is True
+    assert structured.parsed["summary"]["modules"]
+
+
+def test_doc_agent_auto_highlights(tmp_path: Path) -> None:
+    repo_root = tmp_path / "auto"
+    repo_root.mkdir()
+    summary = _make_file_summary("src/api.py", "Adds REST handlers and validation.")
+    repo_context = FakeRepoContext(repo_root, {summary.path: summary}, {})
+    agent = DocAgent(repo_context=repo_context)
+
+    result = agent.draft_updates(
+        highlights=None,
+        include_changelog=False,
+        walkthrough_topics=None,
+        summary_paths=["src/api.py"],
+    )
+
+    assert result.readme is not None
+    assert result.readme.highlights, "auto-generated highlights should populate"
+    assert "src/api.py" in result.readme.content
+    assert result.diff_bundle is not None
+
+
+class DummySession:
+    """Lightweight stub mimicking :class:`AgentSession` for manager tests."""
+
+    def __init__(self) -> None:
+        self.rounds: list[Any] = []
+
+    def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:
+        self._on_round_start = on_round_start
+        self._on_round_end = on_round_end
+
+    def act(self, *_: Any, **__: Any) -> tuple[str, StructuredResponse]:
+        raise AssertionError("Doc tasks should not call session.act")
+
+
+@dataclass
+class StubDocAgent:
+    result: DocumentationResult
+
+    def __post_init__(self) -> None:
+        self.called_with: dict[str, Any] | None = None
+
+    def draft_updates(self, **kwargs: Any) -> DocumentationResult:
+        self.called_with = dict(kwargs)
+        return self.result
+
+    def to_structured_response(self, result: DocumentationResult) -> StructuredResponse:
+        payload = result.to_dict()
+        return StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "doc summary",
+                            "parsed": payload,
+                        }
+                    }
+                ]
+            },
+            content="doc summary",
+            parsed=payload,
+            schema={"name": "DocumentationResult"},
+            structured=True,
+        )
+
+    def format_result(self, _: DocumentationResult) -> str:
+        return "doc summary"
+
+    def attach_research_agent(self, *_: Any, **__: Any) -> None:
+        return None
+
+
+def test_manager_routes_documentation_tasks() -> None:
+    summary = DocumentationSummary(overview="Overview", modules=(), metadata={})
+    doc_result = DocumentationResult(
+        summary=summary,
+        readme=ReadmeDraft(content="", section="## What's New"),
+        changelog=None,
+        walkthrough=(),
+        artifacts=(".doc_artifacts/readme.md",),
+    )
+    stub_agent = StubDocAgent(result=doc_result)
+
+    status_updates: list[ManagerStatusUpdate] = []
+
+    manager = ManagerAgent(
+        session=DummySession(),
+        repo_context=None,
+        doc_agent=stub_agent,
+        plan_builder=lambda _: [
+            {
+                "name": "docs",
+                "prompt": "docs",
+                "metadata": {"kind": "documentation"},
+                "documentation": {"highlights": ["Ship docs"]},
+            }
+        ],
+        status_callback=status_updates.append,
+    )
+
+    result = manager.run("prepare documentation")
+
+    assert result.response_text == "doc summary"
+    assert stub_agent.called_with is not None
+    assert stub_agent.called_with["highlights"] == ("Ship docs",)
+    assert any(update.kind == "documentation_summary" for update in status_updates)


### PR DESCRIPTION
## Summary
- add a `DocAgent` with documentation result models that produces README, changelog, and walkthrough drafts backed by repo summaries and research evidence
- export the documentation agent, add manager routing for `documentation` tasks, and record generated markdown artifacts and diff bundles
- create unit tests for the documentation agent and manager integration using repo context and research stubs

## Testing
- pytest tests/test_doc_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68e61525b338832f85b19f43ef7666ac