### PR TITLE
Add shared memory tooling and conversation logging

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -8,6 +8,12 @@ from typing import Any, Iterable, MutableSequence, Optional, Sequence
 from chat import CallbackMap
 from session import AgentSession, Hook
 from tooling import ToolRegistry, ToolSpec
+from internal.tools.memory import (
+    memory_add_tool,
+    memory_promote_tool,
+    memory_search_tool,
+    memory_update_tool,
+)
 
 __all__ = [
     "AgentBuilder",
@@ -272,6 +278,18 @@ def register_default_toolset(
     payload = tuple(specs)
     _DEFAULT_TOOLSETS[name] = payload
     return payload
+
+
+register_default_toolset(
+    "memory",
+    (
+        memory_search_tool,
+        memory_add_tool,
+        memory_update_tool,
+        memory_promote_tool,
+    ),
+    replace=True,
+)
 
 
 def _ensure_registered(registry: ToolRegistry, tool: ToolSpec | Any) -> ToolSpec:

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -6,10 +6,19 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 import time
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence, TYPE_CHECKING
+from uuid import uuid4
 
 from internal.DAG import DAG
 from internal.structures import StructuredResponse
 from session import AgentRound, AgentSession
+from memory import (
+    ConversationMemoryHooks,
+    MemoryFacade,
+    MemoryRouter,
+    get_shared_memory_facade,
+    get_shared_memory_router,
+    set_shared_memory_facade,
+)
 
 from .dependency import DependencyBuildAgent
 from .doc import DocAgent
@@ -160,12 +169,16 @@ class ManagerAgent:
         eval_agent: EvalAgent | None = None,
         security_agent: SecurityAgent | None = None,
         doc_agent: DocAgent | None = None,
+        memory_router: MemoryRouter | None = None,
+        memory_facade: MemoryFacade | None = None,
+        session_id: str | None = None,
     ) -> None:
         if session is None:
             if session_factory is None:
                 raise ValueError("ManagerAgent requires a session or session_factory")
             session = session_factory()
         self.session = session
+        self.session_id = session_id or uuid4().hex
         self._status_callback = status_callback
         self._plan_builder = plan_builder or self._default_plan_builder
         self.plan_retries = max(0, plan_retries)
@@ -199,6 +212,36 @@ class ManagerAgent:
         self._gate_source: str | None = None
         self._last_eval_summary: RegressionSummary | None = None
         self._completed_evaluations: list[RegressionSummary] = []
+
+        resolved_router = memory_router
+        resolved_facade = memory_facade
+
+        if resolved_facade is None:
+            if resolved_router is None:
+                try:
+                    resolved_facade = get_shared_memory_facade()
+                except Exception:  # pragma: no cover - defensive fallback
+                    resolved_router = get_shared_memory_router()
+                    resolved_facade = MemoryFacade(resolved_router)
+                else:
+                    resolved_router = resolved_facade.router
+            else:
+                resolved_facade = MemoryFacade(resolved_router)
+        else:
+            if resolved_router is None:
+                resolved_router = resolved_facade.router
+            set_shared_memory_facade(resolved_facade)
+
+        self.memory_router = resolved_router
+        self.memory_facade = resolved_facade
+        self._memory_hooks: ConversationMemoryHooks | None = None
+        if self.memory_facade is not None:
+            set_shared_memory_facade(self.memory_facade)
+            self._memory_hooks = ConversationMemoryHooks(
+                self.memory_facade,
+                session_id=self.session_id,
+                agent_label="manager",
+            )
         if test_critic is not None:
             self.attach_test_critic(test_critic)
         if eval_agent is not None:
@@ -210,6 +253,11 @@ class ManagerAgent:
             on_round_start=self._handle_round_start,
             on_round_end=self._handle_round_end,
         )
+        if self._memory_hooks is not None:
+            self.session.add_round_hooks(
+                on_round_start=self._memory_hooks.on_round_start,
+                on_round_end=self._memory_hooks.on_round_end,
+            )
 
     # ------------------------------------------------------------------
     # Public API

