### PR TITLE
Add comprehensive README coverage and dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,143 @@
+# Auto-Coder
+
+<div align="center">
+
+![Python 3.10+](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)
+![Status: Active](https://img.shields.io/badge/Status-Active-brightgreen)
+![Made with ❤️ for Builders](https://img.shields.io/badge/Made%20with-%E2%9D%A4-red)
+
+</div>
+
+> **Auto-Coder** is a multi-agent development companion that coordinates code generation, documentation, testing, and research tasks through LM Studio powered large language models.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Feature Highlights](#feature-highlights)
+- [Architecture at a Glance](#architecture-at-a-glance)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Launch the Interactive Manager](#launch-the-interactive-manager)
+- [Development Workflow](#development-workflow)
+  - [Running Tests](#running-tests)
+  - [Playwright Browser Support](#playwright-browser-support)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Community & Support](#community--support)
+
+---
+
+## Overview
+
+Auto-Coder orchestrates a suite of specialised agents—coding, documentation, dependency management, research, testing, and more—to automate the day-to-day workflows of shipping software. Each agent collaborates through a shared session layer backed by LM Studio's chat runtime, enabling the system to draft plans, execute tool calls, apply diffs, and validate outcomes with minimal human guidance.
+
+The repository includes:
+
+- A production-ready manager agent with live status streaming.
+- Tooling abstractions that expose safe file editing, shell execution, and repository inspection capabilities to language models.
+- Rich documentation for Auto-Coder itself, LM Studio usage patterns, and the LMF2 model family that powers key features.
+
+## Feature Highlights
+
+- **LM Studio Native** – Uses the `lmstudio` Python SDK for chat completions, streaming responses, and schema-constrained outputs.
+- **Composable Tooling** – The `ToolRegistry` makes it trivial to register Python callables as LM Studio tools, complete with discovery helpers for module or package scans.
+- **Deep Agent Catalogue** – Manager, coder, researcher, tester, security, documentation, dependency, and database migration agents ship out of the box, each emitting structured results for downstream orchestration.
+- **Repository Context & RAG** – Built-in repository search, diff summarisation, and web retrieval pipelines keep models grounded in real project state.
+- **Extensible Internals** – Internal libraries such as TTS/STT wrappers, DAG scheduling, and process runners are factored for reuse across custom workloads.
+
+## Architecture at a Glance
+
+| Layer | Responsibilities | Key Modules |
+| --- | --- | --- |
+| Session & Chat | Normalise prompts, stream responses, and manage message history while enforcing optional schemas. | [`chat.py`](./chat.py), [`session.py`](./session.py) |
+| Orchestration | Build multi-agent workflows, surface live status updates, and coordinate retries or plan execution. | [`main.py`](./main.py), [`agents/manager.py`](./agents/manager.py) |
+| Specialised Agents | Apply diffs, generate docs, run tests, manage dependencies, perform research, and more. | [`agents/`](./agents) |
+| Tooling | Register reusable tools, expose safe file/process utilities, and integrate with git/patch flows. | [`tooling.py`](./tooling.py), [`internal/tools`](./internal/tools) |
+| Retrieval & Utilities | Provide repository-aware RAG, structured responses, and speech utilities for future integrations. | [`internal/RAG.py`](./internal/RAG.py), [`internal/schemas.py`](./internal/schemas.py), [`internal/TTS.py`](./internal/TTS.py) |
+
+Dive deeper with the [Auto-Coder documentation set](./docs/autocoder/README.md) for module-by-module references.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10 or newer.
+- [LM Studio](https://lmstudio.ai/) installed locally with at least one model downloaded.
+- (Optional) Node.js 18+ if you plan to work with the bundled Playwright integrations.
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/your-org/auto-coder.git
+cd auto-coder
+
+# Create and activate a virtual environment
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+
+# Install Python dependencies
+pip install -r requirements.txt
+```
+
+### Launch the Interactive Manager
+
+```bash
+python main.py
+```
+
+You will enter an interactive loop; type your request and watch the manager agent coordinate the supporting agents. Use `exit` or `quit` to leave the session.
+
+## Development Workflow
+
+- **Repository Context** – Populate the `agents/repo_context.py` helpers with up-to-date repository information for best results.
+- **Tool Registration** – Attach your own toolsets with `AgentBuilder.with_tools()` or `register_default_toolset()`.
+- **Configuration** – Set environment variables referenced by `internal.RAG.WebRAG` or other modules to customise behaviour (proxies, anonymous browsing, etc.).
+
+### Running Tests
+
+```bash
+pytest
+```
+
+The automated suite exercises agent builders, schema utilities, speech interfaces, and integration helpers. Feel free to augment the suite when extending functionality.
+
+### Playwright Browser Support
+
+Some retrieval flows leverage Playwright for deterministic rendering. After installing Python dependencies, add the browser binaries:
+
+```bash
+playwright install
+```
+
+This unlocks the Playwright-backed search pipeline in `internal/web_playwright.py` and `internal/RAG.py`.
+
+## Documentation
+
+The `docs/` directory houses three complementary knowledge bases:
+
+- [`docs/autocoder`](./docs/autocoder/README.md) – Deep dive into this repository's layout, runtime architecture, agent catalogue, and tests.
+- [`docs/LMStudio`](./docs/LMStudio/index.md) – Tutorials, SDK guides, and API references for LM Studio.
+- [`docs/LMF2`](./docs/LMF2/index.md) – Model cards and usage notes for the Liquid LMF2 family.
+
+A curated overview is available in [`docs/README.md`](./docs/README.md).
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Install dependencies and run the test suite with `pytest`.
+3. Format or lint your changes as appropriate for the touched modules.
+4. Submit a pull request describing the motivation, design, and testing strategy.
+
+When proposing agent or tooling updates, include documentation changes so the knowledge base stays authoritative.
+
+## Community & Support
+
+- File issues or feature requests through the repository's issue tracker.
+- Share reproducible steps and logs when reporting bugs to accelerate triage.
+- Contributions of new agents, tool integrations, or docs are welcome—let us know what you're building!
+
+Happy building! 🚀

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Documentation Hub
+
+Welcome to the central guide for everything packaged under the `docs/` directory. The repository ships three focused knowledge bases that serve different audiences—choose the path that matches the task at hand and follow the cross-links for deeper dives.
+
+## 📚 Section Overview
+
+| Area | Audience | Highlights |
+| --- | --- | --- |
+| [Auto-Coder](./autocoder/README.md) | Contributors building or maintaining this repository. | Repository layout, runtime architecture, agent catalogue, internal libraries, and test strategy. |
+| [LM Studio](./LMStudio/index.md) | Developers embedding LM Studio into products. | Application walkthroughs, REST/SDK references, tool calling guides, and structured output recipes. |
+| [LMF2 Model Family](./LMF2/index.md) | Practitioners deploying Liquid LMF2 models. | Model cards, context limits, licensing details, and download instructions. |
+
+## 🔗 Quick Links
+
+- Browse upcoming enhancements and historical notes inside [`docs/plans/`](./plans).
+- Jump straight to the Auto-Coder runtime deep dive with [`runtime.md`](./autocoder/runtime.md).
+- Need API coverage? Start at [`app/api/`](./LMStudio/app/api/) inside the LM Studio docs for endpoint and tool-call specifics.
+- Looking for evaluation data? Review the [`LMF2-2.6B`](./LMF2/LMF2-2.6B) folder for example prompts and benchmarks.
+
+## ✍️ Contributing to the Docs
+
+1. Edit the Markdown file under the relevant section (Auto-Coder, LM Studio, or LMF2).
+2. Keep links relative so they render correctly both on GitHub and inside static site generators.
+3. Update this hub when you introduce a brand-new section so discoverability stays high.
+
+Clear, concise documentation keeps the agent stack approachable—thanks for helping maintain it!

--- a/docs/autocoder/README.md
+++ b/docs/autocoder/README.md
@@ -1,0 +1,26 @@
+# Auto-Coder Documentation
+
+Welcome to the Auto-Coder documentation set. This hub explains how the repository is organised, how the runtime fits together, and where each specialised agent lives. Use it as your starting point when onboarding, planning refactors, or updating supporting materials.
+
+## 🧭 Quick Index
+
+| Topic | Description |
+| --- | --- |
+| [Directory Overview](./directory-overview.md) | High-level tour of the repository layout and responsibilities of each top-level folder. |
+| [Core Runtime Components](./runtime.md) | Walkthrough of the CLI entry point, chat/session abstractions, tool registry, and other runtime helpers. |
+| [Agents](./agents.md) | Responsibilities, inputs/outputs, and collaborators for every agent implementation in `agents/`. |
+| [Internal Libraries](./internal.md) | Shared building blocks in the `internal/` namespace plus bundled tool implementations. |
+| [Testing Strategy](./testing.md) | Coverage summary for the automated test suite and the behaviours it exercises. |
+
+## 🔄 Keeping Docs Fresh
+
+- Update the relevant page whenever you introduce, rename, or remove a module. That keeps the mental model aligned with the code.
+- When you add a new agent, capture its remit in [`agents.md`](./agents.md) and reference any novel data structures.
+- Use relative links so these files render correctly on GitHub and within static doc tooling.
+
+## 📎 Related Resources
+
+- The repository-wide onboarding guide lives in the [root README](../../README.md).
+- Broader documentation for LM Studio and the LMF2 model family is indexed in the [docs hub](../README.md).
+
+Your future self (and teammates) will thank you for keeping this knowledge base accurate. 🙌

--- a/docs/autocoder/agents.md
+++ b/docs/autocoder/agents.md
@@ -1,0 +1,103 @@
+# Agents
+
+This page catalogues every agent class shipped with Auto-Coder. Each section
+covers the agent's responsibilities, inputs/outputs, and any notable
+collaborators.
+
+## Manager (`agents/manager.py`)
+
+- Orchestrates end-to-end workflows by delegating tasks to specialised agents
+  (coder, documentation, dependency, research, testing, etc.).
+- Tracks per-task budgets via `TaskBudget`, emits human-friendly progress
+  updates through `ManagerStatusUpdate`, and aggregates results in
+  `ManagerResult`.
+- Builds plans (optionally via injected plan builders) and coordinates retries,
+  research evidence, evaluations, and repo context usage.
+
+## Coding (`agents/coder.py`)
+
+- Applies code changes using LM Studio guidance, repository context artefacts,
+  and the `internal.tools.file`/`internal.tools.patch` helpers.
+- Produces `CoderResult` summaries with applied diffs, change summaries, and
+  structured responses, allowing the manager to present diffs or chain follow-up
+  actions.
+- Leverages a `ToolRegistry` to expose safe editing primitives to the model.
+
+## Documentation (`agents/doc.py`)
+
+- Generates README, changelog, and walkthrough updates using repo context and
+  optional research snippets.
+- Outputs rich structures such as `DocumentationSummary`, `ReadmeDraft`,
+  `ChangelogDraft`, and `WalkthroughSection` for downstream rendering.
+
+## Dependency Build (`agents/dependency.py`)
+
+- Uses `RunnerAgent` to execute dependency installation commands, capturing
+  diffs to lockfiles and offering caching hints through
+  `DependencyCacheDirective` objects.
+- Summarises the overall dependency resolution in `DependencyResolution`,
+  including environment notes and follow-up actions.
+
+## Database Migration (`agents/db_migration.py`)
+
+- Coordinates schema migration plans, leverages `RunnerAgent` for command
+  execution, and uses `RepoContextAgent` for migration file discovery.
+- Tracks executed migrations in `MigrationRecord`, `SchemaMigrationPlan`, and
+  `MigrationResult`, with optional ephemeral database specifications.
+
+## Evaluation (`agents/eval.py`)
+
+- Runs prompt regressions or scenario evaluations, optionally parsing YAML specs
+  for evaluation cases.
+- Produces `PromptComparison`, `PromptEvalResult`, and `RegressionSummary`
+  structures to inform the manager about behavioural drift.
+
+## Integrations (`agents/integrations.py`)
+
+- Manages CI/CD pipeline updates, release metadata, and external integration
+  chores.
+- Emits `PipelineUpdateResult` and `CIJobPlan` records describing planned or
+  executed automation steps.
+
+## Repository Context (`agents/repo_context.py`)
+
+- Performs repository searches, symbol extraction, and diff summarisation to
+  provide context for other agents.
+- Wraps git helpers and the `internal.RAG.CodebaseRAG` retriever to surface
+  semantic matches.
+- Returns `RepoSearchResult`, `RepoSymbolResult`, `DiffBundle`, and `DiffFileStat`
+  records for downstream consumers.
+
+## Research (`agents/research.py`)
+
+- Implements higher-level browsing and summarisation on top of
+  `internal.RAG.WebRAG`.
+- Delivers `ResearchSnippet` collections grouped into `ResearchResult`
+  structures for evidence gathering.
+
+## Runner (`agents/runner.py`)
+
+- Encapsulates shell/process execution with timeout handling, working directory
+  resolution, and environment capture.
+- Produces `RunReport` entries with stdout/stderr, exit codes, and timing
+  metadata for reuse by dependency, testing, and security agents.
+
+## Security (`agents/security.py`)
+
+- Drives security scanning toolchains, capturing findings in
+  `SecurityScanFinding` entries and aggregated `SecurityScanReport` results.
+- Supports caching through `SecurityCacheDirective` hints and wraps execution
+  via `RunnerAgent`.
+
+## Testing Critic (`agents/tester.py`)
+
+- Provides quick validation by running targeted test commands or lint checks via
+  `RunnerAgent`.
+- Emits `TestSuiteResult`, `CriticStatusEvent`, and `CriticAnalysis` objects to
+  convey confidence levels and remediation guidance.
+
+## Research & Testing Collaborators
+
+- Multiple agents (coder, doc, manager) accept injected `ResearchAgent` or
+  `TestCriticAgent` instances, enabling richer multi-agent workflows without
+  tight coupling between modules.

--- a/docs/autocoder/directory-overview.md
+++ b/docs/autocoder/directory-overview.md
@@ -1,0 +1,21 @@
+# Directory Overview
+
+The repository is intentionally organized around agent capabilities and shared
+runtime infrastructure. The table below summarises the top-level directories
+and notable standalone modules.
+
+| Path | Description |
+| --- | --- |
+| `agents/` | Collection of domain-specific agent implementations that orchestrate coding, documentation, testing, security review, research, and more. Each module exports the agent class plus result/summary data structures. |
+| `chat.py` | High-level helpers around the LM Studio Python SDK to send prompts, stream responses, and normalise outputs into structured responses. |
+| `session.py` | Defines `AgentSession` and `AgentRound`, wrapping the chat helpers with tool management, callback hooks, and transcript tracking. |
+| `tooling.py` | Implements the tool registry, normalisation logic, and helpers for discovering/validating callables that can be exposed to models. |
+| `main.py` | Command-line entry point that builds the manager agent, renders status updates, and runs an interactive REPL loop. |
+| `TUI.py`, `core.py`, `memory.py` | Reserved placeholders for future terminal UI, application core, and memory subsystems respectively. |
+| `internal/` | Shared libraries used across agents (retrieval, speech, schemas, tool wrappers, web automation, etc.). |
+| `tests/` | Pytest-based regression suite covering agents, toolchains, schema helpers, and speech/retrieval integrations. |
+| `docs/` | Existing documentation space housing LM Studio quick-start notes, plans, and this Auto-Coder reference. |
+| `requirements.txt` | Python package dependencies required to run the agents and tests. |
+| `TODO.md` | High-level backlog or future improvements list. |
+
+Refer to the other documents in this directory for deeper dives into each area.

--- a/docs/autocoder/internal.md
+++ b/docs/autocoder/internal.md
@@ -1,0 +1,61 @@
+# Internal Libraries
+
+The `internal/` package provides reusable building blocks that power multiple
+agents. Key areas include task planning, retrieval-augmented generation,
+schemas, speech interfaces, tool wrappers, and browser automation.
+
+## DAG Execution (`internal/DAG.py`)
+
+- Supplies a general-purpose directed acyclic graph executor with retry,
+  timeout, and context propagation support via `DAG`, `DAGNode`, and helper
+  classes.
+- Enables the manager workflow to model multi-step plans with dependencies and
+  collect structured results from each node.
+
+## Retrieval-Augmented Generation (`internal/RAG.py`)
+
+- Implements both codebase (`CodebaseRAG`) and web (`WebRAG`) retrieval
+  strategies, including tokenisation, chunk ranking, optional Playwright-backed
+  browsing, and web fetch fallbacks.
+- Provides `DocumentChunk` structures and stopword-aware token scoring to power
+  semantic search in repository and online sources.
+
+## Speech Interfaces (`internal/STT.py`, `internal/TTS.py`)
+
+- Wrap speech-to-text (STT) and text-to-speech (TTS) pipelines with optional
+  streaming, batching, and caching primitives.
+- Designed to integrate with LM Studio tool definitions so conversational agents
+  can transcribe audio or generate spoken responses when needed.
+
+## Agent Configuration Helpers (`internal/agents.py`)
+
+- Defines typed containers for LM Studio agent settings (`AgentConfigPayload`,
+  `StructuredResponseSettings`) and utilities to build response format payloads
+  from schemas.
+
+## Schema Utilities (`internal/schemas.py`)
+
+- Offers helpers to construct JSON schema payloads, validate structured
+  responses, and convert between multiple schema representations.
+- Exposes `SchemaError` and `SchemaLike` abstractions shared by chat/session
+  modules.
+
+## Structured Response Wrapper (`internal/structures.py`)
+
+- Provides `StructuredResponse`, a thin wrapper around raw model responses that
+  preserves the original payload while exposing parsed/validated content.
+
+## Tool Wrappers (`internal/tools/`)
+
+- Bundles reusable LM Studio tools for file manipulation, git operations, patch
+  application, planning assistance, process management, and shell execution.
+- Each module exposes callables adhering to the `ToolFunctionDef` protocol so
+  they can be registered with `ToolRegistry` without additional adapters.
+
+## Browser Automation (`internal/web_playwright.py`)
+
+- Supplies a Playwright-backed web client for agents requiring headless browser
+  automation (used by RAG web retrieval when available).
+
+These utilities are intentionally separated from the agent implementations to
+promote reuse and make it easier to test shared behaviour in isolation.

--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -1,0 +1,51 @@
+# Core Runtime Components
+
+## Command-Line Interface (`main.py`)
+
+- Bootstraps an `AgentBuilder` and constructs a `ManagerAgent` with a status
+  callback that prints real-time updates. [`main.py`](../../main.py)
+- Provides an interactive loop that accepts user prompts until `exit`/`quit`
+  are entered, forwarding each message to the manager and rendering any
+  additional status updates before printing the final response. [`main.py`](../../main.py)
+
+## Chat Abstractions (`chat.py`)
+
+- Wraps LM Studio's SDK (`lmstudio.llm`) via `get_model`, returning a handle to
+  the configured model. [`chat.py`](../../chat.py)
+- Normalises prompt inputs through `_prepare_input` so callers can supply plain
+  strings, `lms.Chat` histories, or mapping payloads. [`chat.py`](../../chat.py)
+- Provides `_call_model`, `_extract_text`, and `_coerce_response_mapping` to
+  standardise the various return types produced by the SDK. [`chat.py`](../../chat.py)
+- Implements `ChatSession` to manage conversation history, append tool
+  responses, and issue `respond`/`respond_stream` calls with optional
+  callbacks/tool definitions. [`chat.py`](../../chat.py)
+- Supports structured outputs through `_resolve_response_format` and
+  `StructuredResponse`, enabling schema-guided replies. [`chat.py`](../../chat.py)
+
+## Session Management (`session.py`)
+
+- `AgentSession` builds on `ChatSession`, capturing each round in an
+  `AgentRound` object with transcript, messages, tool history, and metadata.
+  [`session.py`](../../session.py)
+- Exposes hooks (`on_message`, `on_tool_call`, `on_tool_result`, `on_round_start`,
+  `on_round_end`) that external orchestrators can use to observe the workflow.
+  [`session.py`](../../session.py)
+- Provides convenience helpers to mutate tools, append user input, and append
+  tool responses, while keeping callbacks in sync. [`session.py`](../../session.py)
+
+## Tool Registry (`tooling.py`)
+
+- Defines `ToolSpec`, a dataclass capturing tool metadata, callable
+  implementation, and parameters required by LM Studio's tool interface.
+  [`tooling.py`](../../tooling.py)
+- Offers `ToolRegistry` for registering callables, resolving tool references by
+  name, preventing duplicates, and ensuring each tool exposes type annotations
+  and documentation. [`tooling.py`](../../tooling.py)
+- Includes discovery helpers (`discover_module_tools`, `discover_package_tools`)
+  to automatically register tools from modules or packages. [`tooling.py`](../../tooling.py)
+
+## Placeholder Modules
+
+- `core.py`, `memory.py`, and `TUI.py` currently contain module headers only,
+  indicating planned areas for core orchestration, long-term memory, and a
+  terminal UI. [`core.py`](../../core.py), [`memory.py`](../../memory.py), [`TUI.py`](../../TUI.py)

--- a/docs/autocoder/testing.md
+++ b/docs/autocoder/testing.md
@@ -1,0 +1,37 @@
+# Testing Strategy
+
+Automated tests live under `tests/` and are executed with `pytest`. The suite is
+organised by agent or subsystem so failures quickly pinpoint the impacted area.
+
+## Agent Coverage
+
+- `test_manager_agent.py`, `test_manager_research.py`, and `test_agents.py`
+  validate manager orchestration, round tracking, and agent builder utilities.
+- `test_coder_agent.py`, `test_doc_agent.py`, `test_dependency_agent.py`,
+  `test_db_migration_agent.py`, `test_security_agent.py`,
+  `test_integrations_agent.py`, and `test_research_agent.py` exercise the domain
+  agents and their interactions with shared tools.
+- `test_eval_agent.py` covers regression/evaluation workflows and structured
+  summary generation.
+
+## Tooling & Infrastructure
+
+- `test_chat_tools.py`, `test_structures.py`, and `test_schemas.py` ensure the
+  chat/session abstractions, structured response wrappers, and schema utilities
+  behave as expected.
+- `test_rag_web.py` focuses on the RAG web retriever, including fallback
+  behaviour when optional dependencies are unavailable.
+- `test_web_playwright.py` validates the Playwright integration and its
+  resilience to environment quirks.
+
+## Speech Interfaces
+
+- `test_stt.py` and `test_tts.py` cover speech-to-text and text-to-speech helper
+  modules, verifying streaming and configuration pathways.
+
+## Running the Suite
+
+1. Install dependencies from `requirements.txt` (consider using a virtual
+   environment).
+2. Execute `pytest` from the repository root. Individual files can be targeted
+   via `pytest tests/test_coder_agent.py` for quicker iteration.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-playwright>=1.42.0
-numpy>=2.3.0
-psutil>=7.1.0
-transformers>=4.57.0
+lmstudio
+numpy>=1.26
+psutil>=5.9
+transformers>=4.37
+torch>=2.1
+playwright>=1.42
+pytest>=7.4


### PR DESCRIPTION
## Summary
- author a polished repository README with project overview, setup, and contribution guidance
- introduce documentation hub README files for the docs root and Auto-Coder section
- update Python requirements to capture runtime, tooling, and testing dependencies

## Testing
- not run (documentation-focused change)


------
https://chatgpt.com/codex/tasks/task_b_68e65a3989e8832fa61cd0e6102451cf