### PR TITLE
Add memory backend setup helper and integration tests

### DIFF
--- a/docs/autocoder/README.md
+++ b/docs/autocoder/README.md
@@ -10,6 +10,7 @@ Welcome to the Auto-Coder documentation set. This hub explains how the repositor
 | [Core Runtime Components](./runtime.md) | Walkthrough of the CLI entry point, chat/session abstractions, tool registry, and other runtime helpers. |
 | [Agents](./agents.md) | Responsibilities, inputs/outputs, and collaborators for every agent implementation in `agents/`. |
 | [Internal Libraries](./internal.md) | Shared building blocks in the `internal/` namespace plus bundled tool implementations. |
+| [Memory Backends](./memory.md) | Redis/PostgreSQL setup instructions, environment variables, and troubleshooting tips. |
 | [Testing Strategy](./testing.md) | Coverage summary for the automated test suite and the behaviours it exercises. |
 
 ## 🔄 Keeping Docs Fresh

--- a/docs/autocoder/memory.md
+++ b/docs/autocoder/memory.md
@@ -1,0 +1,98 @@
+# Memory Backends & Operations Guide
+
+Auto-Coder can persist agent memories in Redis (short-term) and PostgreSQL (long-term). This guide documents the
+configuration knobs, readiness helpers, and troubleshooting steps operators need to keep both stores healthy.
+
+## 🚀 Quick Start
+
+1. Export the connection details for the stores you plan to use.
+2. Run the setup helper to validate connectivity, apply migrations, and create search indexes:
+   ```bash
+   python scripts/setup_memory.py
+   ```
+3. Launch the manager or integration tests once the helper reports all steps as `READY`.
+
+Use `--redis-only` or `--postgres-only` if you want to validate a single backend and `--migrations-dir` to point at
+custom SQL bundles.
+
+## 🔧 Environment Variables
+
+Auto-Coder reads store configuration from `config.json` and the following environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `MEMORY_SHORT_TERM_BACKEND` / `MEMORY_LONG_TERM_BACKEND` | Select the backend for each scope (`memory`, `redis`, `postgres`). |
+| `MEMORY_<SCOPE>_TTL_SECONDS` | Override default TTL for the chosen scope (`SHORT_TERM`, `LONG_TERM`, `COMBINED`). |
+| `MEMORY_<SCOPE>_EMBEDDING_MODEL` | Force a specific embedding model for that scope. |
+| `MEMORY_<SCOPE>_REDIS_URL` | Full Redis URL (`redis://user:pass@host:port/db`). |
+| `MEMORY_<SCOPE>_REDIS_HOST` / `PORT` / `DB` | Hostname, port, and database number when URL is not provided. |
+| `MEMORY_<SCOPE>_REDIS_USERNAME` / `PASSWORD` / `SSL` | Authentication options for Redis. |
+| `MEMORY_<SCOPE>_POSTGRES_DSN` | Connection string for PostgreSQL. |
+| `MEMORY_<SCOPE>_POSTGRES_HOST` / `PORT` / `DATABASE` / `USER` / `PASSWORD` | Individual PostgreSQL connection parts. |
+| `MEMORY_<SCOPE>_POSTGRES_SSLMODE` | Optional SSL mode (e.g., `require`). |
+| `MEMORY_REDIS_URL` / `MEMORY_POSTGRES_DSN` | Global fallbacks applied when per-scope overrides are missing. |
+
+Testing helpers expect temporary services to be available and provide the following overrides:
+
+| Variable | Purpose |
+| --- | --- |
+| `TEST_REDIS_URL` | Redis connection string used by `tests/test_memory_backends.py`. Required when `redis-server` is not installed locally. |
+| `TEST_POSTGRES_DSN` | PostgreSQL DSN consumed by the test fixtures and the setup helper. Must point to a database with the `vector` and `uuid-ossp` extensions installed. |
+
+## 🗄️ PostgreSQL Migrations & pgvector
+
+SQL migrations live in `internal/db/migrations`. Running `python scripts/setup_memory.py` applies every `.sql` file in that
+directory, ensuring the following objects exist:
+
+- `memory_entries`, `memory_tags`, `memory_links`, and `memory_entry_history` tables.
+- An IVFFLAT index on `memory_entries.embedding` for pgvector similarity search.
+- Required extensions: `vector` (pgvector) and `uuid-ossp`.
+
+If the helper reports missing extensions, install them as a superuser:
+
+```sql
+CREATE EXTENSION vector;
+CREATE EXTENSION "uuid-ossp";
+```
+
+Re-run the helper afterwards to confirm readiness.
+
+## 📊 Redis Search Indexes
+
+The Redis short-term store uses hashes with the pattern `memory:<scope>:record:<id>`. When a `vector_index` is configured in
+`config.json` or via environment variables, the helper provisions a RediSearch index with:
+
+- Text field for `content`.
+- Tag fields for `tags`, `session_id`, and `agent_id`.
+- Numeric field for `score`.
+- Optional vector field (`embedding_blob`) using FLAT search with float32 payloads.
+
+Ensure the Redis instance has the RediSearch module loaded. If `redis-server` lacks the module, the helper will report an
+actionable error so you can install RediSearch or disable vector queries.
+
+## 🧪 Testing the Backends
+
+The new `tests/test_memory_backends.py` suite exercises lifecycle flows, promotion/compaction logic, and RAG retrieval across
+Redis and PostgreSQL. To run these integration tests locally:
+
+```bash
+export TEST_REDIS_URL=redis://localhost:6379/0        # or rely on redis-server being on PATH
+export TEST_POSTGRES_DSN=postgresql://user:pass@localhost/autocoder
+pytest tests/test_memory_backends.py
+```
+
+The fixtures will start an ephemeral Redis instance when the binary is available. PostgreSQL tests require an existing
+database with the pgvector extension installed.
+
+## 🛠️ Troubleshooting
+
+| Symptom | Suggested Fix |
+| --- | --- |
+| `redis-py is not installed` | Install the dependency (`pip install redis>=5.0`) or pin it in your environment. |
+| `RedisSearch module is unavailable` | Load the RediSearch module on the target Redis server (`--loadmodule` or Docker image with RediSearch). |
+| `database missing extensions: vector` | Install pgvector in your PostgreSQL instance and re-run the helper. |
+| `no SQL migrations found` | Verify the repository checkout includes `internal/db/migrations` or pass `--migrations-dir`. |
+| Integration tests skipped | Provide `TEST_REDIS_URL` / `TEST_POSTGRES_DSN` so fixtures can connect to real services. |
+
+Keep the helper and tests in your CI pipeline to guarantee that production environments and development workstations remain in
+sync.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: tests that communicate with external services such as Redis or PostgreSQL

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torch>=2.1
 playwright>=1.42
 pytest>=7.4
 psycopg[binary,pool]>=3.1
