### PR TITLE
Add Redis-backed short term memory store

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -16,8 +16,21 @@ import json
 import logging
 import math
 import os
+import struct
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import redis  # type: ignore
+    from redis.exceptions import WatchError  # type: ignore
+    try:
+        from redis.commands.search.query import Query  # type: ignore
+    except Exception:  # pragma: no cover - redis search optional
+        Query = None  # type: ignore
+except Exception:  # pragma: no cover - redis optional
+    redis = None  # type: ignore
+    WatchError = RuntimeError  # type: ignore
+    Query = None  # type: ignore
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +61,101 @@ def _as_bool(value: Optional[str]) -> Optional[bool]:
     if value in {"0", "false", "no", "off"}:
         return False
     return None
+
+
+def _datetime_to_str(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _datetime_from_str(value: Optional[str]) -> datetime:
+    if not value:
+        return _utcnow()
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        except (TypeError, ValueError):
+            return _utcnow()
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _metadata_to_dict(metadata: "MemoryMetadata") -> Dict[str, Any]:
+    return {
+        "source": metadata.source,
+        "created_at": _datetime_to_str(metadata.created_at),
+        "updated_at": _datetime_to_str(metadata.updated_at),
+        "ttl_seconds": metadata.ttl_seconds,
+        "tags": list(metadata.tags),
+        "importance": metadata.importance,
+        "embedding_model": metadata.embedding_model,
+        "attributes": dict(metadata.attributes),
+    }
+
+
+def _metadata_from_dict(payload: Mapping[str, Any]) -> "MemoryMetadata":
+    tags_raw = payload.get("tags")
+    if isinstance(tags_raw, str):
+        try:
+            tags_list = list(json.loads(tags_raw))
+        except json.JSONDecodeError:
+            tags_list = [tag.strip() for tag in tags_raw.split(",") if tag.strip()]
+    else:
+        tags_list = list(tags_raw or [])
+
+    attributes_raw = payload.get("attributes", {})
+    if isinstance(attributes_raw, str):
+        try:
+            attributes = dict(json.loads(attributes_raw))
+        except json.JSONDecodeError:
+            attributes = {"raw": attributes_raw}
+    else:
+        attributes = dict(attributes_raw)
+
+    ttl_raw = payload.get("ttl_seconds")
+    ttl_seconds: Optional[int]
+    if ttl_raw in {None, "", "null"}:
+        ttl_seconds = None
+    else:
+        try:
+            ttl_seconds = int(ttl_raw)
+        except (TypeError, ValueError):
+            ttl_seconds = None
+
+    importance_raw = payload.get("importance")
+    if importance_raw in {None, "", "null"}:
+        importance = None
+    else:
+        try:
+            importance = float(importance_raw)
+        except (TypeError, ValueError):
+            importance = None
+
+    embedding_model = payload.get("embedding_model")
+    if embedding_model == "":
+        embedding_model = None
+
+    created_at = _datetime_from_str(str(payload.get("created_at"))) if payload.get("created_at") else _utcnow()
+    updated_at = _datetime_from_str(str(payload.get("updated_at"))) if payload.get("updated_at") else created_at
+
+    return MemoryMetadata(
+        source=str(payload.get("source", "unknown")),
+        created_at=created_at,
+        updated_at=updated_at,
+        ttl_seconds=ttl_seconds,
+        tags=tuple(str(tag) for tag in tags_list),
+        importance=importance,
+        embedding_model=embedding_model,
+        attributes=attributes,
+    )
+
+
+def _pack_embedding(values: Sequence[float]) -> bytes:
+    if not values:
+        return b""
+    return struct.pack(f"{len(values)}f", *values)
 
 
 @dataclass
@@ -144,6 +252,15 @@ class MemoryRecord:
         """Return a shallow copy of the record with an updated score."""
 
         return replace(self, score=score)
+
+
+@dataclass
+class _RedisRecordState:
+    record: MemoryRecord
+    session_id: Optional[str]
+    agent_id: Optional[str]
+    tags: Tuple[str, ...]
+    deleted: bool = False
 
 
 @dataclass
@@ -353,24 +470,566 @@ class InMemoryMemoryStore(MemoryStore):
         return numerator / (denom_a * denom_b)
 
 
-class RedisMemoryStore(InMemoryMemoryStore):
-    """Placeholder Redis-backed store.
-
-    The implementation currently falls back to the in-memory behaviour while we
-    design persistence.  Configuration metadata is still captured so that the
-    store can later be swapped with a real Redis-backed implementation without
-    changing callers.
-    """
+class ShortTermMemoryStore(MemoryStore):
+    """Redis-backed short term memory store leveraging hashes and sorted sets."""
 
     backend_name = "redis"
 
-    def __init__(self, config: "StoreConfig") -> None:
-        super().__init__(
-            default_ttl=config.ttl_seconds,
-            compaction_threshold=config.compaction_threshold,
-            embedding_model=config.embedding_model,
-        )
+    def __init__(
+        self,
+        config: "StoreConfig",
+        *,
+        redis_client: Optional["redis.Redis"] = None,
+    ) -> None:
+        if redis is None:  # pragma: no cover - requires redis dependency at runtime
+            raise RuntimeError(
+                "Redis backend requested but redis-py is not installed. Install 'redis' to enable the short-term store."
+            )
+
         self.config = config
+        settings = config.redis or RedisSettings()
+        self._client = redis_client or self._create_client(settings)
+
+        self._default_ttl = self._coerce_int(config.ttl_seconds)
+        self._embedding_model = config.embedding_model
+
+        options = dict(config.options)
+        namespace = options.get("namespace") or f"memory:{config.scope}"
+        self._namespace = namespace.rstrip(":")
+        self._session_ttl = self._coerce_int(options.get("session_ttl"))
+        if self._session_ttl is None:
+            self._session_ttl = self._default_ttl
+        self._vector_index_name = options.get("vector_index") or options.get("redis_vector_index")
+        self._supports_vector = bool(self._vector_index_name and Query is not None and hasattr(self._client, "ft"))
+
+    # ------------------------------------------------------------------
+    # MemoryStore interface
+    # ------------------------------------------------------------------
+
+    def add(self, record: MemoryRecord) -> MemoryRecord:
+        record = self._prepare_record(record)
+        return self._upsert(record)
+
+    def update(
+        self,
+        record_id: str,
+        *,
+        content: Optional[str] = None,
+        metadata: Optional[MemoryMetadata] = None,
+        embedding: Optional[Sequence[float]] = None,
+        score: Optional[float] = None,
+    ) -> MemoryRecord:
+        state = self._load_state(record_id, include_deleted=True)
+        if state is None:
+            raise KeyError(f"Memory record '{record_id}' does not exist")
+
+        record = state.record
+        if content is not None:
+            record = replace(record, content=content)
+        if metadata is not None:
+            record = replace(record, metadata=metadata)
+        if embedding is not None:
+            record = replace(record, embedding=list(embedding))
+        if score is not None:
+            record = replace(record, score=score)
+
+        record = self._prepare_record(record)
+        return self._upsert(record)
+
+    def delete(self, record_id: str) -> None:
+        self.soft_delete(record_id)
+
+    def fetch(self, query: MemoryQuery) -> List[MemoryRecord]:
+        if query.embedding:
+            vector_hits = self._vector_search(query.embedding, max(query.limit, 1))
+            if vector_hits is not None:
+                ordered_ids = [hit[0] for hit in vector_hits]
+                states = self._load_states(ordered_ids)
+                results: List[Tuple[float, MemoryRecord]] = []
+                for state in states:
+                    if not state.record.metadata.matches(query.metadata_filters):
+                        continue
+                    score = InMemoryMemoryStore._score_record(state.record, query)
+                    if query.min_score is not None and (score is None or score < query.min_score):
+                        continue
+                    results.append((score or 0.0, state.record.with_score(score)))
+                results.sort(key=lambda item: item[0], reverse=True)
+                return [record for _, record in results[: query.limit]]
+
+        filters = query.metadata_filters
+        session_filter = filters.get("session_id") or filters.get("session")
+        agent_filter = filters.get("agent_id") or filters.get("agent")
+        tags_filter = filters.get("tags")
+
+        ordered_ids, _ = self._candidate_record_ids(session_filter, agent_filter, tags_filter)
+        if not ordered_ids and not (session_filter or agent_filter or tags_filter):
+            ordered_ids, _ = self._candidate_record_ids(None, None, None)
+
+        states = self._load_states(ordered_ids)
+        results: List[Tuple[float, MemoryRecord]] = []
+        for state in states:
+            if not state.record.metadata.matches(filters):
+                continue
+            score = InMemoryMemoryStore._score_record(state.record, query)
+            if query.min_score is not None and (score is None or score < query.min_score):
+                continue
+            results.append((score or 0.0, state.record.with_score(score)))
+
+        results.sort(key=lambda item: item[0], reverse=True)
+        limited = [record for _, record in results[: max(0, query.limit)]]
+        return limited
+
+    def compact(self) -> None:
+        if redis is None:  # pragma: no cover - defensive
+            return
+        for key in self._client.scan_iter(match=f"{self._namespace}:record:*", count=500):
+            record_id = self._record_id_from_key(key)
+            state = self._load_state(record_id, include_deleted=True)
+            if state is None:
+                continue
+            if state.deleted or state.record.metadata.is_expired():
+                self._purge_record(record_id, state)
+
+    # ------------------------------------------------------------------
+    # Extended operations for Redis-backed store
+    # ------------------------------------------------------------------
+
+    def soft_delete(self, record_id: str) -> None:
+        if redis is None:  # pragma: no cover
+            return
+        record_key = self._record_key(record_id)
+        while True:
+            try:
+                with self._client.pipeline() as pipe:
+                    pipe.watch(record_key)
+                    raw = pipe.hgetall(record_key)
+                    if not raw:
+                        pipe.unwatch()
+                        return
+                    data = self._decode_hash(raw)
+                    state = self._state_from_data(record_id, data)
+                    if state is None:
+                        pipe.unwatch()
+                        return
+                    pipe.multi()
+                    pipe.hset(record_key, mapping={"deleted": "1"})
+                    if state.session_id:
+                        pipe.zrem(self._session_key(state.session_id), record_id)
+                    if state.agent_id:
+                        pipe.srem(self._agent_key(state.agent_id), record_id)
+                    for tag in state.tags:
+                        pipe.srem(self._tag_key(tag), record_id)
+                    pipe.execute()
+                    break
+            except WatchError:  # pragma: no cover - retry on contention
+                continue
+
+    def refresh_ttl(self, record_id: str, ttl_seconds: Optional[int] = None) -> None:
+        state = self._load_state(record_id, include_deleted=True)
+        if state is None:
+            return
+        ttl = self._coerce_int(ttl_seconds) or state.record.metadata.ttl_seconds or self._default_ttl
+        if ttl is None:
+            return
+        session_ttl = self._session_ttl or ttl
+        with self._client.pipeline() as pipe:
+            pipe.expire(self._record_key(record_id), ttl)
+            if state.session_id:
+                pipe.expire(self._session_key(state.session_id), session_ttl)
+            if state.agent_id:
+                pipe.expire(self._agent_key(state.agent_id), ttl)
+            for tag in state.tags:
+                pipe.expire(self._tag_key(tag), ttl)
+            pipe.execute()
+
+    def list_entries(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        tags: Optional[Iterable[str]] = None,
+        limit: Optional[int] = None,
+        include_deleted: bool = False,
+    ) -> List[MemoryRecord]:
+        ordered_ids, _ = self._candidate_record_ids(session_id, agent_id, tags)
+        states = self._load_states(ordered_ids, include_deleted=include_deleted)
+        states.sort(key=lambda item: item.record.metadata.updated_at, reverse=True)
+        if limit is not None:
+            states = states[:limit]
+        return [state.record for state in states]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _prepare_record(self, record: MemoryRecord) -> MemoryRecord:
+        metadata = replace(
+            record.metadata,
+            tags=tuple(record.metadata.tags),
+            attributes=dict(record.metadata.attributes),
+        )
+        if metadata.ttl_seconds is None and self._default_ttl is not None:
+            metadata.ttl_seconds = self._default_ttl
+        if metadata.embedding_model is None:
+            metadata.embedding_model = self._embedding_model
+        metadata.touch()
+        embedding = list(record.embedding) if record.embedding is not None else None
+        return replace(record, metadata=metadata, embedding=embedding)
+
+    def _upsert(self, record: MemoryRecord) -> MemoryRecord:
+        record_key = self._record_key(record.record_id)
+        session_id = self._extract_session_id(record.metadata)
+        agent_id = self._extract_agent_id(record.metadata)
+        tags = tuple(str(tag) for tag in record.metadata.tags)
+        mapping = self._serialize_record(record, session_id, agent_id)
+        ttl_seconds = record.metadata.ttl_seconds or self._default_ttl
+        session_ttl = self._session_ttl or ttl_seconds
+
+        while True:
+            try:
+                with self._client.pipeline() as pipe:
+                    pipe.watch(record_key)
+                    raw = pipe.hgetall(record_key)
+                    previous = None
+                    if raw:
+                        previous = self._state_from_data(record.record_id, self._decode_hash(raw))
+                    pipe.multi()
+                    pipe.hset(record_key, mapping=mapping)
+                    if record.embedding is None:
+                        pipe.hdel(record_key, "embedding", "embedding_blob", "embedding_dim")
+                    if ttl_seconds:
+                        pipe.expire(record_key, ttl_seconds)
+                    if session_id:
+                        session_key = self._session_key(session_id)
+                        pipe.zadd(session_key, {record.record_id: record.metadata.updated_at.timestamp()})
+                        if session_ttl:
+                            pipe.expire(session_key, session_ttl)
+                    if agent_id:
+                        agent_key = self._agent_key(agent_id)
+                        pipe.sadd(agent_key, record.record_id)
+                        if ttl_seconds:
+                            pipe.expire(agent_key, ttl_seconds)
+                    for tag in tags:
+                        tag_key = self._tag_key(tag)
+                        pipe.sadd(tag_key, record.record_id)
+                        if ttl_seconds:
+                            pipe.expire(tag_key, ttl_seconds)
+                    if previous is not None:
+                        self._remove_stale_indexes(pipe, record.record_id, previous, session_id, agent_id, tags)
+                    pipe.execute()
+                    break
+            except WatchError:  # pragma: no cover - retry on contention
+                continue
+
+        return record
+
+    def _remove_stale_indexes(
+        self,
+        pipe: "redis.client.Pipeline",
+        record_id: str,
+        previous: _RedisRecordState,
+        session_id: Optional[str],
+        agent_id: Optional[str],
+        tags: Tuple[str, ...],
+    ) -> None:
+        if previous.session_id and previous.session_id != session_id:
+            pipe.zrem(self._session_key(previous.session_id), record_id)
+        if previous.agent_id and previous.agent_id != agent_id:
+            pipe.srem(self._agent_key(previous.agent_id), record_id)
+        previous_tags = set(previous.tags)
+        for tag in previous_tags - set(tags):
+            pipe.srem(self._tag_key(tag), record_id)
+
+    def _serialize_record(
+        self,
+        record: MemoryRecord,
+        session_id: Optional[str],
+        agent_id: Optional[str],
+    ) -> Dict[str, Any]:
+        metadata_dict = _metadata_to_dict(record.metadata)
+        payload: Dict[str, Any] = {
+            "record_id": record.record_id,
+            "content": record.content,
+            "metadata": json.dumps(metadata_dict),
+            "score": "" if record.score is None else json.dumps(record.score),
+            "session_id": session_id or "",
+            "agent_id": agent_id or "",
+            "tags": json.dumps(list(record.metadata.tags)),
+            "deleted": "0",
+        }
+        if record.embedding is not None:
+            payload["embedding"] = json.dumps(list(record.embedding))
+            payload["embedding_dim"] = str(len(record.embedding))
+            payload["embedding_blob"] = _pack_embedding(record.embedding)
+        return payload
+
+    def _vector_search(self, embedding: Sequence[float], limit: int) -> Optional[List[Tuple[str, Optional[float]]]]:
+        if not self._supports_vector or not embedding:
+            return None
+        try:  # pragma: no cover - requires redis search module
+            search = self._client.ft(self._vector_index_name)
+        except Exception:
+            LOGGER.debug("Redis vector index '%s' is unavailable", self._vector_index_name, exc_info=True)
+            return None
+        if Query is None:
+            return None
+        try:
+            blob = _pack_embedding(embedding)
+            query = (
+                Query(f"*=>[KNN {max(limit, 1)} @embedding_blob $vec AS score]")
+                .sort_by("score")
+                .paging(0, max(limit, 1))
+                .return_fields("__key", "score")
+                .dialect(2)
+            )
+            results = search.search(query, query_params={"vec": blob})
+        except Exception:
+            LOGGER.debug("Vector search failed on index '%s'", self._vector_index_name, exc_info=True)
+            return None
+        hits: List[Tuple[str, Optional[float]]] = []
+        docs = getattr(results, "docs", None)
+        if not docs:
+            return []
+        for doc in docs:
+            record_id = getattr(doc, "id", None) or getattr(doc, "__key", None)
+            if record_id is None:
+                continue
+            record_id = self._record_id_from_key(record_id)
+            score_value = getattr(doc, "score", None)
+            try:
+                score_float = float(score_value) if score_value is not None else None
+            except (TypeError, ValueError):
+                score_float = None
+            hits.append((record_id, score_float))
+        return hits
+
+    def _candidate_record_ids(
+        self,
+        session_id: Optional[str],
+        agent_id: Optional[str],
+        tags: Optional[Iterable[str]],
+    ) -> Tuple[List[str], Set[str]]:
+        ordered: List[str] = []
+        candidates: Optional[Set[str]] = None
+
+        if session_id:
+            session_key = self._session_key(str(session_id))
+            ordered_bytes = self._client.zrevrange(session_key, 0, -1)
+            ordered = [self._ensure_str(item) for item in ordered_bytes]
+            candidates = set(ordered)
+
+        if agent_id:
+            agent_members = {self._ensure_str(item) for item in self._client.smembers(self._agent_key(str(agent_id)))}
+            candidates = agent_members if candidates is None else candidates & agent_members
+
+        if tags:
+            tag_values: List[str]
+            if isinstance(tags, str):
+                tag_values = [tags]
+            else:
+                try:
+                    tag_values = [str(tag) for tag in tags]
+                except TypeError:
+                    tag_values = [str(tags)]
+            for tag in tag_values:
+                tag_members = {self._ensure_str(item) for item in self._client.smembers(self._tag_key(tag))}
+                candidates = tag_members if candidates is None else candidates & tag_members
+
+        if candidates is None:
+            candidates = set()
+            ordered = []
+            for key in self._client.scan_iter(match=f"{self._namespace}:record:*", count=500):
+                record_id = self._record_id_from_key(key)
+                candidates.add(record_id)
+                ordered.append(record_id)
+        elif not ordered:
+            ordered = sorted(candidates)
+        else:
+            ordered = [record_id for record_id in ordered if record_id in candidates]
+
+        return ordered, candidates
+
+    def _load_state(self, record_id: str, *, include_deleted: bool = False) -> Optional[_RedisRecordState]:
+        raw = self._client.hgetall(self._record_key(record_id))
+        if not raw:
+            return None
+        state = self._state_from_data(record_id, self._decode_hash(raw))
+        if state is None:
+            return None
+        if state.record.metadata.is_expired():
+            self._purge_record(record_id, state)
+            return None
+        if state.deleted and not include_deleted:
+            return None
+        return state
+
+    def _load_states(
+        self,
+        record_ids: Sequence[str],
+        *,
+        include_deleted: bool = False,
+    ) -> List[_RedisRecordState]:
+        ids = list(record_ids)
+        if not ids:
+            return []
+        pipe = self._client.pipeline()
+        for record_id in ids:
+            pipe.hgetall(self._record_key(record_id))
+        raw_results = pipe.execute()
+        now = _utcnow()
+        states: List[_RedisRecordState] = []
+        for record_id, raw in zip(ids, raw_results):
+            if not raw:
+                continue
+            state = self._state_from_data(record_id, self._decode_hash(raw))
+            if state is None:
+                continue
+            if state.record.metadata.is_expired(now):
+                self._purge_record(record_id, state)
+                continue
+            if state.deleted and not include_deleted:
+                continue
+            states.append(state)
+        return states
+
+    def _state_from_data(self, record_id: str, data: Mapping[str, Any]) -> Optional[_RedisRecordState]:
+        if not data:
+            return None
+        metadata_raw = data.get("metadata")
+        try:
+            metadata_payload = json.loads(metadata_raw) if metadata_raw else {}
+        except (TypeError, json.JSONDecodeError):
+            metadata_payload = {}
+        metadata = _metadata_from_dict(metadata_payload)
+        if metadata.embedding_model is None:
+            metadata.embedding_model = self._embedding_model
+        embedding_json = data.get("embedding")
+        embedding: Optional[List[float]] = None
+        if embedding_json not in (None, "", "null"):
+            try:
+                embedding = list(json.loads(embedding_json))
+            except json.JSONDecodeError:
+                embedding = None
+        score_raw = data.get("score")
+        score: Optional[float]
+        if score_raw in (None, "", "null"):
+            score = None
+        else:
+            try:
+                score = float(score_raw)
+            except (TypeError, ValueError):
+                score = None
+        record = MemoryRecord(
+            content=str(data.get("content", "")),
+            metadata=metadata,
+            embedding=embedding,
+            score=score,
+            record_id=record_id,
+        )
+        deleted = str(data.get("deleted", "0")) == "1"
+        session_id = data.get("session_id") or metadata.attributes.get("session_id") or metadata.attributes.get("session")
+        agent_id = data.get("agent_id") or metadata.attributes.get("agent_id") or metadata.attributes.get("agent")
+        tags = tuple(str(tag) for tag in metadata.tags)
+        return _RedisRecordState(
+            record=record,
+            session_id=str(session_id) if session_id else None,
+            agent_id=str(agent_id) if agent_id else None,
+            tags=tags,
+            deleted=deleted,
+        )
+
+    def _purge_record(self, record_id: str, state: _RedisRecordState) -> None:
+        with self._client.pipeline() as pipe:
+            pipe.delete(self._record_key(record_id))
+            if state.session_id:
+                pipe.zrem(self._session_key(state.session_id), record_id)
+            if state.agent_id:
+                pipe.srem(self._agent_key(state.agent_id), record_id)
+            for tag in state.tags:
+                pipe.srem(self._tag_key(tag), record_id)
+            pipe.execute()
+
+    def _decode_hash(self, raw: Mapping[Any, Any]) -> Dict[str, Any]:
+        decoded: Dict[str, Any] = {}
+        for key, value in raw.items():
+            field = self._ensure_str(key)
+            if isinstance(value, (bytes, bytearray)):
+                if field == "embedding_blob":
+                    decoded[field] = bytes(value)
+                else:
+                    decoded[field] = value.decode()
+            else:
+                decoded[field] = value
+        return decoded
+
+    def _record_key(self, record_id: str) -> str:
+        return f"{self._namespace}:record:{record_id}"
+
+    def _session_key(self, session_id: str) -> str:
+        return f"{self._namespace}:session:{session_id}"
+
+    def _agent_key(self, agent_id: str) -> str:
+        return f"{self._namespace}:agent:{agent_id}"
+
+    def _tag_key(self, tag: str) -> str:
+        return f"{self._namespace}:tag:{tag}"
+
+    @staticmethod
+    def _ensure_str(value: Any) -> str:
+        if isinstance(value, (bytes, bytearray)):
+            return value.decode()
+        return str(value)
+
+    def _record_id_from_key(self, key: Any) -> str:
+        identifier = self._ensure_str(key)
+        if ":" in identifier:
+            return identifier.rsplit(":", 1)[-1]
+        return identifier
+
+    @staticmethod
+    def _extract_session_id(metadata: MemoryMetadata) -> Optional[str]:
+        for candidate in ("session_id", "session", "conversation_id"):
+            value = metadata.attributes.get(candidate)
+            if value:
+                return str(value)
+        return None
+
+    @staticmethod
+    def _extract_agent_id(metadata: MemoryMetadata) -> Optional[str]:
+        for candidate in ("agent_id", "agent", "assistant_id"):
+            value = metadata.attributes.get(candidate)
+            if value:
+                return str(value)
+        return None
+
+    @staticmethod
+    def _coerce_int(value: Optional[Any]) -> Optional[int]:
+        if value in (None, "", "null"):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _create_client(settings: RedisSettings) -> "redis.Redis":
+        kwargs = dict(settings.options)
+        if settings.url:
+            return redis.Redis.from_url(settings.url, decode_responses=False, **kwargs)
+        if settings.username is not None:
+            kwargs["username"] = settings.username
+        if settings.password is not None:
+            kwargs["password"] = settings.password
+        kwargs.setdefault("host", settings.host)
+        kwargs.setdefault("port", settings.port)
+        kwargs.setdefault("db", settings.db)
+        if settings.ssl is not None:
+            kwargs["ssl"] = settings.ssl
+        return redis.Redis(**kwargs)
+
+
+class RedisMemoryStore(ShortTermMemoryStore):
+    """Backward compatible alias for the Redis-backed store."""
 
 
 class PostgresMemoryStore(InMemoryMemoryStore):
@@ -785,6 +1444,16 @@ def build_memory_store(config: StoreConfig) -> MemoryStore:
         if config.redis is None:
             LOGGER.warning("Redis backend selected for %s but no connection details provided; using defaults", config.scope)
             config.redis = RedisSettings()
+        if redis is None:
+            LOGGER.warning(
+                "Redis backend selected for %s but redis-py is not installed; falling back to in-memory store",
+                config.scope,
+            )
+            return InMemoryMemoryStore(
+                default_ttl=config.ttl_seconds,
+                compaction_threshold=config.compaction_threshold,
+                embedding_model=config.embedding_model,
+            )
         return RedisMemoryStore(config)
     if backend in {"postgres", "postgresql"}:
         if config.postgres is None:


### PR DESCRIPTION
## Summary
- add a Redis-powered `ShortTermMemoryStore` that persists records with sorted-set and hash indexes and supports TTL refresh, soft deletes, and tag/session filters
- provide serialization helpers for `MemoryRecord` metadata and keep a backwards-compatible `RedisMemoryStore` alias
- fall back to the in-memory store when the Redis client library is unavailable

## Testing
- pytest *(fails: missing optional dependency `numpy` required by audio tests)*

------
https://chatgpt.com/codex/tasks/task_b_68e6c0b14dc8832f9f4fc34e536d878e