--- a/internal/tools/memory.py
+++ b/internal/tools/memory.py
@@ -1,0 +1,114 @@
+"""Tooling surface for interacting with the shared memory subsystem."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from memory import (
+    MemoryFacade,
+    MemoryRouter,
+    get_shared_memory_facade,
+)
+
+
+def _facade(facade: MemoryFacade | None = None) -> MemoryFacade:
+    return facade or get_shared_memory_facade()
+
+
+def memory_search_tool(
+    query: str,
+    *,
+    scope: str = MemoryRouter.COMBINED,
+    limit: int = 10,
+    min_score: float | None = None,
+    metadata_filters: Mapping[str, Any] | None = None,
+    embedding: Sequence[float] | None = None,
+    facade: MemoryFacade | None = None,
+) -> list[dict[str, Any]]:
+    """Search agent memory for entries relevant to ``query``."""
+
+    records = _facade(facade).search(
+        query,
+        scope=scope,
+        limit=limit,
+        min_score=min_score,
+        metadata_filters=metadata_filters,
+        embedding=embedding,
+    )
+    return [MemoryFacade.to_dict(record) for record in records]
+
+
+def memory_add_tool(
+    content: str,
+    *,
+    scope: str = MemoryRouter.SHORT_TERM,
+    tags: Sequence[str] | None = None,
+    importance: float | None = None,
+    attributes: Mapping[str, Any] | None = None,
+    ttl_seconds: int | None = None,
+    embedding: Sequence[float] | None = None,
+    facade: MemoryFacade | None = None,
+) -> dict[str, Any]:
+    """Add ``content`` into ``scope`` and return the stored record."""
+
+    record = _facade(facade).add(
+        content,
+        scope=scope,
+        tags=tags,
+        importance=importance,
+        attributes=attributes,
+        ttl_seconds=ttl_seconds,
+        embedding=embedding,
+    )
+    return MemoryFacade.to_dict(record)
+
+
+def memory_update_tool(
+    record_id: str,
+    *,
+    scope: str | None = None,
+    content: str | None = None,
+    tags: Sequence[str] | None = None,
+    importance: float | None = None,
+    attributes: Mapping[str, Any] | None = None,
+    ttl_seconds: int | None = None,
+    embedding: Sequence[float] | None = None,
+    score: float | None = None,
+    facade: MemoryFacade | None = None,
+) -> dict[str, Any]:
+    """Update an existing memory record and return the new value."""
+
+    record = _facade(facade).update(
+        record_id,
+        scope=scope,
+        content=content,
+        tags=tags,
+        importance=importance,
+        attributes=attributes,
+        ttl_seconds=ttl_seconds,
+        embedding=embedding,
+        score=score,
+    )
+    return MemoryFacade.to_dict(record)
+
+
+def memory_promote_tool(
+    record_id: str,
+    *,
+    strategy: str = "move",
+    provenance: Mapping[str, Any] | None = None,
+    facade: MemoryFacade | None = None,
+) -> dict[str, Any]:
+    """Promote a short-term memory into long-term storage."""
+
+    record = _facade(facade).promote(record_id, strategy=strategy, provenance=provenance)
+    return MemoryFacade.to_dict(record)
+
+
+__all__ = [
+    "memory_search_tool",
+    "memory_add_tool",
+    "memory_update_tool",
+    "memory_promote_tool",
+]
+

--- a/main.py
+++ b/main.py
@@ -8,10 +8,16 @@ from typing import Callable
 
 from agents import AgentBuilder
 from agents.manager import ManagerAgent, ManagerResult, ManagerStatusUpdate
+from memory import MemoryFacade, build_memory_router, set_shared_memory_facade
 
 
 def _build_manager() -> ManagerAgent:
+    router = build_memory_router()
+    facade = MemoryFacade(router)
+    set_shared_memory_facade(facade)
+
     builder = AgentBuilder()
+    builder.with_toolsets("memory")
     session = builder.build()
 
     def status_printer(update: ManagerStatusUpdate) -> None:
@@ -19,7 +25,12 @@ def _build_manager() -> ManagerAgent:
         task_label = f" [{update.task}]" if update.task else ""
         print(f"[{prefix}{task_label}] {update.message}")
 
-    return ManagerAgent(session=session, status_callback=status_printer)
+    return ManagerAgent(
+        session=session,
+        status_callback=status_printer,
+        memory_router=router,
+        memory_facade=facade,
+    )
 
 
 def _interactive_loop(manager_factory: Callable[[], ManagerAgent]) -> int:

--- a/memory.py
+++ b/memory.py
@@ -3029,7 +3029,412 @@ def build_memory_router(config: Optional[MemoryConfiguration] = None) -> MemoryR
     else:
         stores[MemoryRouter.COMBINED] = build_memory_store(config.combined.copy())
 
-    return MemoryRouter(stores)
+        return MemoryRouter(stores)
+
+
+class MemoryFacade:
+    """High-level helper exposing convenience operations across memory scopes."""
+
+    def __init__(
+        self,
+        router: MemoryRouter,
+        *,
+        default_scope: str = MemoryRouter.SHORT_TERM,
+        combined_scope: str = MemoryRouter.COMBINED,
+    ) -> None:
+        self.router = router
+        self.default_scope = default_scope
+        self.combined_scope = combined_scope
+
+    # ------------------------------------------------------------------
+    # Public API helpers
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        text: str,
+        *,
+        scope: str | None = None,
+        limit: int = 10,
+        min_score: float | None = None,
+        metadata_filters: Mapping[str, Any] | None = None,
+        embedding: Sequence[float] | None = None,
+    ) -> List[MemoryRecord]:
+        """Return records matching ``text`` from the requested ``scope``."""
+
+        store = self._get_store(scope or self.combined_scope)
+        query = MemoryQuery(
+            text=text,
+            embedding=list(embedding) if embedding is not None else None,
+            limit=max(0, int(limit)),
+            min_score=self._coerce_float(min_score),
+            metadata_filters=dict(metadata_filters or {}),
+        )
+        return store.fetch(query)
+
+    def add(
+        self,
+        content: str,
+        *,
+        scope: str | None = None,
+        tags: Sequence[str] | None = None,
+        importance: float | None = None,
+        attributes: Mapping[str, Any] | None = None,
+        ttl_seconds: int | None = None,
+        embedding: Sequence[float] | None = None,
+        score: float | None = None,
+        source: str = "conversation",
+        session_id: str | None = None,
+        agent_id: str | None = None,
+    ) -> MemoryRecord:
+        """Persist ``content`` into ``scope`` returning the stored record."""
+
+        store = self._get_store(scope or self.default_scope)
+        metadata = self._build_metadata(
+            source=source,
+            tags=tags,
+            importance=importance,
+            ttl_seconds=ttl_seconds,
+            attributes=attributes,
+            session_id=session_id,
+            agent_id=agent_id,
+        )
+        record = MemoryRecord(
+            content=content,
+            metadata=metadata,
+            embedding=list(embedding) if embedding is not None else None,
+            score=self._coerce_float(score),
+        )
+        return store.add(record)
+
+    def update(
+        self,
+        record_id: str,
+        *,
+        scope: str | None = None,
+        content: str | None = None,
+        tags: Sequence[str] | None = None,
+        importance: float | None = None,
+        attributes: Mapping[str, Any] | None = None,
+        ttl_seconds: int | None = None,
+        embedding: Sequence[float] | None = None,
+        score: float | None = None,
+    ) -> MemoryRecord:
+        """Update an existing record and return the stored value."""
+
+        candidate_scopes = self._resolve_update_scopes(scope)
+        last_error: Exception | None = None
+        for candidate in candidate_scopes:
+            store = self._get_store(candidate)
+            try:
+                current = store.get(record_id)
+            except KeyError as exc:
+                last_error = exc
+                continue
+
+            metadata = current.metadata
+            if tags is not None:
+                metadata = replace(metadata, tags=tuple(str(tag) for tag in tags))
+            if importance is not None:
+                metadata = replace(metadata, importance=self._coerce_float(importance))
+            if ttl_seconds is not None:
+                metadata = replace(metadata, ttl_seconds=self._coerce_int(ttl_seconds))
+            if attributes:
+                merged = dict(metadata.attributes)
+                merged.update(self._sanitize_attributes(attributes))
+                metadata = replace(metadata, attributes=merged)
+            metadata.touch()
+
+            return store.update(
+                record_id,
+                content=content,
+                metadata=metadata,
+                embedding=list(embedding) if embedding is not None else None,
+                score=self._coerce_float(score),
+            )
+
+        if last_error is not None:
+            raise last_error
+        raise KeyError(f"Memory record '{record_id}' does not exist")
+
+    def promote(
+        self,
+        record_id: str,
+        *,
+        strategy: str = "move",
+        provenance: Mapping[str, Any] | None = None,
+    ) -> MemoryRecord:
+        """Promote a short-term record into long-term storage."""
+
+        payload = {str(key): value for key, value in (provenance or {}).items()}
+        return self.router.promote_to_long_term(record_id, strategy=strategy, provenance=payload)
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def to_dict(record: MemoryRecord) -> Dict[str, Any]:
+        """Return a JSON-serialisable representation of ``record``."""
+
+        metadata_payload = _metadata_to_dict(record.metadata)
+        return {
+            "record_id": record.record_id,
+            "content": record.content,
+            "metadata": metadata_payload,
+            "score": record.score,
+            "embedding": list(record.embedding) if record.embedding is not None else None,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_store(self, scope: str) -> MemoryStore:
+        normalized = scope.lower().replace("-", "_")
+        return self.router.get_store(normalized)
+
+    def _build_metadata(
+        self,
+        *,
+        source: str,
+        tags: Sequence[str] | None,
+        importance: float | None,
+        ttl_seconds: int | None,
+        attributes: Mapping[str, Any] | None,
+        session_id: str | None,
+        agent_id: str | None,
+    ) -> MemoryMetadata:
+        attributes_payload = self._sanitize_attributes(attributes)
+        if session_id is not None:
+            attributes_payload.setdefault("session_id", session_id)
+        if agent_id is not None:
+            attributes_payload.setdefault("agent_id", agent_id)
+        metadata = MemoryMetadata(
+            source=str(source or "unknown"),
+            tags=tuple(str(tag) for tag in (tags or ())),
+            importance=self._coerce_float(importance),
+            ttl_seconds=self._coerce_int(ttl_seconds),
+            attributes=attributes_payload,
+        )
+        metadata.touch()
+        return metadata
+
+    def _sanitize_attributes(self, attributes: Mapping[str, Any] | None) -> Dict[str, Any]:
+        if not attributes:
+            return {}
+        sanitized: Dict[str, Any] = {}
+        for key, value in attributes.items():
+            sanitized[str(key)] = self._sanitize_value(value)
+        return sanitized
+
+    def _sanitize_value(self, value: Any) -> Any:
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return [self._sanitize_value(item) for item in value]
+        if isinstance(value, Mapping):
+            return {str(key): self._sanitize_value(item) for key, item in value.items()}
+        return str(value)
+
+    @staticmethod
+    def _coerce_float(value: Any) -> Optional[float]:
+        if value in (None, ""):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _coerce_int(value: Any) -> Optional[int]:
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _resolve_update_scopes(self, scope: str | None) -> Tuple[str, ...]:
+        if scope is None:
+            return (self.default_scope, MemoryRouter.LONG_TERM)
+        normalized = scope.lower().replace("-", "_")
+        if normalized == "auto":
+            return (self.default_scope, MemoryRouter.LONG_TERM)
+        return (normalized,)
+
+
+class ConversationMemoryHooks:
+    """Lifecycle hooks that persist conversation turns via :class:`MemoryFacade`."""
+
+    def __init__(
+        self,
+        facade: MemoryFacade,
+        *,
+        session_id: str,
+        agent_label: str = "manager",
+        short_scope: str = MemoryRouter.SHORT_TERM,
+        promotion_threshold: float = 0.85,
+    ) -> None:
+        self._facade = facade
+        self._session_id = session_id
+        self._agent_label = agent_label
+        self._short_scope = short_scope
+        self._promotion_threshold = promotion_threshold
+        self._user_records: Dict[int, MemoryRecord] = {}
+        self._assistant_records: Dict[int, MemoryRecord] = {}
+
+    # ------------------------------------------------------------------
+    # Hooks exposed to :class:`AgentSession`
+    # ------------------------------------------------------------------
+
+    def on_round_start(self, payload: Mapping[str, Any]) -> None:
+        user_message = payload.get("user_message")
+        if not user_message:
+            return
+        round_index = int(payload.get("index", 0))
+        metadata = payload.get("metadata")
+        task = None
+        if isinstance(metadata, Mapping):
+            task = metadata.get("task")
+        record = self._facade.add(
+            str(user_message),
+            scope=self._short_scope,
+            tags=("conversation", "user"),
+            attributes={
+                "role": "user",
+                "round_index": round_index,
+                "task": task,
+            },
+            session_id=self._session_id,
+            agent_id=self._agent_label,
+            source="conversation",
+        )
+        self._user_records[round_index] = record
+
+    def on_round_end(self, round_record: "AgentRound") -> None:
+        round_index = round_record.index
+        metadata_payload = dict(round_record.metadata or {})
+        task = metadata_payload.get("task")
+        record = self._facade.add(
+            round_record.response_text,
+            scope=self._short_scope,
+            tags=("conversation", "assistant"),
+            attributes={
+                "role": "assistant",
+                "round_index": round_index,
+                "task": task,
+                "metadata": metadata_payload,
+            },
+            session_id=self._session_id,
+            agent_id=self._agent_label,
+            source="conversation",
+        )
+        self._assistant_records[round_index] = record
+
+        memory_meta: Dict[str, Any] = {}
+        existing_memory = metadata_payload.get("memory")
+        if isinstance(existing_memory, Mapping):
+            memory_meta.update(existing_memory)
+        user_record = self._user_records.get(round_index)
+        if user_record is not None:
+            memory_meta.setdefault("user_record_id", user_record.record_id)
+        memory_meta["assistant_record_id"] = record.record_id
+
+        promotion_reason = self._promotion_reason(metadata_payload)
+        if promotion_reason is not None:
+            promoted = self._facade.promote(
+                record.record_id,
+                strategy="copy",
+                provenance={
+                    "reason": promotion_reason,
+                    "trigger_round": round_index,
+                    "task": task,
+                },
+            )
+            memory_meta["long_term_record_id"] = promoted.record_id
+            self._facade.update(
+                record.record_id,
+                attributes={
+                    "promotion": {
+                        "promoted": True,
+                        "long_term_record_id": promoted.record_id,
+                        "reason": promotion_reason,
+                    }
+                },
+            )
+
+        metadata_payload["memory"] = memory_meta
+        round_record.metadata = metadata_payload
+
+    # ------------------------------------------------------------------
+    # Promotion heuristics
+    # ------------------------------------------------------------------
+
+    def _promotion_reason(self, metadata: Mapping[str, Any]) -> Optional[str]:
+        if not metadata:
+            return None
+        tags = metadata.get("tags")
+        if isinstance(tags, (list, tuple, set, frozenset)):
+            for tag in tags:
+                if str(tag).lower() in {"important", "high_importance", "milestone"}:
+                    return "tagged_high_importance"
+
+        importance = metadata.get("importance") or metadata.get("response_importance")
+        try:
+            if importance is not None and float(importance) >= self._promotion_threshold:
+                return "high_importance_score"
+        except (TypeError, ValueError):
+            pass
+
+        plan_state = metadata.get("plan_status") or metadata.get("plan")
+        if isinstance(plan_state, str) and plan_state.lower() in {"complete", "completed", "done"}:
+            return "plan_completed"
+
+        if metadata.get("promote_to_long_term"):
+            return "explicit_promotion_request"
+
+        return None
+
+
+_SHARED_MEMORY_ROUTER: Optional[MemoryRouter] = None
+_SHARED_MEMORY_FACADE: Optional[MemoryFacade] = None
+
+
+def get_shared_memory_router() -> MemoryRouter:
+    """Return the shared :class:`MemoryRouter`, constructing one on demand."""
+
+    global _SHARED_MEMORY_ROUTER
+    if _SHARED_MEMORY_ROUTER is None:
+        _SHARED_MEMORY_ROUTER = build_memory_router()
+    return _SHARED_MEMORY_ROUTER
+
+
+def set_shared_memory_router(router: Optional[MemoryRouter]) -> None:
+    """Override the shared router used by tooling and agents."""
+
+    global _SHARED_MEMORY_ROUTER, _SHARED_MEMORY_FACADE
+    _SHARED_MEMORY_ROUTER = router
+    if router is None:
+        _SHARED_MEMORY_FACADE = None
+
+
+def get_shared_memory_facade() -> MemoryFacade:
+    """Return a singleton :class:`MemoryFacade` backed by the shared router."""
+
+    global _SHARED_MEMORY_FACADE
+    if _SHARED_MEMORY_FACADE is None:
+        _SHARED_MEMORY_FACADE = MemoryFacade(get_shared_memory_router())
+    return _SHARED_MEMORY_FACADE
+
+
+def set_shared_memory_facade(facade: Optional[MemoryFacade]) -> None:
+    """Replace the globally shared :class:`MemoryFacade`."""
+
+    global _SHARED_MEMORY_FACADE, _SHARED_MEMORY_ROUTER
+    _SHARED_MEMORY_FACADE = facade
+    if facade is not None:
+        _SHARED_MEMORY_ROUTER = facade.router
 
 
 __all__ = [
@@ -3049,6 +3454,12 @@ __all__ = [
     "StoreConfig",
     "MemoryConfiguration",
     "MemoryRouter",
+    "MemoryFacade",
+    "ConversationMemoryHooks",
+    "get_shared_memory_router",
+    "set_shared_memory_router",
+    "get_shared_memory_facade",
+    "set_shared_memory_facade",
     "load_config_json",
     "load_memory_configuration",
     "build_memory_store",

--- a/tests/test_memory_management.py
+++ b/tests/test_memory_management.py
@@ -3,11 +3,30 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from memory import (
+    ConversationMemoryHooks,
     InMemoryMemoryStore,
+    MemoryFacade,
     MemoryMetadata,
     MemoryRecord,
     MemoryRouter,
+    set_shared_memory_facade,
 )
+from internal.tools.memory import (
+    memory_add_tool,
+    memory_promote_tool,
+    memory_search_tool,
+    memory_update_tool,
+)
+
+
+class ListableInMemoryStore(InMemoryMemoryStore):
+    def list_entries(self, *, limit=None, include_deleted=False, **_: object):  # type: ignore[override]
+        records = list(self._records.values())
+        if include_deleted:
+            records.extend(record for record, _ in self._deleted_records.values())
+        if limit is not None:
+            records = records[:limit]
+        return records
 
 
 def test_inmemory_soft_and_hard_delete_behaviour() -> None:
@@ -65,15 +84,6 @@ def test_memory_router_promote_and_copy_workflows() -> None:
 
 
 def test_compaction_with_summarizer_creates_summary_and_discards_sources() -> None:
-    class ListableInMemoryStore(InMemoryMemoryStore):
-        def list_entries(self, *, limit=None, include_deleted=False, **_: object):  # type: ignore[override]
-            records = list(self._records.values())
-            if include_deleted:
-                records.extend(record for record, _ in self._deleted_records.values())
-            if limit is not None:
-                records = records[:limit]
-            return records
-
     short_store = ListableInMemoryStore()
     long_store = InMemoryMemoryStore()
     router = MemoryRouter({
@@ -122,3 +132,106 @@ def test_compaction_with_summarizer_creates_summary_and_discards_sources() -> No
     stored_short = short_store.get(summary.record_id)
     stored_long = long_store.get(summary.record_id)
     assert stored_short.content == stored_long.content == summary.content
+
+
+def test_memory_facade_basic_workflow() -> None:
+    router = MemoryRouter(
+        {
+            MemoryRouter.SHORT_TERM: ListableInMemoryStore(),
+            MemoryRouter.LONG_TERM: ListableInMemoryStore(),
+        }
+    )
+    facade = MemoryFacade(router, combined_scope=MemoryRouter.SHORT_TERM)
+
+    record = facade.add(
+        "Hello memory",
+        tags=("greeting",),
+        attributes={"session_id": "session-1", "flag": True},
+        importance=0.5,
+        session_id="session-1",
+        agent_id="tester",
+    )
+
+    results = facade.search("Hello", scope=MemoryRouter.SHORT_TERM)
+    assert any(found.record_id == record.record_id for found in results)
+
+    updated = facade.update(
+        record.record_id,
+        tags=("greeting", "updated"),
+        importance=0.9,
+        attributes={"note": "updated"},
+    )
+    assert pytest.approx(updated.metadata.importance or 0.0, rel=1e-6) == 0.9
+    assert "note" in updated.metadata.attributes
+
+    promoted = facade.promote(record.record_id, strategy="copy", provenance={"actor": "unit"})
+    long_term_record = router.long_term.get(promoted.record_id)
+    assert long_term_record.content == record.content
+
+
+def test_conversation_memory_hooks_log_rounds_and_promote() -> None:
+    router = MemoryRouter(
+        {
+            MemoryRouter.SHORT_TERM: ListableInMemoryStore(),
+            MemoryRouter.LONG_TERM: ListableInMemoryStore(),
+        }
+    )
+    facade = MemoryFacade(router, combined_scope=MemoryRouter.SHORT_TERM)
+    hooks = ConversationMemoryHooks(
+        facade,
+        session_id="session-xyz",
+        agent_label="manager",
+        promotion_threshold=0.8,
+    )
+
+    hooks.on_round_start({"index": 0, "user_message": "Remember this", "metadata": {"task": "task-1"}})
+
+    class DummyRound:
+        def __init__(self) -> None:
+            self.index = 0
+            self.user_message = "Remember this"
+            self.response_text = "Important insight"
+            self.result = {"content": "Important insight"}
+            self.transcript = []
+            self.messages = []
+            self.tool_history = {}
+            self.metadata = {"task": "task-1", "importance": 0.95}
+
+    round_record = DummyRound()
+
+    hooks.on_round_end(round_record)
+
+    short_records = router.short_term.list_entries()
+    roles = {entry.metadata.attributes.get("role") for entry in short_records}
+    assert {"user", "assistant"}.issubset(roles)
+
+    memory_meta = round_record.metadata.get("memory", {}) if round_record.metadata else {}
+    assert "assistant_record_id" in memory_meta
+    assert "long_term_record_id" in memory_meta
+
+    long_records = router.long_term.list_entries()
+    assert any(record.content == "Important insight" for record in long_records)
+
+
+def test_memory_tool_callables_use_shared_facade() -> None:
+    router = MemoryRouter(
+        {
+            MemoryRouter.SHORT_TERM: ListableInMemoryStore(),
+            MemoryRouter.LONG_TERM: ListableInMemoryStore(),
+        }
+    )
+    facade = MemoryFacade(router, combined_scope=MemoryRouter.SHORT_TERM)
+    set_shared_memory_facade(facade)
+
+    added = memory_add_tool("Tool memo", tags=("tool",))
+    results = memory_search_tool("Tool memo", scope=MemoryRouter.SHORT_TERM)
+    assert any(result["record_id"] == added["record_id"] for result in results)
+
+    updated = memory_update_tool(added["record_id"], tags=("tool", "updated"), importance=0.9)
+    assert set(updated["metadata"]["tags"]) == {"tool", "updated"}
+
+    promoted = memory_promote_tool(added["record_id"], strategy="copy")
+    stored = router.long_term.get(promoted["record_id"])
+    assert stored.content == "Tool memo"
+
+    set_shared_memory_facade(None)


### PR DESCRIPTION
## Summary
- add a MemoryFacade plus conversation hooks and shared router/facade helpers for coordinating memory scopes
- expose memory_* tool callables via a default toolset and wire the manager session builder to provide the shared facade
- extend memory management tests to cover the facade workflow, conversation hooks, and tool callables

## Testing
- pytest tests/test_memory_management.py

------
https://chatgpt.com/codex/tasks/task_b_68e7b2920c4c832fa191ce6aea191a81