+redis>=5.0

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Utility scripts packaged as importable modules."""
+
+__all__ = [
+    "setup_memory",
+]

--- a/scripts/setup_memory.py
+++ b/scripts/setup_memory.py
@@ -1,0 +1,424 @@
+"""Command-line helper for preparing Redis and PostgreSQL memory backends."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+from memory import (
+    RedisSettings,
+    PostgresSettings,
+    StoreConfig,
+    load_memory_configuration,
+)
+
+LOGGER = logging.getLogger("setup_memory")
+
+try:  # pragma: no cover - optional dependency
+    import redis  # type: ignore
+    from redis.exceptions import RedisError  # type: ignore
+    from redis.exceptions import ResponseError  # type: ignore
+    from redis.commands.search.indexDefinition import IndexDefinition, IndexType  # type: ignore
+    from redis.commands.search.field import NumericField, TagField, TextField, VectorField  # type: ignore
+except Exception:  # pragma: no cover - redis optional
+    redis = None  # type: ignore
+    RedisError = Exception  # type: ignore
+    ResponseError = Exception  # type: ignore
+    IndexDefinition = None  # type: ignore
+    IndexType = None  # type: ignore
+    NumericField = None  # type: ignore
+    TagField = None  # type: ignore
+    TextField = None  # type: ignore
+    VectorField = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import psycopg  # type: ignore
+    from psycopg.errors import DuplicateObject  # type: ignore
+except Exception:  # pragma: no cover - psycopg optional
+    psycopg = None  # type: ignore
+    DuplicateObject = Exception  # type: ignore
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MIGRATIONS_DIR = REPO_ROOT / "internal" / "db" / "migrations"
+
+
+@dataclass(slots=True)
+class StepResult:
+    """Result emitted for each setup step."""
+
+    name: str
+    ok: bool
+    detail: str
+    hint: Optional[str] = None
+
+    def format(self) -> str:
+        status = "READY" if self.ok else "ERROR"
+        message = f"[{status}] {self.name}: {self.detail}"
+        if self.hint:
+            message += f"\n    hint: {self.hint}"
+        return message
+
+
+def _coerce_int(options: Optional[dict[str, object]], key: str, default: int) -> int:
+    try:
+        raw = (options or {}).get(key, default)
+    except AttributeError:
+        return default
+    try:
+        return int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _redis_namespace(config: StoreConfig) -> str:
+    namespace = config.options.get("namespace") if config.options else None
+    if namespace:
+        return str(namespace).rstrip(":")
+    return f"memory:{config.scope}"
+
+
+def _redis_vector_index_name(config: StoreConfig) -> Optional[str]:
+    options = config.options or {}
+    vector_name = options.get("vector_index") or options.get("redis_vector_index")
+    if vector_name:
+        return str(vector_name)
+    return None
+
+
+def ensure_redis_ready(
+    config: StoreConfig,
+    *,
+    vector_dimensions: Optional[int] = None,
+) -> StepResult:
+    """Ping Redis and provision RediSearch indexes when required."""
+
+    scope = config.scope
+    if redis is None:
+        return StepResult(
+            name=f"redis:{scope}",
+            ok=False,
+            detail="redis-py is not installed",
+            hint="pip install redis>=5.0 and rerun the setup script",
+        )
+
+    settings: RedisSettings = config.redis or RedisSettings()
+
+    try:
+        if settings.url:
+            client = redis.Redis.from_url(settings.url, decode_responses=False)  # type: ignore[attr-defined]
+            connection_repr = settings.url
+        else:
+            kwargs = dict(settings.options)
+            if settings.username:
+                kwargs.setdefault("username", settings.username)
+            if settings.password:
+                kwargs.setdefault("password", settings.password)
+            if settings.ssl is not None:
+                kwargs.setdefault("ssl", settings.ssl)
+            client = redis.Redis(  # type: ignore[call-arg]
+                host=settings.host,
+                port=settings.port,
+                db=settings.db,
+                **kwargs,
+            )
+            connection_repr = f"{settings.host}:{settings.port}/{settings.db}"
+    except Exception as exc:  # pragma: no cover - redis misconfiguration
+        return StepResult(
+            name=f"redis:{scope}",
+            ok=False,
+            detail=f"failed to construct Redis client: {exc}",
+            hint="verify MEMORY_*_REDIS_* environment variables",
+        )
+
+    try:
+        client.ping()  # type: ignore[attr-defined]
+    except RedisError as exc:
+        return StepResult(
+            name=f"redis:{scope}",
+            ok=False,
+            detail=f"unable to ping Redis at {connection_repr}: {exc}",
+            hint="ensure the Redis service is running and accessible",
+        )
+
+    namespace = _redis_namespace(config)
+    vector_index = _redis_vector_index_name(config)
+    options = config.options or {}
+    dimensions = vector_dimensions or _coerce_int(options, "vector_dimensions", _coerce_int(options, "embedding_dimensions", 1536))
+
+    index_created = False
+    if vector_index:
+        if not hasattr(client, "ft"):
+            return StepResult(
+                name=f"redis:{scope}",
+                ok=False,
+                detail="RedisSearch module is unavailable on the target server",
+                hint="install RediSearch or remove the vector_index option",
+            )
+        if any(field is None for field in (IndexDefinition, IndexType, NumericField, TagField, TextField, VectorField)):
+            return StepResult(
+                name=f"redis:{scope}",
+                ok=False,
+                detail="redisearch Python helpers are missing",
+                hint="upgrade redis-py to 5.0+ with search extras enabled",
+            )
+        search = client.ft(vector_index)  # type: ignore[attr-defined]
+        try:
+            search.info()
+        except ResponseError as exc:  # type: no cover - index absent
+            if "Unknown Index name" not in str(exc):
+                return StepResult(
+                    name=f"redis:{scope}",
+                    ok=False,
+                    detail=f"unable to inspect vector index '{vector_index}': {exc}",
+                    hint="verify the RediSearch module is loaded",
+                )
+            try:
+                schema = [
+                    TextField("content"),
+                    TagField("tags"),
+                    TagField("session_id"),
+                    TagField("agent_id"),
+                    NumericField("score"),
+                ]
+                if dimensions:
+                    schema.append(
+                        VectorField(
+                            "embedding_blob",
+                            "FLAT",
+                            {
+                                "TYPE": "FLOAT32",
+                                "DIM": dimensions,
+                                "DISTANCE_METRIC": "L2",
+                                "INITIAL_CAP": 1000,
+                            },
+                        )
+                    )
+                definition = IndexDefinition(prefix=[f"{namespace}:record:"], index_type=IndexType.HASH)
+                search.create_index(schema, definition=definition)
+                index_created = True
+            except ResponseError as creation_error:
+                return StepResult(
+                    name=f"redis:{scope}",
+                    ok=False,
+                    detail=f"failed to create vector index '{vector_index}': {creation_error}",
+                    hint="check RedisSearch permissions and configuration",
+                )
+        except Exception as exc:  # pragma: no cover - unexpected redis errors
+            return StepResult(
+                name=f"redis:{scope}",
+                ok=False,
+                detail=f"failed to query vector index '{vector_index}': {exc}",
+                hint="inspect Redis logs for RediSearch errors",
+            )
+
+    detail = f"ping successful for {connection_repr}"
+    if vector_index:
+        if index_created:
+            detail += f"; created RediSearch index '{vector_index}'"
+        else:
+            detail += f"; vector index '{vector_index}' is available"
+    return StepResult(name=f"redis:{scope}", ok=True, detail=detail)
+
+
+def _build_pg_conninfo(settings: PostgresSettings) -> str:
+    if settings.dsn:
+        return settings.dsn
+    parts = []
+    if settings.host:
+        parts.append(f"host={settings.host}")
+    if settings.port:
+        parts.append(f"port={settings.port}")
+    if settings.database:
+        parts.append(f"dbname={settings.database}")
+    if settings.user:
+        parts.append(f"user={settings.user}")
+    if settings.password:
+        parts.append(f"password={settings.password}")
+    if settings.sslmode:
+        parts.append(f"sslmode={settings.sslmode}")
+    for key, value in (settings.options or {}).items():
+        parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+def ensure_postgres_ready(
+    config: StoreConfig,
+    *,
+    migrations_path: Path = DEFAULT_MIGRATIONS_DIR,
+) -> StepResult:
+    """Run SQL migrations and validate pgvector availability."""
+
+    scope = config.scope
+    if psycopg is None:
+        return StepResult(
+            name=f"postgres:{scope}",
+            ok=False,
+            detail="psycopg (v3) is not installed",
+            hint="pip install psycopg[binary,pool]>=3.1",
+        )
+
+    settings: PostgresSettings = config.postgres or PostgresSettings()
+    conninfo = _build_pg_conninfo(settings)
+
+    connect_kwargs = dict(settings.options)
+    try:
+        conn = psycopg.connect(conninfo, **connect_kwargs)  # type: ignore[call-arg]
+    except Exception as exc:
+        return StepResult(
+            name=f"postgres:{scope}",
+            ok=False,
+            detail=f"unable to connect using '{conninfo or settings.dsn}': {exc}",
+            hint="confirm credentials and network access to PostgreSQL",
+        )
+
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1")
+    except Exception as exc:
+        conn.close()
+        return StepResult(
+            name=f"postgres:{scope}",
+            ok=False,
+            detail=f"connection check failed: {exc}",
+            hint="review PostgreSQL logs for authentication errors",
+        )
+
+    migration_files = sorted(path for path in Path(migrations_path).glob("*.sql") if path.is_file())
+    if not migration_files:
+        conn.close()
+        return StepResult(
+            name=f"postgres:{scope}",
+            ok=False,
+            detail=f"no SQL migrations found in {migrations_path}",
+            hint="verify the repository checkout includes internal/db/migrations",
+        )
+
+    try:
+        with conn.cursor() as cur:
+            for migration in migration_files:
+                sql_text = migration.read_text(encoding="utf-8")
+                if not sql_text.strip():
+                    continue
+                try:
+                    cur.execute(sql_text)
+                except DuplicateObject:
+                    continue
+    except psycopg.errors.UndefinedFile as exc:  # type: ignore[attr-defined]
+        conn.close()
+        return StepResult(
+            name=f"postgres:{scope}",
+            ok=False,
+            detail=f"required extension is missing: {exc}",
+            hint="install the pgvector and uuid-ossp extensions on the target database",
+        )
+    except Exception as exc:
+        conn.close()
+        return StepResult(
+            name=f"postgres:{scope}",
+            ok=False,
+            detail=f"migration failed: {exc}",
+            hint="rerun with --migrations-dir to point at valid SQL scripts",
+        )
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('public.memory_entries')")
+            table_name = cur.fetchone()[0]
+            if table_name is None:
+                raise RuntimeError("memory_entries table was not created")
+            cur.execute("SELECT extname FROM pg_extension WHERE extname IN ('vector', 'uuid-ossp')")
+            installed_extensions = {row[0] for row in cur.fetchall()}
+            missing = {"vector", "uuid-ossp"} - installed_extensions
+            if missing:
+                return StepResult(
+                    name=f"postgres:{scope}",
+                    ok=False,
+                    detail=f"database missing extensions: {', '.join(sorted(missing))}",
+                    hint="install required extensions (CREATE EXTENSION vector; CREATE EXTENSION \"uuid-ossp\";)",
+                )
+            cur.execute(
+                "SELECT indexname FROM pg_indexes WHERE tablename = 'memory_entries' AND indexname = 'idx_memory_entries_embedding'"
+            )
+            has_vector_index = cur.fetchone() is not None
+    finally:
+        conn.close()
+
+    detail = f"connected using '{conninfo or settings.dsn}'"
+    if has_vector_index:
+        detail += "; pgvector index ready"
+    else:
+        detail += "; warning: vector index not found"
+    hint = None if has_vector_index else "re-run migrations or create the ivfflat index manually"
+    return StepResult(name=f"postgres:{scope}", ok=has_vector_index, detail=detail, hint=hint)
+
+
+def _iter_configs(config: StoreConfig, *, kind: str) -> Iterable[StoreConfig]:
+    if config.backend.lower() == kind:
+        yield config
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, help="Optional path to a memory config JSON override")
+    parser.add_argument(
+        "--migrations-dir",
+        type=Path,
+        default=DEFAULT_MIGRATIONS_DIR,
+        help="Directory containing SQL migrations for PostgreSQL backends",
+    )
+    parser.add_argument(
+        "--redis-only",
+        action="store_true",
+        help="Only prepare Redis backends (skip PostgreSQL steps)",
+    )
+    parser.add_argument(
+        "--postgres-only",
+        action="store_true",
+        help="Only prepare PostgreSQL backends (skip Redis steps)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.redis_only and args.postgres_only:
+        parser.error("--redis-only and --postgres-only are mutually exclusive")
+
+    config = load_memory_configuration(args.config)
+
+    results: list[StepResult] = []
+    if not args.postgres_only:
+        for store in (
+            config.short_term.copy(),
+            config.long_term.copy(),
+            config.combined.copy(),
+        ):
+            for redis_config in _iter_configs(store, kind="redis"):
+                results.append(ensure_redis_ready(redis_config))
+
+    if not args.redis_only:
+        for store in (
+            config.short_term.copy(),
+            config.long_term.copy(),
+            config.combined.copy(),
+        ):
+            for pg_config in _iter_configs(store, kind="postgres"):
+                results.append(ensure_postgres_ready(pg_config, migrations_path=args.migrations_dir))
+
+    if not results:
+        print("No Redis or PostgreSQL backends configured; nothing to do.")
+        return 0
+
+    all_ok = True
+    for result in results:
+        print(result.format())
+        all_ok = all_ok and result.ok
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    logging.basicConfig(level=os.getenv("SETUP_MEMORY_LOG", "INFO"))
+    sys.exit(main())

--- a/tests/test_memory_backends.py
+++ b/tests/test_memory_backends.py
@@ -1,0 +1,250 @@
+"""Integration tests for Redis and PostgreSQL memory stores."""
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, Iterator
+
+import pytest
+
+from memory import (
+    InMemoryMemoryStore,
+    MemoryMetadata,
+    MemoryQuery,
+    MemoryRecord,
+    MemoryStore,
+    PostgresSettings,
+    RedisSettings,
+    StoreConfig,
+    build_memory_store,
+    clear_embedding_providers,
+    register_embedding_provider,
+)
+from internal.memory_rag import MemoryRAG, MemoryRetrievalConfig
+from scripts import setup_memory
+
+
+@pytest.fixture(autouse=True)
+def _reset_embedding_cache() -> Iterator[None]:
+    clear_embedding_providers()
+    yield
+    clear_embedding_providers()
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def redis_service() -> Iterator[Dict[str, object]]:
+    redis_mod = pytest.importorskip("redis")
+    url = os.getenv("TEST_REDIS_URL")
+    if url:
+        client = redis_mod.Redis.from_url(url)
+        try:
+            client.ping()
+        except redis_mod.RedisError as exc:  # type: ignore[attr-defined]
+            pytest.skip(f"Redis service not reachable: {exc}")
+        yield {"url": url, "client": client}
+        client.flushdb()
+        return
+
+    binary = shutil.which("redis-server")
+    if not binary:
+        pytest.skip("redis-server binary missing; set TEST_REDIS_URL to run Redis integration tests")
+
+    port = _find_free_port()
+    proc = subprocess.Popen(
+        [
+            binary,
+            "--save",
+            "",
+            "--appendonly",
+            "no",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    client = redis_mod.Redis(host="127.0.0.1", port=port, db=0)
+    for _ in range(50):
+        try:
+            client.ping()
+            break
+        except redis_mod.RedisError:  # type: ignore[attr-defined]
+            time.sleep(0.1)
+    else:
+        proc.terminate()
+        pytest.skip("Redis server failed to start within the timeout window")
+
+    yield {"url": f"redis://127.0.0.1:{port}/0", "client": client, "process": proc}
+
+    client.flushdb()
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+@pytest.fixture
+def redis_store(redis_service: Dict[str, object]) -> Iterator[MemoryStore]:
+    url = str(redis_service["url"])
+    config = StoreConfig(
+        scope="short_term",
+        backend="redis",
+        redis=RedisSettings(url=url),
+        options={
+            "namespace": "autocoder:test",
+            "vector_index": "autocoder_test_idx",
+            "vector_dimensions": 2,
+        },
+    )
+    result = setup_memory.ensure_redis_ready(config)
+    if not result.ok:
+        pytest.skip(result.hint or result.detail)
+
+    store = build_memory_store(config.copy())
+    try:
+        yield store  # type: ignore[misc]
+    finally:
+        try:
+            client = redis_service["client"]
+            if hasattr(client, "flushdb"):
+                client.flushdb()
+        except Exception:
+            pass
+
+
+@pytest.fixture(scope="session")
+def postgres_config() -> Iterator[StoreConfig]:
+    dsn = os.getenv("TEST_POSTGRES_DSN")
+    if not dsn:
+        pytest.skip("Set TEST_POSTGRES_DSN to run PostgreSQL integration tests")
+
+    psycopg_mod = pytest.importorskip("psycopg")
+
+    try:
+        conn = psycopg_mod.connect(dsn)
+        conn.close()
+    except Exception as exc:  # pragma: no cover - configuration error
+        pytest.skip(f"Unable to connect to PostgreSQL using TEST_POSTGRES_DSN: {exc}")
+
+    config = StoreConfig(scope="long_term", backend="postgres", postgres=PostgresSettings(dsn=dsn))
+    migrations_dir = Path(__file__).resolve().parents[1] / "internal" / "db" / "migrations"
+    result = setup_memory.ensure_postgres_ready(config, migrations_path=migrations_dir)
+    if not result.ok:
+        pytest.skip(result.hint or result.detail)
+
+    yield config
+
+    with psycopg_mod.connect(dsn, autocommit=True) as conn:
+        for table in ("memory_links", "memory_tags", "memory_entry_history", "memory_entries"):
+            conn.execute(f"TRUNCATE {table} RESTART IDENTITY CASCADE")
+
+
+@pytest.fixture
+def postgres_store(postgres_config: StoreConfig) -> Iterator[MemoryStore]:
+    store = build_memory_store(postgres_config.copy())
+    try:
+        yield store  # type: ignore[misc]
+    finally:
+        pool = getattr(store, "_pool", None)
+        if pool is not None:
+            try:
+                pool.close()
+            except Exception:
+                pass
+
+
+@pytest.mark.integration
+def test_redis_store_lifecycle(redis_store: MemoryStore) -> None:
+    metadata = MemoryMetadata(source="redis", tags=("alpha",), attributes={"session_id": "redis-session"})
+    record = MemoryRecord(content="Alpha memo", metadata=metadata, embedding=[1.0, 0.0])
+
+    stored = redis_store.add(record)
+    fetched = redis_store.get(stored.record_id)
+    assert fetched.content == "Alpha memo"
+
+    updated = redis_store.update(stored.record_id, content="Updated alpha memo")
+    assert updated.content == "Updated alpha memo"
+
+    results = redis_store.fetch(MemoryQuery(text="alpha", limit=5, metadata_filters={"tags": ("alpha",)}))
+    assert any(item.record_id == stored.record_id for item in results)
+
+    long_term = InMemoryMemoryStore()
+    promoted = redis_store.promote_to_long_term(stored.record_id, long_term, strategy="copy")
+    assert long_term.get(promoted.record_id).content == "Updated alpha memo"
+
+    redis_store.delete(stored.record_id, hard=True)
+    with pytest.raises(KeyError):
+        redis_store.get(stored.record_id)
+
+    redis_store.compact()
+
+
+@pytest.mark.integration
+def test_postgres_store_lifecycle(postgres_store: MemoryStore) -> None:
+    metadata = MemoryMetadata(source="postgres", tags=("beta",), attributes={"project": "proj-1"})
+    record = MemoryRecord(content="Beta memo", metadata=metadata)
+
+    stored = postgres_store.add(record)
+    fetched = postgres_store.get(stored.record_id)
+    assert fetched.content == "Beta memo"
+
+    postgres_store.update(stored.record_id, content="Beta memo updated")
+    results = postgres_store.fetch(MemoryQuery(text="updated", limit=5))
+    assert any(item.record_id == stored.record_id for item in results)
+
+    postgres_store.delete(stored.record_id)
+    with pytest.raises(KeyError):
+        postgres_store.get(stored.record_id)
+
+    postgres_store.compact()
+
+
+@pytest.mark.integration
+def test_rag_across_backends(
+    redis_store: MemoryStore,
+    postgres_store: MemoryStore,
+) -> None:
+    def embed(text: str) -> list[float]:
+        lowered = text.lower()
+        return [1.0 if "alpha" in lowered else 0.0, 1.0 if "beta" in lowered else 0.0]
+
+    register_embedding_provider(embed, model_name="integration-test")
+
+    short_metadata = MemoryMetadata(source="redis", tags=("alpha",), attributes={"session_id": "rag"})
+    short_record = MemoryRecord(
+        content="Alpha project overview",
+        metadata=short_metadata,
+        embedding=[1.0, 0.0],
+    )
+    redis_store.add(short_record)
+
+    long_metadata = MemoryMetadata(source="postgres", tags=("beta",), attributes={"project": "rag"})
+    long_record = MemoryRecord(
+        content="Beta roadmap and milestones",
+        metadata=long_metadata,
+        score=0.9,
+    )
+    postgres_store.add(long_record)
+
+    rag = MemoryRAG(
+        short_term=redis_store,
+        long_term=postgres_store,
+        config=MemoryRetrievalConfig(short_term_weight=1.4, long_term_weight=1.0, include_combined=False),
+    )
+
+    alpha_hits = list(rag.query_memory("alpha milestones", limit=5))
+    assert any(hit.scope == "short_term" for hit in alpha_hits)
+
+    beta_hits = list(rag.query_memory("beta milestones", limit=5))
+    assert any(hit.scope == "long_term" for hit in beta_hits)


### PR DESCRIPTION
## Summary
- add a reusable `scripts/setup_memory.py` helper that validates Redis/PostgreSQL connectivity, provisions indexes, and reports actionable status details
- extend the test suite with Redis/PostgreSQL lifecycle and RAG integration coverage plus pytest marker registration
- document memory environment variables, setup workflow, and troubleshooting guidance for operators

## Testing
- pytest tests/test_memory_backends.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e89b11da5c832fa27548cbf0d971ac