### PR TITLE
Enhance manager task orchestration and tests

### DIFF
--- a/agents/manager.py
+++ b/agents/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass, field
 import time
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence, TYPE_CHECKING
@@ -173,6 +174,7 @@ class ManagerAgent:
         self._active_plan: list[dict[str, Any]] = []
         self._budgets: dict[str, TaskBudget] = {}
         self._status_log: list[ManagerStatusUpdate] = []
+        self._task_outputs: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
         self._current_task: str | None = None
         self._current_round_task: str | None = None
         self._last_response_text: str = ""
@@ -528,6 +530,12 @@ class ManagerAgent:
             if self._gate_blocked:
                 break
 
+        if not self._gate_blocked:
+            response_text, structured = self._synthesise_task_outputs(
+                default_text=response_text,
+                default_structured=structured,
+            )
+
         if self.test_critic is not None and not self._gate_blocked:
             report = self.test_critic.run_and_report()
             self._gate_report = report
@@ -559,19 +567,128 @@ class ManagerAgent:
     # ------------------------------------------------------------------
     # Planning helpers
     # ------------------------------------------------------------------
-    def _default_plan_builder(self, user_message: str) -> Sequence[Mapping[str, Any]]:
+    _SPECIALIST_BLUEPRINTS: tuple[Mapping[str, Any], ...] = (
+        {
+            "name": "dependency-resolution",
+            "kind": "dependency",
+            "agent": "dependency",
+            "description": "Resolve or install project dependencies",
+            "keywords": ("dependency", "dependencies", "install", "package", "pip", "npm"),
+            "budget": {"limit": 1.0, "unit": "rounds"},
+            "research": {"required": False},
+        },
+        {
+            "name": "database-migration",
+            "kind": "db_migration",
+            "agent": "db_migration",
+            "description": "Prepare and run database migrations",
+            "keywords": ("migration", "migrate", "schema"),
+            "budget": {"limit": 1.0, "unit": "rounds"},
+            "research": {"required": False},
+        },
+        {
+            "name": "security-audit",
+            "kind": "security",
+            "agent": "security",
+            "description": "Execute security scans and report findings",
+            "keywords": ("security", "vulnerability", "scan", "audit"),
+            "budget": {"limit": 1.0, "unit": "rounds"},
+            "research": {"required": False},
+        },
+        {
+            "name": "documentation-updates",
+            "kind": "documentation",
+            "agent": "documentation",
+            "description": "Draft documentation or release notes",
+            "keywords": ("document", "docs", "changelog", "readme", "release notes"),
+            "budget": {"limit": 2.0, "unit": "rounds"},
+            "research": {"required": True, "audience": "docs"},
+        },
+        {
+            "name": "ci-integration",
+            "kind": "integrations",
+            "agent": "integrations",
+            "description": "Update CI/CD integrations",
+            "keywords": ("pipeline", "ci", "integration", "deploy", "release"),
+            "budget": {"limit": 1.0, "unit": "rounds"},
+            "research": {"required": False},
+        },
+        {
+            "name": "regression-evaluation",
+            "kind": "eval",
+            "agent": "evaluation",
+            "description": "Run regression or evaluation suites",
+            "keywords": ("evaluate", "evaluation", "benchmark", "regression"),
+            "budget": {"limit": 1.0, "unit": "rounds"},
+            "research": {"required": False},
+        },
+    )
+
+    def _default_plan_builder(
+        self,
+        user_message: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Sequence[Mapping[str, Any]]:
         cleaned = user_message.strip()
-        description = "Respond to the user's request"
-        if not cleaned:
-            description = "Prompt the user for additional details"
-        return [
-            {
-                "name": "task-1",
-                "description": description,
-                "prompt": user_message,
-                "budget": {"limit": 1.0, "unit": "rounds"},
-            }
-        ]
+        lowered = cleaned.lower()
+        metadata = metadata or {}
+        requested = self._ensure_sequence(metadata.get("requested_tasks"))
+        tasks: list[dict[str, Any]] = []
+
+        def _matches(blueprint: Mapping[str, Any]) -> bool:
+            if requested and blueprint["kind"] not in requested:
+                return False
+            for keyword in blueprint.get("keywords", ()):  # pragma: no cover - defensive
+                if keyword and keyword in lowered:
+                    return True
+            return bool(requested)
+
+        for blueprint in self._SPECIALIST_BLUEPRINTS:
+            if _matches(blueprint):
+                tasks.append(self._build_task_from_blueprint(blueprint, user_message))
+
+        if not tasks:
+            description = "Respond to the user's request"
+            if not cleaned:
+                description = "Prompt the user for additional details"
+            tasks.append(
+                {
+                    "name": "task-1",
+                    "description": description,
+                    "prompt": user_message,
+                    "budget": {"limit": 1.0, "unit": "rounds"},
+                    "metadata": {"kind": "general", "agent": "session"},
+                    "research": {"required": False},
+                }
+            )
+
+        return tasks
+
+    def _build_task_from_blueprint(
+        self,
+        blueprint: Mapping[str, Any],
+        user_message: str,
+    ) -> dict[str, Any]:
+        name = str(blueprint.get("name") or blueprint.get("kind") or "task")
+        budget_payload = dict(blueprint.get("budget", {}))
+        research_payload = dict(blueprint.get("research", {}))
+        metadata_payload = {
+            "kind": blueprint.get("kind"),
+            "agent": blueprint.get("agent"),
+            "research": dict(research_payload) if research_payload else None,
+        }
+        if metadata_payload.get("research") is None:
+            metadata_payload.pop("research", None)
+        return {
+            "name": name,
+            "description": blueprint.get("description", ""),
+            "prompt": user_message,
+            "kind": blueprint.get("kind"),
+            "budget": budget_payload,
+            "metadata": metadata_payload,
+            "research": research_payload,
+        }
 
     def _call_plan_builder(self, user_message: str) -> Sequence[Mapping[str, Any]]:
         builder = self._plan_builder
@@ -608,6 +725,62 @@ class ManagerAgent:
     # ------------------------------------------------------------------
     # Execution helpers
     # ------------------------------------------------------------------
+    def _synthesise_task_outputs(
+        self,
+        *,
+        default_text: str,
+        default_structured: StructuredResponse | None,
+    ) -> tuple[str, StructuredResponse | None]:
+        if not self._task_outputs:
+            self._last_response_text = default_text
+            self._last_structured = default_structured
+            return default_text, default_structured
+
+        summary_lines: list[str] = []
+        tasks_payload: OrderedDict[str, dict[str, Any]] = OrderedDict()
+        for name, record in self._task_outputs.items():
+            text = str(record.get("text") or "").strip()
+            if text:
+                summary_lines.append(f"{name}: {text}")
+            kind = record.get("kind") or "general"
+            entry: dict[str, Any] = {"kind": kind, "text": text}
+            structured = record.get("structured")
+            if structured is not None:
+                structured_payload: dict[str, Any] = {
+                    "content": structured.content,
+                    "structured": bool(structured.structured),
+                }
+                if structured.parsed is not None:
+                    structured_payload["parsed"] = structured.parsed
+                if structured.schema is not None:
+                    structured_payload["schema"] = structured.schema
+                entry["structured_output"] = structured_payload
+            tasks_payload[name] = entry
+
+        aggregated_text = "\n\n".join(summary_lines) if summary_lines else default_text
+        parsed_payload = {"tasks": tasks_payload}
+        aggregated = StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": aggregated_text,
+                            "parsed": parsed_payload,
+                        }
+                    }
+                ]
+            },
+            content=aggregated_text,
+            parsed=parsed_payload,
+            schema={"name": "ManagerTaskOutputs"},
+            structured=True,
+        )
+
+        self._last_response_text = aggregated_text
+        self._last_structured = aggregated
+        return aggregated_text, aggregated
+
     def _execute_task(
         self,
         task: Mapping[str, Any],
@@ -645,6 +818,8 @@ class ManagerAgent:
             return self._run_integrations_task(name, task, metadata, budget=budget)
 
         research_spec = task.get("research")
+        if not isinstance(research_spec, Mapping):
+            research_spec = metadata.get("research") if isinstance(metadata, Mapping) else None
         audience_hint = None
         raw_queries: Any = None
         if isinstance(research_spec, Mapping):
@@ -652,10 +827,14 @@ class ManagerAgent:
             if raw_queries is None and research_spec.get("query") is not None:
                 raw_queries = research_spec.get("query")
             audience_hint = research_spec.get("audience")
+            required_research = bool(research_spec.get("required"))
         else:
             raw_queries = task.get("research_queries")
             audience_hint = task.get("research_audience")
+            required_research = False
         queries = self._coerce_queries(raw_queries)
+        if required_research and not queries and prompt.strip():
+            queries = [prompt.strip()]
         audience_value = str(audience_hint).strip() if audience_hint is not None else None
         if queries:
             try:
@@ -702,9 +881,57 @@ class ManagerAgent:
             self._mark_task_complete(name)
             self._last_response_text = text
             self._last_structured = structured
+            self._register_task_output(name, text, structured, kind=task_kind or "general")
             return text, structured
         finally:
             self._current_task = None
+
+    def _register_task_output(
+        self,
+        task_name: str,
+        text: str,
+        structured: StructuredResponse | None,
+        *,
+        kind: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        normalized_kind = kind or "general"
+        payload: dict[str, Any] = {"kind": normalized_kind, "text": text}
+        if structured is not None:
+            if structured.parsed is not None:
+                payload["parsed"] = structured.parsed
+            if structured.schema is not None:
+                payload["schema"] = structured.schema
+        if metadata:
+            payload["metadata"] = dict(metadata)
+        self._task_outputs[task_name] = {
+            "text": text,
+            "structured": structured,
+            "kind": normalized_kind,
+        }
+        self._publish_status(
+            f"Recorded output for {task_name}",
+            kind="task_output",
+            task=task_name,
+            payload=payload,
+        )
+
+    def _ingest_task_evidence(
+        self,
+        task_name: str,
+        evidence: Iterable[Any] | None,
+    ) -> None:
+        if not evidence:
+            return
+        bucket = self._shared_evidence.setdefault(task_name, [])
+        seen = {getattr(snippet, "url", None) for snippet in bucket if getattr(snippet, "url", None)}
+        for snippet in evidence:
+            url = getattr(snippet, "url", None)
+            if url and url in seen:
+                continue
+            bucket.append(snippet)
+            if url:
+                seen.add(url)
 
     def _run_dependency_task(
         self,
@@ -778,6 +1005,7 @@ class ManagerAgent:
         self._mark_task_complete(name)
         self._last_response_text = summary_text
         self._last_structured = structured
+        self._register_task_output(name, summary_text, structured, kind="dependency")
         return summary_text, structured
 
     def _run_db_migration_task(
@@ -892,6 +1120,7 @@ class ManagerAgent:
         self._mark_task_complete(name)
         self._last_response_text = summary_text
         self._last_structured = structured
+        self._register_task_output(name, summary_text, structured, kind="db_migration")
         return summary_text, structured
 
     def _run_eval_task(
@@ -952,6 +1181,7 @@ class ManagerAgent:
         else:
             self._last_response_text = text
             self._last_structured = structured
+        self._register_task_output(name, text, structured, kind="eval")
         return text, structured
 
     def _run_security_task(
@@ -1059,6 +1289,7 @@ class ManagerAgent:
             self._gate_blocked = True
             self._gate_source = "security"
         self._mark_task_complete(name)
+        self._register_task_output(name, summary_text, structured, kind="security")
         return summary_text, structured
 
     def _run_documentation_task(
@@ -1156,6 +1387,8 @@ class ManagerAgent:
         self._mark_task_complete(name)
         self._last_response_text = text
         self._last_structured = structured
+        self._ingest_task_evidence(name, getattr(result, "evidence", None))
+        self._register_task_output(name, text, structured, kind="documentation")
         return text, structured
 
     def _run_integrations_task(
@@ -1319,6 +1552,7 @@ class ManagerAgent:
         self._mark_task_complete(name)
         self._last_response_text = summary_text
         self._last_structured = structured
+        self._register_task_output(name, summary_text, structured, kind="integrations")
         return summary_text, structured
 
     def _handle_task_failure(
@@ -1418,6 +1652,7 @@ class ManagerAgent:
         self._gate_source = None
         self._external_browsing_enabled = self._external_browsing_default
         self._shared_evidence.clear()
+        self._task_outputs.clear()
         self._last_eval_summary = None
         self._completed_evaluations.clear()
 

--- a/tests/test_manager_agent.py
+++ b/tests/test_manager_agent.py
@@ -1,8 +1,70 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+import types
 from typing import Any, Mapping
 
+import sys
+
 import pytest
+
+
+class _StubModel:
+    def respond(self, *_, **__):
+        return {"choices": [{"message": {"content": "stub"}}]}
+
+    def respond_stream(self, *_, **__):
+        yield {"choices": [{"delta": {"content": "stub"}}]}
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None) -> None:
+        self.messages: list[Mapping[str, Any]] = []
+        if system_prompt is not None:
+            self.messages.append({"role": "system", "content": system_prompt})
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":
+        instance = cls()
+        if isinstance(history, Mapping):
+            messages = history.get("messages", [])
+            if isinstance(messages, list):
+                instance.messages = list(messages)
+        elif isinstance(history, str):
+            instance.messages = [{"role": "user", "content": history}]
+        return instance
+
+    def add_user_message(self, content: str) -> None:
+        self.messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        self.messages.append({"role": "assistant", "content": content})
+
+
+class _StubToolFunctionDef:
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters: Mapping[str, Any] | None = None,
+        implementation: Any = None,
+        **_: Any,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.parameters = dict(parameters or {})
+        self.implementation = implementation
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *_, **__: _StubModel(),
+        Chat=_StubChat,
+        ToolFunctionDef=_StubToolFunctionDef,
+    ),
+)
 
 from agents.manager import ManagerAgent, ManagerStatusUpdate
 from internal.structures import StructuredResponse
@@ -64,7 +126,7 @@ def test_manager_tracks_budget_progress(message: str) -> None:
 
     result = manager.run(message)
 
-    assert result.response_text == session.next_response_text
+    assert session.next_response_text in result.response_text
     assert result.plan, "planner should produce at least one task"
     first_task = result.plan[0]
     assert "name" in first_task
@@ -77,3 +139,202 @@ def test_manager_tracks_budget_progress(message: str) -> None:
     assert last_round.metadata is not None
     assert last_round.metadata["budget"]["consumed"] == pytest.approx(1.0)
     assert any(update.kind == "progress" for update in captured)
+    assert result.structured_response is not None
+    parsed = result.structured_response.parsed
+    assert isinstance(parsed, Mapping)
+    assert "task-1" in parsed.get("tasks", {})
+
+
+@dataclass
+class StubSnippet:
+    url: str
+    title: str
+    quote: str
+    citation: str
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            "url": self.url,
+            "title": self.title,
+            "quote": self.quote,
+            "citation": self.citation,
+        }
+
+
+class StubDocResult:
+    def __init__(self, payload: Mapping[str, Any], evidence: tuple[StubSnippet, ...]):
+        self._payload = dict(payload)
+        self.evidence = evidence
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return dict(self._payload)
+
+
+class StubDocAgent:
+    def __init__(self) -> None:
+        self.calls: list[Mapping[str, Any]] = []
+
+    def draft_updates(self, **kwargs: Any) -> StubDocResult:
+        self.calls.append(kwargs)
+        snippet = StubSnippet(
+            url="https://example.com/docs",
+            title="Example",
+            quote="Sample evidence",
+            citation="[1]",
+        )
+        return StubDocResult({"doc": "Doc summary"}, (snippet,))
+
+    @staticmethod
+    def to_structured_response(result: StubDocResult) -> StructuredResponse:
+        payload = result.to_dict()
+        return StructuredResponse(
+            raw_response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "Doc summary",
+                            "parsed": payload,
+                        }
+                    }
+                ]
+            },
+            content="Doc summary",
+            parsed=payload,
+            schema={"name": "DocStub"},
+            structured=True,
+        )
+
+
+@dataclass
+class StubSecurityResult:
+    summary: str | None = None
+    blocked: bool = False
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            "reports": [],
+            "threshold": None,
+            "blocked": self.blocked,
+            "highest_severity": None,
+            "summary": self.summary,
+            "artifacts": [],
+        }
+
+
+class StubSecurityAgent:
+    DEFAULT_SEQUENCE = ("dependencies",)
+
+    def __init__(self, result: StubSecurityResult) -> None:
+        self._result = result
+
+    def run_scans(self, **_: Any) -> StubSecurityResult:
+        return self._result
+
+    @staticmethod
+    def format_result(result: StubSecurityResult) -> str:
+        return result.summary or "Security summary"
+
+
+def multi_agent_plan(message: str, *, metadata: Mapping[str, Any] | None = None) -> list[Mapping[str, Any]]:
+    del metadata
+    return [
+        {
+            "name": "documentation-updates",
+            "description": "Draft docs",
+            "prompt": message,
+            "kind": "documentation",
+            "budget": {"limit": 2.0, "unit": "rounds"},
+            "metadata": {"kind": "documentation"},
+            "research": {"required": False},
+        },
+        {
+            "name": "respond",
+            "description": "Answer the question",
+            "prompt": message,
+            "budget": {"limit": 1.0, "unit": "rounds"},
+        },
+    ]
+
+
+def blocking_security_plan(message: str, *, metadata: Mapping[str, Any] | None = None) -> list[Mapping[str, Any]]:
+    del metadata
+    return [
+        {
+            "name": "security-audit",
+            "description": "Run security checks",
+            "prompt": message,
+            "kind": "security",
+            "budget": {"limit": 1.0, "unit": "rounds"},
+            "metadata": {"kind": "security"},
+        },
+        {
+            "name": "respond",
+            "description": "Fallback response",
+            "prompt": message,
+            "budget": {"limit": 1.0, "unit": "rounds"},
+        },
+    ]
+
+
+def test_manager_merges_specialist_outputs() -> None:
+    session = DummySession()
+    captured: list[ManagerStatusUpdate] = []
+    doc_agent = StubDocAgent()
+    manager = ManagerAgent(
+        session=session,
+        status_callback=captured.append,
+        plan_builder=multi_agent_plan,
+        doc_agent=doc_agent,
+    )
+
+    result = manager.run("please update the docs")
+
+    assert result.plan and [task["name"] for task in result.plan] == [
+        "documentation-updates",
+        "respond",
+    ]
+    assert result.response_text.startswith("documentation-updates:")
+    assert "Doc summary" in result.response_text
+    assert session.next_response_text in result.response_text
+    assert result.structured_response is not None
+    parsed_tasks = result.structured_response.parsed.get("tasks", {})
+    assert "documentation-updates" in parsed_tasks
+    assert parsed_tasks["documentation-updates"]["structured_output"]["parsed"] == {
+        "doc": "Doc summary"
+    }
+    assert result.budgets["documentation-updates"].consumed == pytest.approx(1.0)
+    assert result.budgets["respond"].consumed == pytest.approx(1.0)
+    task_output_updates = {update.task for update in captured if update.kind == "task_output"}
+    assert {"documentation-updates", "respond"}.issubset(task_output_updates)
+    evidence = result.evidence.get("documentation-updates")
+    assert evidence is not None and evidence[0].url == "https://example.com/docs"
+
+
+def test_manager_blocks_when_security_fails() -> None:
+    session = DummySession()
+    captured: list[ManagerStatusUpdate] = []
+    security_result = StubSecurityResult(blocked=True, summary="Security blocked")
+    manager = ManagerAgent(
+        session=session,
+        status_callback=captured.append,
+        plan_builder=blocking_security_plan,
+        security_agent=StubSecurityAgent(security_result),
+    )
+
+    result = manager.run("run security scan")
+
+    assert result.plan and [task["name"] for task in result.plan] == [
+        "security-audit",
+        "respond",
+    ]
+    assert result.response_text == "Security blocked"
+    assert result.structured_response is not None
+    assert result.structured_response.schema == {"name": "SecurityScanResult"}
+    assert result.budgets["security-audit"].consumed == pytest.approx(1.0)
+    assert result.budgets["respond"].consumed == pytest.approx(0.0)
+    assert any(update.kind == "security_blocked" for update in captured)
+    task_output_updates = [update for update in captured if update.kind == "task_output"]
+    assert any(update.task == "security-audit" for update in task_output_updates)
+    assert all(update.task != "respond" for update in task_output_updates)
+    assert result.rounds == []


### PR DESCRIPTION
## Summary
- extend the manager plan builder to emit typed specialist tasks with default budgets and research metadata
- collect and aggregate structured outputs per task, sharing evidence from specialist agents and exposing the combined summary
- add integration-style manager tests that simulate documentation and security workflows while stubbing lmstudio dependencies

## Testing
- pytest *(fails: missing optional test dependencies such as numpy)*

------
https://chatgpt.com/codex/tasks/task_b_68e634f274dc832f9145973bb0962d6f