### PR TITLE
Add integrations agent for CI workflows

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -57,6 +57,12 @@ from .doc import (
     ChangelogDraft,
     WalkthroughSection,
 )
+from .integrations import (
+    CIJobPlan,
+    PipelineUpdateResult,
+    ReleaseMetadata,
+    IntegrationsAgent,
+)
 
 from .repo_context import (
     DiffBundle,
@@ -135,6 +141,15 @@ __all__.extend(
         "ReadmeDraft",
         "ChangelogDraft",
         "WalkthroughSection",
+    ]
+)
+
+__all__.extend(
+    [
+        "IntegrationsAgent",
+        "CIJobPlan",
+        "PipelineUpdateResult",
+        "ReleaseMetadata",
     ]
 )
 

--- a/agents/integrations.py
+++ b/agents/integrations.py
@@ -1,0 +1,244 @@
+"""Agents for working with CI/CD integrations, container builds, and releases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+from typing import Any, Mapping, Sequence
+from string import Template
+
+from .repo_context import RepoContextAgent
+from .runner import RunReport, RunnerAgent
+
+__all__ = [
+    "CIJobPlan",
+    "PipelineUpdateResult",
+    "ReleaseMetadata",
+    "IntegrationsAgent",
+]
+
+
+@dataclass(slots=True)
+class CIJobPlan:
+    """Declarative description of a CI pipeline job to be rendered."""
+
+    provider: str
+    name: str
+    path: str
+    template: str
+    variables: Mapping[str, Any] = field(default_factory=dict)
+    rendered: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "provider": self.provider,
+            "name": self.name,
+            "path": self.path,
+            "template": self.template,
+            "variables": dict(self.variables),
+        }
+        if self.rendered is not None:
+            payload["rendered"] = self.rendered
+        return payload
+
+    def with_rendered(self, content: str) -> "CIJobPlan":
+        """Return a copy of the plan with ``rendered`` populated."""
+
+        return CIJobPlan(
+            provider=self.provider,
+            name=self.name,
+            path=self.path,
+            template=self.template,
+            variables=dict(self.variables),
+            rendered=content,
+        )
+
+
+@dataclass(slots=True)
+class PipelineUpdateResult:
+    """Summary of a pipeline write operation."""
+
+    provider: str
+    path: str
+    rendered: str
+    changed: bool
+    digest: str
+    previous_digest: str | None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "provider": self.provider,
+            "path": self.path,
+            "rendered": self.rendered,
+            "changed": self.changed,
+            "digest": self.digest,
+            "previous_digest": self.previous_digest,
+            "metadata": dict(self.metadata),
+        }
+        return payload
+
+
+@dataclass(slots=True)
+class ReleaseMetadata:
+    """Structured representation of a release announcement."""
+
+    version: str
+    tag: str
+    notes: str | None
+    artifacts: tuple[str, ...]
+    branch: str | None
+    commit: str | None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "tag": self.tag,
+            "notes": self.notes,
+            "artifacts": list(self.artifacts),
+            "branch": self.branch,
+            "commit": self.commit,
+            "metadata": dict(self.metadata),
+        }
+
+
+class IntegrationsAgent:
+    """High-level helper for CI detection, pipeline authoring, and releases."""
+
+    def __init__(
+        self,
+        *,
+        repo_context: RepoContextAgent,
+        runner: RunnerAgent | None = None,
+    ) -> None:
+        self.repo_context = repo_context
+        self.runner = runner or RunnerAgent(repo_root=repo_context.repo_root)
+
+    # ------------------------------------------------------------------
+    # CI discovery & planning
+    # ------------------------------------------------------------------
+    def detect_pipelines(self) -> dict[str, tuple[str, ...]]:
+        """Detect existing CI systems using the repository context agent."""
+
+        return self.repo_context.detect_ci_systems()
+
+    def render_pipeline(self, plan: CIJobPlan) -> CIJobPlan:
+        """Render a pipeline template with the provided variables."""
+
+        template = Template(plan.template)
+        rendered = template.safe_substitute(plan.variables)
+        return plan.with_rendered(rendered)
+
+    def apply_pipeline(self, plan: CIJobPlan) -> PipelineUpdateResult:
+        """Persist a rendered pipeline to disk."""
+
+        if plan.rendered is None:
+            raise ValueError("CIJobPlan must be rendered before applying")
+
+        previous = self.repo_context.read_file(plan.path)
+        previous_digest = hashlib.sha256(previous.encode("utf-8")).hexdigest() if previous else None
+        digest = hashlib.sha256(plan.rendered.encode("utf-8")).hexdigest()
+        changed = self.repo_context.update_file_if_changed(plan.path, plan.rendered)
+        metadata: dict[str, Any] = {
+            "previous_length": len(previous) if previous is not None else 0,
+            "new_length": len(plan.rendered),
+        }
+        return PipelineUpdateResult(
+            provider=plan.provider,
+            path=plan.path,
+            rendered=plan.rendered,
+            changed=changed,
+            digest=digest,
+            previous_digest=previous_digest,
+            metadata=metadata,
+        )
+
+    # ------------------------------------------------------------------
+    # Container orchestration
+    # ------------------------------------------------------------------
+    def run_container_build(
+        self,
+        image: str,
+        *,
+        context: str = ".",
+        dockerfile: str | None = None,
+        build_args: Mapping[str, Any] | None = None,
+        extra_args: Sequence[str] | None = None,
+        workdir: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> RunReport:
+        """Execute a container build and return the resulting run report."""
+
+        command: list[str] = ["docker", "build", "-t", image]
+        if dockerfile:
+            command.extend(["-f", dockerfile])
+        if build_args:
+            for key, value in build_args.items():
+                command.extend(["--build-arg", f"{key}={value}"])
+        if extra_args:
+            command.extend(str(arg) for arg in extra_args)
+        command.append(context)
+        return self.runner.run_shell(
+            command,
+            workdir=workdir,
+            env=env,
+            combine_output=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Release helpers
+    # ------------------------------------------------------------------
+    def prepare_release_metadata(
+        self,
+        version: str,
+        *,
+        tag: str | None = None,
+        notes: str | None = None,
+        artifacts: Sequence[str] | None = None,
+        commit: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> ReleaseMetadata:
+        """Prepare a standardized release metadata payload."""
+
+        branch: str | None = None
+        try:
+            branch = self.repo_context.current_branch()
+        except Exception:  # pragma: no cover - git may not be initialized
+            branch = None
+        tag_value = tag or f"v{version}"
+        artifacts_tuple = tuple(str(item) for item in artifacts) if artifacts else ()
+        metadata_payload: Mapping[str, Any] = metadata or {}
+        return ReleaseMetadata(
+            version=version,
+            tag=tag_value,
+            notes=notes,
+            artifacts=artifacts_tuple,
+            branch=branch,
+            commit=commit,
+            metadata=dict(metadata_payload),
+        )
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def orchestrate_pipeline(
+        self,
+        plan: CIJobPlan,
+        *,
+        apply: bool = True,
+    ) -> PipelineUpdateResult:
+        """Render and optionally apply a pipeline plan."""
+
+        rendered_plan = self.render_pipeline(plan)
+        if not apply:
+            return PipelineUpdateResult(
+                provider=rendered_plan.provider,
+                path=rendered_plan.path,
+                rendered=rendered_plan.rendered or "",
+                changed=False,
+                digest=hashlib.sha256((rendered_plan.rendered or "").encode("utf-8")).hexdigest(),
+                previous_digest=None,
+                metadata={"applied": False},
+            )
+        return self.apply_pipeline(rendered_plan)

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -14,6 +14,7 @@ from .dependency import DependencyBuildAgent
 from .doc import DocAgent
 from .db_migration import DBMigrationAgent
 from .eval import EvalAgent, RegressionSummary
+from .integrations import CIJobPlan, IntegrationsAgent
 from .repo_context import (
     DiffBundle,
     RepoContextAgent,
@@ -192,6 +193,7 @@ class ManagerAgent:
         self._security_agent: SecurityAgent | None = security_agent
         self._security_report: SecurityScanResult | None = None
         self._doc_agent: DocAgent | None = doc_agent
+        self._integrations_agent: IntegrationsAgent | None = None
         self._gate_source: str | None = None
         self._last_eval_summary: RegressionSummary | None = None
         self._completed_evaluations: list[RegressionSummary] = []
@@ -638,6 +640,9 @@ class ManagerAgent:
         if task_kind == "documentation":
             metadata.pop("kind", None)
             return self._run_documentation_task(name, task, metadata, budget=budget)
+        if task_kind == "integrations":
+            metadata.pop("kind", None)
+            return self._run_integrations_task(name, task, metadata, budget=budget)
 
         research_spec = task.get("research")
         audience_hint = None
@@ -1153,6 +1158,169 @@ class ManagerAgent:
         self._last_structured = structured
         return text, structured
 
+    def _run_integrations_task(
+        self,
+        name: str,
+        task: Mapping[str, Any],
+        metadata: MutableMapping[str, Any],
+        *,
+        budget: TaskBudget | None,
+    ) -> tuple[str, StructuredResponse | None]:
+        try:
+            agent = self._ensure_integrations_agent()
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        spec: dict[str, Any] = {}
+        integrations_spec = task.get("integrations") or task.get("integration")
+        if isinstance(integrations_spec, Mapping):
+            spec.update(integrations_spec)
+        metadata_spec = metadata.get("integrations") if isinstance(metadata, Mapping) else None
+        if isinstance(metadata_spec, Mapping):
+            spec.update(metadata_spec)
+        for key in ("detect", "pipeline", "build", "release"):
+            if key in task and key not in spec:
+                spec[key] = task[key]
+            if key in metadata and key not in spec:
+                spec[key] = metadata[key]
+
+        outputs: dict[str, Any] = {}
+        summary_lines: list[str] = []
+
+        try:
+            detect_flag = bool(spec.get("detect")) or bool(spec.get("discover"))
+            if detect_flag:
+                detected = agent.detect_pipelines()
+                outputs["detected"] = detected
+                if detected:
+                    provider_list = ", ".join(sorted(detected))
+                    message = f"Detected CI providers: {provider_list}"
+                else:
+                    message = "No CI providers detected"
+                self._publish_status(
+                    message,
+                    kind="integrations_detect",
+                    task=name,
+                    payload={"providers": detected},
+                )
+                summary_lines.append(message)
+
+            pipeline_spec = spec.get("pipeline")
+            if isinstance(pipeline_spec, Mapping):
+                template_value = pipeline_spec.get("template")
+                path_value = pipeline_spec.get("path")
+                if not path_value:
+                    raise ValueError("Integrations pipeline spec requires a 'path'")
+                if template_value is None:
+                    raise ValueError("Integrations pipeline spec requires a 'template'")
+                variables_value = pipeline_spec.get("variables") or {}
+                if not isinstance(variables_value, Mapping):
+                    raise ValueError("Integrations pipeline 'variables' must be a mapping")
+                plan = CIJobPlan(
+                    provider=str(pipeline_spec.get("provider", "github_actions")),
+                    name=str(pipeline_spec.get("name", name)),
+                    path=str(path_value),
+                    template=str(template_value),
+                    variables=dict(variables_value),
+                )
+                apply_flag = bool(pipeline_spec.get("apply", True))
+                pipeline_result = agent.orchestrate_pipeline(plan, apply=apply_flag)
+                pipeline_payload = pipeline_result.to_dict()
+                outputs["pipeline"] = pipeline_payload
+                message = f"Pipeline '{plan.name}' processed for {plan.provider}"
+                self._publish_status(
+                    message,
+                    kind="integrations_pipeline",
+                    task=name,
+                    payload=pipeline_payload,
+                )
+                summary_lines.append(message)
+
+            build_spec = spec.get("build")
+            if isinstance(build_spec, Mapping):
+                image_value = build_spec.get("image")
+                if not image_value:
+                    raise ValueError("Integrations build spec requires an 'image'")
+                extra_args = build_spec.get("extra_args")
+                if isinstance(extra_args, (str, bytes)):
+                    extra_args = [extra_args]
+                report = agent.run_container_build(
+                    str(image_value),
+                    context=str(build_spec.get("context", ".")),
+                    dockerfile=str(build_spec.get("dockerfile")) if build_spec.get("dockerfile") else None,
+                    build_args=build_spec.get("build_args") if isinstance(build_spec.get("build_args"), Mapping) else None,
+                    extra_args=list(extra_args) if extra_args is not None else None,
+                    workdir=str(build_spec.get("workdir")) if build_spec.get("workdir") else None,
+                    env=build_spec.get("env") if isinstance(build_spec.get("env"), Mapping) else None,
+                )
+                build_payload = report.to_dict()
+                outputs["build"] = build_payload
+                message = f"Container image '{image_value}' build triggered"
+                self._publish_status(
+                    message,
+                    kind="integrations_build",
+                    task=name,
+                    payload=build_payload,
+                )
+                summary_lines.append(message)
+
+            release_spec = spec.get("release")
+            if release_spec is None and "version" in spec:
+                release_spec = spec
+            if isinstance(release_spec, Mapping) and release_spec.get("version"):
+                metadata_value = release_spec.get("metadata")
+                if metadata_value is not None and not isinstance(metadata_value, Mapping):
+                    raise ValueError("Integrations release 'metadata' must be a mapping if provided")
+                release = agent.prepare_release_metadata(
+                    str(release_spec.get("version")),
+                    tag=release_spec.get("tag"),
+                    notes=release_spec.get("notes"),
+                    artifacts=release_spec.get("artifacts"),
+                    commit=release_spec.get("commit"),
+                    metadata=metadata_value,
+                )
+                release_payload = release.to_dict()
+                outputs["release"] = release_payload
+                message = f"Prepared release metadata for version {release.version}"
+                self._publish_status(
+                    message,
+                    kind="integrations_release",
+                    task=name,
+                    payload=release_payload,
+                )
+                summary_lines.append(message)
+        except Exception as exc:
+            return self._handle_task_failure(name, exc)
+
+        if budget is not None:
+            budget.consume()
+
+        if not summary_lines:
+            summary_lines.append("Integrations task completed with no actions performed")
+
+        summary_text = "\n".join(summary_lines)
+        structured = StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": summary_text,
+                            "parsed": outputs,
+                        }
+                    }
+                ]
+            },
+            content=summary_text,
+            parsed=outputs,
+            schema={"name": "IntegrationsResult"},
+            structured=True,
+        )
+        self._mark_task_complete(name)
+        self._last_response_text = summary_text
+        self._last_structured = structured
+        return summary_text, structured
+
     def _handle_task_failure(
         self,
         task_name: str,
@@ -1297,3 +1465,10 @@ class ManagerAgent:
                 research_agent=self.research_agent,
             )
         return self._doc_agent
+
+    def _ensure_integrations_agent(self) -> IntegrationsAgent:
+        if self.repo_context is None:
+            raise RuntimeError("Integration tasks require a RepoContextAgent")
+        if self._integrations_agent is None:
+            self._integrations_agent = IntegrationsAgent(repo_context=self.repo_context)
+        return self._integrations_agent

--- a/agents/repo_context.py
+++ b/agents/repo_context.py
@@ -506,6 +506,58 @@ class RepoContextAgent:
         return self.diff_bundle(staged=staged, include_untracked=include_untracked)
 
     # ------------------------------------------------------------------
+    # CI configuration helpers
+    # ------------------------------------------------------------------
+    def detect_ci_systems(self) -> dict[str, tuple[str, ...]]:
+        """Return discovered CI configuration files grouped by provider."""
+
+        providers: dict[str, list[str]] = {}
+        github_root = os.path.join(self.repo_root, ".github", "workflows")
+        if os.path.isdir(github_root):
+            github_files: list[str] = []
+            for entry in sorted(os.listdir(github_root)):
+                if not entry.lower().endswith((".yml", ".yaml")):
+                    continue
+                rel_path = self._rel_path(os.path.join(github_root, entry))
+                github_files.append(rel_path)
+            if github_files:
+                providers["github_actions"] = github_files
+
+        gitlab_file = os.path.join(self.repo_root, ".gitlab-ci.yml")
+        if os.path.isfile(gitlab_file):
+            providers["gitlab_ci"] = [self._rel_path(gitlab_file)]
+
+        return {name: tuple(paths) for name, paths in providers.items()}
+
+    def read_file(self, path: str, *, encoding: str = "utf-8") -> str | None:
+        """Read a repository file returning ``None`` when not found."""
+
+        abs_path = self._abs_path(path)
+        try:
+            with open(abs_path, "r", encoding=encoding) as handle:
+                return handle.read()
+        except FileNotFoundError:
+            return None
+
+    def update_file_if_changed(
+        self,
+        path: str,
+        content: str,
+        *,
+        encoding: str = "utf-8",
+    ) -> bool:
+        """Write ``content`` only when it differs from the existing file."""
+
+        abs_path = self._abs_path(path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        current = self.read_file(path, encoding=encoding)
+        if current == content:
+            return False
+        with open(abs_path, "w", encoding=encoding) as handle:
+            handle.write(content)
+        return True
+
+    # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
     def _rel_path(self, path: str) -> str:

--- a/tests/test_integrations_agent.py
+++ b/tests/test_integrations_agent.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+from typing import Any, Mapping, Sequence
+
+if "lmstudio" not in sys.modules:
+    class _DummyChat:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.messages: list[Any] = []
+
+        @classmethod
+        def from_history(cls, history: Mapping[str, Any] | None = None) -> "_DummyChat":
+            instance = cls()
+            if isinstance(history, Mapping):
+                instance.messages.extend(history.get("messages", []))
+            return instance
+
+        def append(self, message: Any) -> None:  # pragma: no cover - not used in tests
+            self.messages.append(message)
+
+    class _DummyModel:
+        def respond(self, *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+            return {"choices": [{"message": {"content": ""}}]}
+
+        def respond_stream(self, *args: Any, **kwargs: Any):  # pragma: no cover - streaming unused
+            return iter(())
+
+    def _dummy_llm(*args: Any, **kwargs: Any) -> _DummyModel:
+        return _DummyModel()
+
+    class ToolFunctionDef:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            self.name = kwargs.get("name")
+
+    sys.modules["lmstudio"] = types.SimpleNamespace(
+        Chat=_DummyChat,
+        llm=_dummy_llm,
+        ToolFunctionDef=ToolFunctionDef,
+    )
+
+if "chat" not in sys.modules:
+    CallbackMap = Mapping[str, Any]
+    sys.modules["chat"] = types.SimpleNamespace(CallbackMap=CallbackMap)
+
+if "psutil" not in sys.modules:
+    class _DummyPsutil(types.SimpleNamespace):
+        class NoSuchProcess(Exception):
+            pass
+
+        class TimeoutExpired(Exception):
+            pass
+
+        def Process(self, pid: int):  # pragma: no cover - process inspection unused
+            raise self.NoSuchProcess()
+
+        def process_iter(self, attrs: Any):  # pragma: no cover - not used
+            return []
+
+    sys.modules["psutil"] = _DummyPsutil()
+
+if "tooling" not in sys.modules:
+    class ToolSpec:
+        def __init__(self, func: Any, name: str | None = None) -> None:
+            self.func = func
+            self.name = name or getattr(func, "__name__", "tool")
+
+    class ToolRegistry:
+        def __init__(self) -> None:
+            self._tools: dict[str, ToolSpec] = {}
+
+        def register(self, tool: Any, *args: Any, **kwargs: Any) -> ToolSpec:
+            spec = tool if isinstance(tool, ToolSpec) else ToolSpec(tool, kwargs.get("name"))
+            self._tools[spec.name] = spec
+            return spec
+
+        def list(self) -> list[ToolSpec]:  # pragma: no cover - unused
+            return list(self._tools.values())
+
+        def clear(self) -> None:  # pragma: no cover - unused
+            self._tools.clear()
+
+    def register_default_toolset(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - unused
+        return None
+
+    def list_default_toolsets() -> list[str]:  # pragma: no cover - unused
+        return []
+
+    def clear_default_toolsets() -> None:  # pragma: no cover - unused
+        return None
+
+    sys.modules["tooling"] = types.SimpleNamespace(
+        ToolSpec=ToolSpec,
+        ToolRegistry=ToolRegistry,
+        register_default_toolset=register_default_toolset,
+        list_default_toolsets=list_default_toolsets,
+        clear_default_toolsets=clear_default_toolsets,
+    )
+
+if "session" not in sys.modules:
+    class _DummyAgentSession:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.rounds: list[Any] = []
+
+        def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:  # pragma: no cover
+            return
+
+    class _DummyHook:  # pragma: no cover - documentation only
+        pass
+
+    class _DummyAgentRound:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.metadata = kwargs.get("metadata")
+
+        def to_dict(self) -> dict[str, Any]:  # pragma: no cover - unused in tests
+            return {"metadata": self.metadata}
+
+    sys.modules["session"] = types.SimpleNamespace(
+        AgentSession=_DummyAgentSession,
+        Hook=_DummyHook,
+        AgentRound=_DummyAgentRound,
+    )
+
+from agents.integrations import CIJobPlan, IntegrationsAgent
+from agents.repo_context import RepoContextAgent
+from agents.runner import RunReport
+
+
+class StubRepoContext:
+    """Minimal stub implementing the subset of RepoContextAgent APIs we exercise."""
+
+    def __init__(self, root: Path) -> None:
+        self.repo_root = str(root)
+
+    def detect_ci_systems(self) -> dict[str, tuple[str, ...]]:
+        return {}
+
+    def read_file(self, path: str, *, encoding: str = "utf-8") -> str | None:
+        file_path = Path(self.repo_root) / path
+        if file_path.exists():
+            return file_path.read_text(encoding=encoding)
+        return None
+
+    def update_file_if_changed(self, path: str, content: str, *, encoding: str = "utf-8") -> bool:
+        file_path = Path(self.repo_root) / path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        if file_path.exists() and file_path.read_text(encoding=encoding) == content:
+            return False
+        file_path.write_text(content, encoding=encoding)
+        return True
+
+    def current_branch(self) -> str:
+        return "main"
+
+
+class DummyRunner:
+    """Simple runner stub capturing invocations for assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Sequence[str] | str, Mapping[str, Any]]] = []
+
+    def run_shell(self, command: Sequence[str] | str, **kwargs: Any) -> RunReport:
+        self.calls.append((command, kwargs))
+        command_display = " ".join(command) if isinstance(command, (list, tuple)) else str(command)
+        return RunReport(
+            identifier=len(self.calls),
+            runner="shell",
+            command=command,
+            command_display=command_display,
+            workdir=str(kwargs.get("workdir") or Path(self.calls[-1][1].get("workdir", "."))),
+            env=kwargs.get("env") or {},
+            status="success",
+            ok=True,
+            exit_code=0,
+            pid=1234,
+            stdout="",
+            stderr="",
+            combined_output=kwargs.get("combine_output") and "" or None,
+            error=None,
+            start_time=0.0,
+            end_time=0.0,
+            duration=0.0,
+            artifacts=tuple(kwargs.get("artifacts") or ()),
+            metadata=kwargs.get("metadata") or {},
+            raw={},
+        )
+
+
+def test_repo_context_detects_ci_systems(tmp_path) -> None:
+    agent = RepoContextAgent.__new__(RepoContextAgent)
+    agent.repo_root = str(tmp_path)
+    workflows_dir = tmp_path / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    (workflows_dir / "ci.yaml").write_text("name: CI\n")
+    (tmp_path / ".gitlab-ci.yml").write_text("stages: []\n")
+
+    providers = RepoContextAgent.detect_ci_systems(agent)
+
+    assert providers["github_actions"] == (".github/workflows/ci.yaml",)
+    assert providers["gitlab_ci"] == (".gitlab-ci.yml",)
+
+
+def test_integrations_agent_renders_and_applies_pipeline(tmp_path) -> None:
+    repo = StubRepoContext(tmp_path)
+    agent = IntegrationsAgent(repo_context=repo, runner=DummyRunner())
+    plan = CIJobPlan(
+        provider="github_actions",
+        name="ci",
+        path=".github/workflows/ci.yml",
+        template="""name: ${job}\non:\n  push:\n    branches: [${branch}]\n""",
+        variables={"job": "CI", "branch": "main"},
+    )
+
+    rendered = agent.render_pipeline(plan)
+
+    assert rendered.rendered is not None
+    assert "${" not in rendered.rendered
+
+    result = agent.apply_pipeline(rendered)
+
+    assert result.changed is True
+    assert (tmp_path / ".github" / "workflows" / "ci.yml").read_text() == rendered.rendered
+
+    second = agent.apply_pipeline(rendered)
+    assert second.changed is False
+
+
+def test_integrations_agent_runs_container_build(tmp_path) -> None:
+    repo = StubRepoContext(tmp_path)
+    runner = DummyRunner()
+    agent = IntegrationsAgent(repo_context=repo, runner=runner)
+
+    report = agent.run_container_build(
+        "example:latest",
+        context=".",
+        dockerfile="Dockerfile",
+        build_args={"BUILD": "1"},
+        extra_args=["--no-cache"],
+        workdir=str(tmp_path),
+        env={"CI": "true"},
+    )
+
+    assert runner.calls, "run_shell should have been invoked"
+    command, kwargs = runner.calls[0]
+    assert command[:4] == ["docker", "build", "-t", "example:latest"]
+    assert "--no-cache" in command
+    assert command[-1] == "."
+    assert kwargs["combine_output"] is True
+    assert kwargs["env"] == {"CI": "true"}
+    assert report.ok
+
+
+def test_integrations_agent_prepares_release_metadata(tmp_path) -> None:
+    repo = StubRepoContext(tmp_path)
+    agent = IntegrationsAgent(repo_context=repo, runner=DummyRunner())
+
+    release = agent.prepare_release_metadata("1.2.3", notes="Ready", artifacts=["dist/app.whl"])
+
+    assert release.tag == "v1.2.3"
+    assert release.branch == "main"
+    assert release.to_dict()["artifacts"] == ["dist/app.whl"]


### PR DESCRIPTION
## Summary
- add an integrations agent that renders CI templates, applies updates, runs container builds, and prepares release metadata
- extend the repository context agent with CI detection and idempotent file updates and wire integrations tasks into the manager
- export the new agent and cover the behavior with integration-focused unit tests

## Testing
- pytest tests/test_integrations_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68e6197a0a78832fad7bb85b9f9135fd