### PR TITLE
Add hybrid memory retrieval with automatic embeddings

### DIFF
--- a/internal/memory_rag.py
+++ b/internal/memory_rag.py
@@ -1,0 +1,445 @@
+"""Hybrid memory retrieval utilities combining vector and keyword search."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+import math
+import os
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .RAG import _HybridRanker, _Tokenizer, _DEFAULT_STOPWORDS
+from memory import (
+    MemoryQuery,
+    MemoryRecord,
+    MemoryStore,
+    MemoryMetadata,
+    resolve_embedding_provider,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _coerce_embedding(values: Any) -> List[float]:
+    if values is None:
+        return []
+    if isinstance(values, Mapping):
+        for key in ("embedding", "vector", "values", "data"):
+            if key in values:
+                return _coerce_embedding(values[key])
+        return []
+    if hasattr(values, "embedding"):
+        return _coerce_embedding(getattr(values, "embedding"))
+    if hasattr(values, "tolist") and callable(values.tolist):  # pragma: no cover - numpy arrays
+        return _coerce_embedding(values.tolist())
+    if isinstance(values, str):
+        try:
+            import json
+
+            return _coerce_embedding(json.loads(values))
+        except Exception:  # pragma: no cover - defensive parsing
+            return []
+    if isinstance(values, Sequence) and not isinstance(values, (bytes, bytearray, str)):
+        try:
+            return [float(item) for item in values]
+        except (TypeError, ValueError):
+            return []
+    try:
+        return [float(values)]
+    except (TypeError, ValueError):
+        return []
+
+
+def _clamp01(value: float) -> float:
+    if value <= 0.0:
+        return 0.0
+    if value >= 1.0:
+        return 1.0
+    return value
+
+
+def _cosine_similarity(vec_a: Sequence[float], vec_b: Sequence[float]) -> float:
+    if len(vec_a) != len(vec_b) or not vec_a:
+        return 0.0
+    numerator = sum(a * b for a, b in zip(vec_a, vec_b))
+    denom_a = math.sqrt(sum(a * a for a in vec_a))
+    denom_b = math.sqrt(sum(b * b for b in vec_b))
+    if denom_a == 0.0 or denom_b == 0.0:
+        return 0.0
+    return numerator / (denom_a * denom_b)
+
+
+@dataclass(slots=True)
+class MemoryRetrievalConfig:
+    """Tunable parameters that control hybrid memory retrieval."""
+
+    short_term_top_k: int = 6
+    long_term_top_k: int = 12
+    combined_top_k: int = 8
+    max_results: int = 20
+    embedding_weight: float = 0.6
+    keyword_weight: float = 0.4
+    hybrid_alpha: float = 0.6
+    freshness_weight: float = 0.1
+    freshness_halflife_hours: float = 24.0
+    short_term_weight: float = 1.1
+    long_term_weight: float = 1.0
+    combined_weight: float = 1.0
+    include_combined: bool = False
+
+    @classmethod
+    def from_env(cls, prefix: str = "MEMORY_RAG_") -> "MemoryRetrievalConfig":
+        mapping: Dict[str, Tuple[str, Any]] = {
+            "short_term_top_k": ("SHORT_TERM_TOP_K", int),
+            "long_term_top_k": ("LONG_TERM_TOP_K", int),
+            "combined_top_k": ("COMBINED_TOP_K", int),
+            "max_results": ("MAX_RESULTS", int),
+            "embedding_weight": ("EMBEDDING_WEIGHT", float),
+            "keyword_weight": ("KEYWORD_WEIGHT", float),
+            "hybrid_alpha": ("HYBRID_ALPHA", float),
+            "freshness_weight": ("FRESHNESS_WEIGHT", float),
+            "freshness_halflife_hours": ("FRESHNESS_HALFLIFE_HOURS", float),
+            "short_term_weight": ("SHORT_TERM_WEIGHT", float),
+            "long_term_weight": ("LONG_TERM_WEIGHT", float),
+            "combined_weight": ("COMBINED_WEIGHT", float),
+        }
+        overrides: Dict[str, Any] = {}
+        for field_name, (suffix, caster) in mapping.items():
+            value = os.getenv(f"{prefix}{suffix}")
+            if value is None:
+                continue
+            try:
+                overrides[field_name] = caster(value)
+            except (TypeError, ValueError):
+                LOGGER.debug("Ignoring invalid value for %s%s", prefix, suffix, exc_info=True)
+        include_combined = os.getenv(f"{prefix}INCLUDE_COMBINED")
+        if include_combined is not None:
+            overrides["include_combined"] = include_combined.strip().lower() in {"1", "true", "yes", "on"}
+        return cls(**overrides)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "short_term_top_k": self.short_term_top_k,
+            "long_term_top_k": self.long_term_top_k,
+            "combined_top_k": self.combined_top_k,
+            "max_results": self.max_results,
+            "embedding_weight": self.embedding_weight,
+            "keyword_weight": self.keyword_weight,
+            "hybrid_alpha": self.hybrid_alpha,
+            "freshness_weight": self.freshness_weight,
+            "freshness_halflife_hours": self.freshness_halflife_hours,
+            "short_term_weight": self.short_term_weight,
+            "long_term_weight": self.long_term_weight,
+            "combined_weight": self.combined_weight,
+            "include_combined": self.include_combined,
+        }
+
+
+@dataclass(slots=True)
+class MemoryHit:
+    """Container for ranked memory results returned by :class:`MemoryRAG`."""
+
+    record: MemoryRecord
+    scope: str
+    backend: str
+    score: float
+    embedding_score: float
+    keyword_score: float
+    embedding_raw: float
+    keyword_raw: float
+    freshness_boost: float
+
+    @property
+    def content(self) -> str:
+        return self.record.content
+
+    @property
+    def metadata(self) -> MemoryMetadata:
+        return self.record.metadata
+
+    @property
+    def provenance(self) -> Dict[str, Any]:
+        metadata = self.record.metadata
+        return {
+            "record_id": self.record.record_id,
+            "scope": self.scope,
+            "backend": self.backend,
+            "source": metadata.source,
+            "updated_at": metadata.updated_at.astimezone(timezone.utc).isoformat(),
+            "tags": list(metadata.tags),
+            "embedding_model": metadata.embedding_model,
+            "embedding_score": self.embedding_score,
+            "keyword_score": self.keyword_score,
+            "embedding_raw": self.embedding_raw,
+            "keyword_raw": self.keyword_raw,
+            "freshness_boost": self.freshness_boost,
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "content": self.content,
+            "score": self.score,
+            "record_id": self.record.record_id,
+            "metadata": self.record.metadata,
+            "provenance": self.provenance,
+        }
+
+
+@dataclass(slots=True)
+class _StoreCandidate:
+    scope: str
+    backend: str
+    record: MemoryRecord
+
+
+class MemoryRAG:
+    """Compose multiple memory stores into a hybrid retrieval pipeline."""
+
+    def __init__(
+        self,
+        *,
+        short_term: Optional[MemoryStore] = None,
+        long_term: Optional[MemoryStore] = None,
+        combined: Optional[MemoryStore] = None,
+        config: Optional[MemoryRetrievalConfig] = None,
+        embedder: Optional[Callable[[str], Sequence[float]]] = None,
+        embedding_model: Optional[str] = None,
+    ) -> None:
+        stores: Dict[str, MemoryStore] = {}
+        if short_term is not None:
+            stores["short_term"] = short_term
+        if long_term is not None:
+            stores["long_term"] = long_term
+        if combined is not None:
+            stores["combined"] = combined
+        if not stores:
+            raise ValueError("MemoryRAG requires at least one memory store")
+        self._stores = stores
+        self.config = config or MemoryRetrievalConfig.from_env()
+        self._tokenizer = _Tokenizer(_DEFAULT_STOPWORDS)
+        self._embedder, resolved_name = self._resolve_embedder(embedder, embedding_model)
+        self._embedding_model_name = resolved_name or embedding_model
+        total_weight = float(self.config.embedding_weight + self.config.keyword_weight)
+        if total_weight <= 0:
+            self._embedding_factor = 0.0
+            self._keyword_factor = 0.0
+            self._has_weight_signal = False
+        else:
+            self._embedding_factor = float(self.config.embedding_weight) / total_weight
+            self._keyword_factor = float(self.config.keyword_weight) / total_weight
+            self._has_weight_signal = True
+
+    def query_memory(
+        self,
+        text: str,
+        *,
+        metadata_filters: Optional[Mapping[str, Any]] = None,
+        limit: Optional[int] = None,
+        stream: bool = False,
+        embedding: Optional[Sequence[float]] = None,
+    ) -> Iterable[MemoryHit]:
+        """Return ranked memory chunks for ``text`` enriched with provenance."""
+
+        limit_value = max(1, int(limit or self.config.max_results))
+        query_embedding = self._normalize_embedding(embedding)
+        if query_embedding is None:
+            query_embedding = self._embed_query(text)
+        per_store_limits = self._per_store_limits(limit_value)
+        filters = dict(metadata_filters or {})
+        candidates: List[_StoreCandidate] = []
+        for scope, store in self._stores.items():
+            store_limit = per_store_limits.get(scope, 0)
+            if store_limit <= 0:
+                continue
+            try:
+                records = store.fetch(
+                    MemoryQuery(
+                        text=text,
+                        embedding=query_embedding,
+                        limit=store_limit,
+                        metadata_filters=dict(filters),
+                    )
+                )
+            except Exception:  # pragma: no cover - store-specific runtime errors
+                LOGGER.warning("Memory store '%s' failed to fetch candidates", scope, exc_info=True)
+                continue
+            backend_name = getattr(store, "backend_name", store.__class__.__name__)
+            for record in records:
+                candidates.append(_StoreCandidate(scope=scope, backend=backend_name, record=record))
+
+        if not candidates:
+            return []
+
+        query_tokens = self._tokenizer.tokenize(text)
+        doc_tokens = [self._tokenizer.tokenize(candidate.record.content) for candidate in candidates]
+        keyword_scores: Dict[int, float] = {}
+        if query_tokens and doc_tokens:
+            ranker = _HybridRanker(doc_tokens)
+            keyword_scores = dict(ranker.topk(query_tokens, len(doc_tokens), alpha=self.config.hybrid_alpha))
+
+        embedding_scores: Dict[int, float] = {}
+        if query_embedding is not None:
+            for idx, candidate in enumerate(candidates):
+                if candidate.record.embedding:
+                    embedding_scores[idx] = _cosine_similarity(query_embedding, candidate.record.embedding)
+        for idx, candidate in enumerate(candidates):
+            if idx in embedding_scores:
+                continue
+            if candidate.record.score is None:
+                continue
+            try:
+                embedding_scores[idx] = float(candidate.record.score)
+            except (TypeError, ValueError):
+                continue
+
+        max_keyword = max(keyword_scores.values(), default=0.0)
+        embed_values = list(embedding_scores.values())
+        embed_min = min(embed_values, default=0.0)
+        embed_max = max(embed_values, default=0.0)
+        embed_range = embed_max - embed_min
+
+        def normalize_keyword(raw: float) -> float:
+            if max_keyword <= 0.0:
+                return 0.0
+            return _clamp01(raw / max_keyword)
+
+        def normalize_embedding(raw: float) -> float:
+            if not embed_values:
+                return 0.0
+            if embed_range <= 1e-6:
+                if embed_min < 0.0 or embed_max > 1.0:
+                    return _clamp01((raw + 1.0) / 2.0)
+                return _clamp01(raw)
+            return _clamp01((raw - embed_min) / embed_range)
+
+        now = datetime.now(timezone.utc)
+        hits: List[MemoryHit] = []
+        for idx, candidate in enumerate(candidates):
+            keyword_raw = keyword_scores.get(idx, 0.0)
+            embedding_raw = embedding_scores.get(idx, 0.0)
+            keyword_signal = normalize_keyword(keyword_raw)
+            embedding_signal = normalize_embedding(embedding_raw)
+            combined = 0.0
+            if self._has_weight_signal:
+                combined = (embedding_signal * self._embedding_factor) + (
+                    keyword_signal * self._keyword_factor
+                )
+            combined *= self._store_weight(candidate.scope)
+            freshness = self._freshness_boost(candidate.record.metadata, candidate.scope, now)
+            total_score = combined + freshness
+            record_with_score = candidate.record.with_score(total_score)
+            hits.append(
+                MemoryHit(
+                    record=record_with_score,
+                    scope=candidate.scope,
+                    backend=candidate.backend,
+                    score=total_score,
+                    embedding_score=embedding_signal,
+                    keyword_score=keyword_signal,
+                    embedding_raw=embedding_raw,
+                    keyword_raw=keyword_raw,
+                    freshness_boost=freshness,
+                )
+            )
+
+        dedup: Dict[str, MemoryHit] = {}
+        for hit in hits:
+            key = hit.record.record_id
+            existing = dedup.get(key)
+            if existing is None or hit.score > existing.score:
+                dedup[key] = hit
+        ranked = list(dedup.values())
+        ranked.sort(key=lambda item: item.score, reverse=True)
+        ranked = ranked[:limit_value]
+
+        if stream:
+            return (hit for hit in ranked)
+        return ranked
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+
+    def _resolve_embedder(
+        self,
+        embedder: Optional[Any],
+        embedding_model: Optional[str],
+    ) -> Tuple[Optional[Any], Optional[str]]:
+        if callable(embedder):
+            return embedder, embedding_model
+        inferred = embedding_model or self._infer_model_name()
+        provider, resolved_name = resolve_embedding_provider(inferred)
+        return provider, resolved_name or inferred
+
+    def _infer_model_name(self) -> Optional[str]:
+        for scope in ("short_term", "long_term", "combined"):
+            store = self._stores.get(scope)
+            if store is None:
+                continue
+            config = getattr(store, "config", None)
+            if config is not None:
+                name = getattr(config, "embedding_model", None)
+                if name:
+                    return name
+            name = getattr(store, "_embedding_model", None)
+            if name:
+                return name
+        return None
+
+    def _normalize_embedding(self, embedding: Optional[Sequence[float]]) -> Optional[List[float]]:
+        if embedding is None:
+            return None
+        coerced = _coerce_embedding(embedding)
+        return coerced or None
+
+    def _embed_query(self, text: str) -> Optional[List[float]]:
+        if self._embedder is None:
+            return None
+        cleaned = text.strip()
+        if not cleaned:
+            return None
+        try:
+            values = self._embedder(cleaned)
+        except Exception:  # pragma: no cover - runtime embedding errors
+            LOGGER.debug("Query embedding failed", exc_info=True)
+            return None
+        coerced = _coerce_embedding(values)
+        return coerced or None
+
+    def _per_store_limits(self, limit: int) -> Dict[str, int]:
+        limits: Dict[str, int] = {}
+        if "short_term" in self._stores:
+            limits["short_term"] = min(self.config.short_term_top_k, limit)
+        if "long_term" in self._stores:
+            limits["long_term"] = min(self.config.long_term_top_k, limit)
+        if self.config.include_combined and "combined" in self._stores:
+            limits["combined"] = min(self.config.combined_top_k, limit)
+        return limits
+
+    def _store_weight(self, scope: str) -> float:
+        if scope == "short_term":
+            return self.config.short_term_weight
+        if scope == "long_term":
+            return self.config.long_term_weight
+        if scope == "combined":
+            return self.config.combined_weight
+        return 1.0
+
+    def _freshness_boost(
+        self,
+        metadata: MemoryMetadata,
+        scope: str,
+        now: datetime,
+    ) -> float:
+        if self.config.freshness_weight <= 0.0 or self.config.freshness_halflife_hours <= 0.0:
+            return 0.0
+        updated_at = metadata.updated_at
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=timezone.utc)
+        age = max(0.0, (now - updated_at).total_seconds() / 3600.0)
+        decay = math.pow(0.5, age / self.config.freshness_halflife_hours)
+        base = self.config.freshness_weight * decay
+        return base * self._store_weight(scope)
+
+
+__all__ = ["MemoryRetrievalConfig", "MemoryHit", "MemoryRAG"]

--- a/memory.py
+++ b/memory.py
@@ -18,8 +18,9 @@ import logging
 import math
 import os
 import struct
+import threading
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Coroutine
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Coroutine
 
 try:  # pragma: no cover - optional dependency
     import redis  # type: ignore
@@ -43,6 +44,176 @@ except Exception:  # pragma: no cover - psycopg optional
     AsyncConnectionPool = None  # type: ignore
 
 LOGGER = logging.getLogger(__name__)
+
+
+EmbeddingFunction = Callable[[str], Sequence[float]]
+
+
+def _embedder_cache_key(model_name: Optional[str]) -> str:
+    value = (model_name or "__default__").strip()
+    return value or "__default__"
+
+
+_EMBEDDER_CACHE: Dict[str, Tuple[Optional[EmbeddingFunction], Optional[str]]] = {}
+_EMBEDDER_CACHE_LOCK = threading.Lock()
+
+
+def register_embedding_provider(
+    provider: EmbeddingFunction,
+    *,
+    model_name: Optional[str] = None,
+) -> None:
+    """Register a custom embedding provider used during memory ingestion."""
+
+    key = _embedder_cache_key(model_name)
+    with _EMBEDDER_CACHE_LOCK:
+        _EMBEDDER_CACHE[key] = (provider, model_name)
+
+
+def clear_embedding_providers() -> None:
+    """Clear all cached embedding providers."""
+
+    with _EMBEDDER_CACHE_LOCK:
+        _EMBEDDER_CACHE.clear()
+
+
+def _coerce_embedding_sequence(payload: Any) -> List[float]:
+    if payload is None:
+        return []
+    if isinstance(payload, Mapping):
+        for key in ("embedding", "vector", "data", "values"):
+            if key in payload:
+                return _coerce_embedding_sequence(payload[key])
+        return []
+    if hasattr(payload, "embedding"):
+        return _coerce_embedding_sequence(getattr(payload, "embedding"))
+    if hasattr(payload, "vector"):
+        return _coerce_embedding_sequence(getattr(payload, "vector"))
+    if hasattr(payload, "tolist") and callable(payload.tolist):  # pragma: no cover - numpy arrays
+        return _coerce_embedding_sequence(payload.tolist())
+    if isinstance(payload, str):
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError:
+            return []
+        return _coerce_embedding_sequence(decoded)
+    if isinstance(payload, Sequence) and not isinstance(payload, (bytes, bytearray, str)):
+        try:
+            return [float(value) for value in payload]
+        except (TypeError, ValueError):
+            return []
+    if isinstance(payload, (bytes, bytearray)):
+        return []
+    try:
+        return [float(payload)]
+    except (TypeError, ValueError):
+        return []
+
+
+def _load_embedding_function(
+    model_name: Optional[str],
+) -> Tuple[Optional[EmbeddingFunction], Optional[str]]:
+    key = _embedder_cache_key(model_name)
+    with _EMBEDDER_CACHE_LOCK:
+        cached = _EMBEDDER_CACHE.get(key)
+        if cached is not None:
+            return cached
+
+    resolved_name = model_name or os.getenv("MEMORY_EMBEDDING_MODEL")
+
+    try:  # pragma: no cover - optional dependency
+        import lmstudio as lms  # type: ignore
+    except Exception:  # pragma: no cover - executed when lmstudio missing
+        LOGGER.debug("LM Studio embeddings are unavailable; continuing without automatic embeddings")
+        result = (None, resolved_name)
+        with _EMBEDDER_CACHE_LOCK:
+            _EMBEDDER_CACHE[key] = result
+        return result
+
+    try:
+        handle = lms.embedding_model(resolved_name) if resolved_name else lms.embedding_model()
+    except Exception:  # pragma: no cover - runtime configuration issues
+        LOGGER.warning("Failed to load LM Studio embedding model '%s'", resolved_name, exc_info=True)
+        result = (None, resolved_name)
+        with _EMBEDDER_CACHE_LOCK:
+            _EMBEDDER_CACHE[key] = result
+        return result
+
+    def _invoke(text: str) -> Sequence[float]:
+        try:
+            raw = handle.embed(text)
+        except Exception:  # pragma: no cover - runtime errors
+            LOGGER.debug("Embedding model raised an exception", exc_info=True)
+            return []
+        if asyncio.iscoroutine(raw):  # pragma: no cover - defensive guard
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                raw = asyncio.run(raw)
+            else:
+                if loop.is_running():
+                    LOGGER.warning(
+                        "Embedding model returned coroutine while an event loop is active; skipping embedding computation",
+                    )
+                    return []
+                raw = loop.run_until_complete(raw)
+        return _coerce_embedding_sequence(raw)
+
+    def provider(text: str) -> Sequence[float]:
+        return list(_invoke(text))
+
+    resolved_handle_name = (
+        getattr(handle, "model_key", None)
+        or getattr(handle, "model", None)
+        or getattr(handle, "name", None)
+        or resolved_name
+    )
+
+    result = (provider, resolved_handle_name)
+    with _EMBEDDER_CACHE_LOCK:
+        _EMBEDDER_CACHE[key] = result
+    return result
+
+
+def resolve_embedding_provider(
+    model_name: Optional[str] = None,
+) -> Tuple[Optional[EmbeddingFunction], Optional[str]]:
+    """Return a cached embedding provider and associated model name."""
+
+    return _load_embedding_function(model_name)
+
+
+def _ensure_embedding(
+    record: "MemoryRecord",
+    embedder: Optional[EmbeddingFunction],
+    model_name: Optional[str],
+) -> "MemoryRecord":
+    metadata = record.metadata
+    existing = _coerce_embedding_sequence(record.embedding) if record.embedding else []
+    if embedder is None:
+        if existing and metadata.embedding_model is None and model_name:
+            metadata = replace(metadata, embedding_model=model_name)
+        if existing:
+            return replace(record, embedding=existing, metadata=metadata)
+        return record
+
+    content = (record.content or "").strip()
+    computed: List[float] = []
+    if content:
+        try:
+            computed = _coerce_embedding_sequence(embedder(content))
+        except Exception:  # pragma: no cover - defensive
+            LOGGER.debug("Embedding provider raised an exception", exc_info=True)
+            computed = []
+    if not computed:
+        computed = existing
+    if computed:
+        if metadata.embedding_model is None and model_name:
+            metadata = replace(metadata, embedding_model=model_name)
+        return replace(record, embedding=computed, metadata=metadata)
+    if metadata.embedding_model is None and model_name:
+        metadata = replace(metadata, embedding_model=model_name)
+    return replace(record, embedding=None, metadata=metadata)
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +512,7 @@ class InMemoryMemoryStore(MemoryStore):
         self._compaction_threshold = compaction_threshold or 0
         self._compaction_counter = 0
         self._embedding_model = embedding_model
+        self._embedder_fn, self._embedder_model_name = _load_embedding_function(embedding_model)
 
     def add(self, record: MemoryRecord) -> MemoryRecord:
         record = self._prepare_record(record)
@@ -370,12 +542,7 @@ class InMemoryMemoryStore(MemoryStore):
         if score is not None:
             record = replace(record, score=score)
 
-        record.metadata.touch()
-        if record.metadata.ttl_seconds is None and self._default_ttl is not None:
-            record.metadata.ttl_seconds = self._default_ttl
-        if record.metadata.embedding_model is None:
-            record.metadata.embedding_model = self._embedding_model
-
+        record = self._prepare_record(record)
         self._records[record_id] = record
         self._maybe_compact()
         return record
@@ -421,6 +588,11 @@ class InMemoryMemoryStore(MemoryStore):
     # ------------------------------------------------------------------
 
     def _prepare_record(self, record: MemoryRecord) -> MemoryRecord:
+        record = _ensure_embedding(
+            record,
+            self._embedder_fn,
+            self._embedder_model_name or self._embedding_model,
+        )
         metadata = replace(
             record.metadata,
             tags=tuple(record.metadata.tags),
@@ -503,6 +675,7 @@ class ShortTermMemoryStore(MemoryStore):
 
         self._default_ttl = self._coerce_int(config.ttl_seconds)
         self._embedding_model = config.embedding_model
+        self._embedder_fn, self._embedder_model_name = _load_embedding_function(self._embedding_model)
 
         options = dict(config.options)
         namespace = options.get("namespace") or f"memory:{config.scope}"
@@ -674,6 +847,11 @@ class ShortTermMemoryStore(MemoryStore):
     # ------------------------------------------------------------------
 
     def _prepare_record(self, record: MemoryRecord) -> MemoryRecord:
+        record = _ensure_embedding(
+            record,
+            self._embedder_fn,
+            self._embedder_model_name or self._embedding_model,
+        )
         metadata = replace(
             record.metadata,
             tags=tuple(record.metadata.tags),
@@ -1056,6 +1234,8 @@ class LongTermMemoryStore(MemoryStore):
 
         self.config = config
         self._settings = config.postgres or PostgresSettings()
+        self._embedding_model = config.embedding_model
+        self._embedder_fn, self._embedder_model_name = _load_embedding_function(self._embedding_model)
         self._embedding_dimensions = self._option_int("embedding_dimensions", 1536)
         self._pool = AsyncConnectionPool(
             conninfo=self._build_conninfo(self._settings),
@@ -1137,6 +1317,11 @@ class LongTermMemoryStore(MemoryStore):
     # ------------------------------------------------------------------
 
     def add(self, record: MemoryRecord) -> MemoryRecord:
+        record = _ensure_embedding(
+            record,
+            self._embedder_fn,
+            self._embedder_model_name or self._embedding_model,
+        )
         return self._run(self._add(record))
 
     async def _add(self, record: MemoryRecord) -> MemoryRecord:
@@ -1279,6 +1464,21 @@ class LongTermMemoryStore(MemoryStore):
                         new_score = float(new_score)
                     except (TypeError, ValueError):
                         new_score = None
+                candidate_record = MemoryRecord(
+                    content=new_content,
+                    metadata=new_metadata,
+                    embedding=new_embedding,
+                    score=new_score,
+                    record_id=record_id,
+                )
+                candidate_record = _ensure_embedding(
+                    candidate_record,
+                    self._embedder_fn,
+                    self._embedder_model_name or self._embedding_model,
+                )
+                new_metadata = candidate_record.metadata
+                new_embedding = candidate_record.embedding
+                new_score = candidate_record.score
                 expires_at = self._compute_expiry(new_metadata, new_metadata.created_at)
                 tags = self._normalize_tags(new_metadata.tags)
                 actor = self._resolve_actor(new_metadata)
@@ -2326,6 +2526,9 @@ def build_memory_router(config: Optional[MemoryConfiguration] = None) -> MemoryR
 
 
 __all__ = [
+    "register_embedding_provider",
+    "clear_embedding_providers",
+    "resolve_embedding_provider",
     "MemoryMetadata",
     "MemoryRecord",
     "MemoryQuery",

--- a/tests/test_memory_rag.py
+++ b/tests/test_memory_rag.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from memory import (
+    MemoryMetadata,
+    MemoryRecord,
+    InMemoryMemoryStore,
+    clear_embedding_providers,
+    register_embedding_provider,
+)
+from internal.memory_rag import MemoryHit, MemoryRAG, MemoryRetrievalConfig
+
+
+@pytest.fixture(autouse=True)
+def reset_embedding_providers() -> None:
+    clear_embedding_providers()
+    yield
+    clear_embedding_providers()
+
+
+def _fake_embedder(text: str) -> list[float]:
+    lowered = text.lower()
+    return [1.0 if "alpha" in lowered else 0.0, 1.0 if "beta" in lowered else 0.0]
+
+
+def test_embeddings_computed_on_add() -> None:
+    calls: list[str] = []
+
+    def embedder(text: str) -> list[float]:
+        calls.append(text)
+        return _fake_embedder(text)
+
+    register_embedding_provider(embedder, model_name="unit-test")
+    store = InMemoryMemoryStore(embedding_model="unit-test")
+    assert getattr(store, "_embedder_fn") is embedder
+    record = MemoryRecord(content="Alpha memo", metadata=MemoryMetadata(source="unit"))
+
+    stored = store.add(record)
+
+    assert stored.embedding == [1.0, 0.0]
+    assert stored.metadata.embedding_model == "unit-test"
+
+    updated = store.update(
+        stored.record_id,
+        content="Beta memo",
+    )
+    assert calls == ["Alpha memo", "Beta memo"]
+    assert updated.content == "Beta memo"
+    assert updated.embedding == [0.0, 1.0]
+
+
+def test_memory_rag_ranking_and_streaming() -> None:
+    register_embedding_provider(_fake_embedder, model_name="unit-test")
+    short_store = InMemoryMemoryStore(embedding_model="unit-test")
+    long_store = InMemoryMemoryStore(embedding_model="unit-test")
+
+    short_record = MemoryRecord(
+        content="Alpha project details",
+        metadata=MemoryMetadata(source="short", tags=("alpha",), updated_at=datetime.now(timezone.utc)),
+    )
+    long_recent = MemoryRecord(
+        content="Beta project notes",
+        metadata=MemoryMetadata(source="long", tags=("beta",), updated_at=datetime.now(timezone.utc)),
+    )
+    long_alpha = MemoryRecord(
+        content="Alpha research summary",
+        metadata=MemoryMetadata(
+            source="long",
+            tags=("alpha",),
+            updated_at=datetime.now(timezone.utc) - timedelta(hours=3),
+        ),
+    )
+
+    short_store.add(short_record)
+    long_store.add(long_recent)
+    long_store.add(long_alpha)
+
+    rag = MemoryRAG(
+        short_term=short_store,
+        long_term=long_store,
+        config=MemoryRetrievalConfig(short_term_weight=1.5, long_term_weight=1.0, freshness_weight=0.0),
+    )
+
+    hits = list(rag.query_memory("alpha insights", limit=5))
+
+    assert hits, "expected at least one retrieval result"
+    assert isinstance(hits[0], MemoryHit)
+    assert hits[0].scope == "short_term"
+    assert hits[0].record.content == "Alpha project details"
+    assert hits[0].record.score == pytest.approx(hits[0].score)
+    assert hits[0].provenance["backend"] == short_store.backend_name
+
+    streamed = list(rag.query_memory("alpha insights", limit=5, stream=True))
+    assert [hit.record.record_id for hit in streamed] == [hit.record.record_id for hit in hits]


### PR DESCRIPTION
## Summary
- add an embedding provider registry and ensure in-memory, Redis, and Postgres memory stores compute vectors automatically during ingest and updates
- introduce `internal/memory_rag.py` to perform hybrid keyword/vector retrieval with configurable weighting and streaming results
- add unit tests covering embedding ingestion and hybrid memory ranking

## Testing
- pytest tests/test_memory_rag.py

------
https://chatgpt.com/codex/tasks/task_b_68e6dee0fe08832f8e520780fa1e8840