### PR TITLE
Seed manager sessions from persisted memory

### DIFF
--- a/agents/manager.py
+++ b/agents/manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from dataclasses import dataclass, field
+import logging
 import time
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence, TYPE_CHECKING
 from uuid import uuid4
@@ -15,6 +16,7 @@ from memory import (
     ConversationMemoryHooks,
     MemoryFacade,
     MemoryRouter,
+    MemoryRecord,
     get_shared_memory_facade,
     get_shared_memory_router,
     set_shared_memory_facade,
@@ -44,6 +46,9 @@ __all__ = [
     "ManagerResult",
     "ManagerAgent",
 ]
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -242,6 +247,7 @@ class ManagerAgent:
                 session_id=self.session_id,
                 agent_label="manager",
             )
+            self._seed_conversation_history_from_memory()
         if test_critic is not None:
             self.attach_test_critic(test_critic)
         if eval_agent is not None:
@@ -386,6 +392,91 @@ class ManagerAgent:
             include_untracked=include_untracked,
         )
         return bundle.to_dict()
+
+    # ------------------------------------------------------------------
+    # Conversation replay helpers
+    # ------------------------------------------------------------------
+
+    def _seed_conversation_history_from_memory(self) -> None:
+        if not self.session_id or self.memory_facade is None:
+            return
+
+        chat_session = getattr(self.session, "chat_session", None)
+        if chat_session is None:
+            return
+        chat = getattr(chat_session, "chat", None)
+        if chat is None or not hasattr(chat, "append"):
+            return
+
+        existing = getattr(chat, "messages", None)
+        if isinstance(existing, list):
+            if any(self._is_conversation_message(message) for message in existing):
+                return
+
+        try:
+            records = self.memory_facade.iter_session_messages(self.session_id)
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.exception(
+                "Failed to replay conversation history for session '%s'", self.session_id
+            )
+            return
+
+        if not records:
+            return
+
+        for message in self._records_to_chat_messages(records):
+            chat.append(message)
+
+    @staticmethod
+    def _is_conversation_message(message: Any) -> bool:
+        if not isinstance(message, Mapping):
+            return False
+        role = message.get("role")
+        if not isinstance(role, str):
+            return False
+        return role.lower() in {"user", "assistant", "tool"}
+
+    def _records_to_chat_messages(self, records: Sequence[MemoryRecord]) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        for record in records:
+            message = self._memory_record_to_chat_message(record)
+            if message:
+                messages.append(message)
+        return messages
+
+    def _memory_record_to_chat_message(self, record: MemoryRecord) -> dict[str, Any]:
+        attributes = record.metadata.attributes if isinstance(record.metadata.attributes, Mapping) else {}
+        role = self._infer_memory_role(record, attributes)
+
+        message: dict[str, Any] = {"role": role, "content": record.content}
+
+        if role == "tool" and isinstance(attributes, Mapping):
+            tool_call_id = attributes.get("tool_call_id")
+            if isinstance(tool_call_id, str):
+                message["tool_call_id"] = tool_call_id
+            tool_name = attributes.get("name")
+            if isinstance(tool_name, str):
+                message["name"] = tool_name
+
+        return message
+
+    @staticmethod
+    def _infer_memory_role(
+        record: MemoryRecord, attributes: Mapping[str, Any] | None
+    ) -> str:
+        if isinstance(attributes, Mapping):
+            role = attributes.get("role")
+            if isinstance(role, str):
+                normalized = role.lower()
+                if normalized in {"system", "user", "assistant", "tool"}:
+                    return normalized
+
+        tags = {str(tag).lower() for tag in record.metadata.tags}
+        for candidate in ("system", "user", "assistant", "tool"):
+            if candidate in tags:
+                return candidate
+
+        return "assistant"
 
     # ------------------------------------------------------------------
     # Research helpers

--- a/memory.py
+++ b/memory.py
@@ -3072,6 +3072,84 @@ class MemoryFacade:
         )
         return store.fetch(query)
 
+    def iter_session_messages(
+        self,
+        session_id: str,
+        *,
+        scope: str | Sequence[str] | None = None,
+        limit: int | None = None,
+    ) -> List[MemoryRecord]:
+        """Return ordered conversation records for ``session_id``.
+
+        The iterator gathers records from the requested ``scope`` (or, by
+        default, both the short- and long-term stores when available), filters
+        them by ``session_id`` and sorts them by the recorded round index so the
+        original conversation order can be reconstructed reliably.
+        """
+
+        if not session_id:
+            return []
+
+        normalized_scopes = self._normalize_history_scopes(scope)
+        if not normalized_scopes:
+            return []
+
+        resolved_limit = None
+        if limit is not None:
+            query_limit = self._coerce_int(limit)
+            if query_limit is not None and query_limit <= 0:
+                return []
+            resolved_limit = query_limit
+        if resolved_limit is None:
+            resolved_limit = 1000
+
+        filters = {"session_id": session_id}
+        collected: List[Tuple[str, MemoryRecord]] = []
+        seen_ids: Set[str] = set()
+
+        for candidate_scope in normalized_scopes:
+            try:
+                store = self._get_store(candidate_scope)
+            except KeyError:
+                LOGGER.debug(
+                    "Skipping unknown memory scope '%s' while replaying session history",
+                    candidate_scope,
+                )
+                continue
+
+            try:
+                fetched = store.fetch(
+                    MemoryQuery(limit=resolved_limit, metadata_filters=filters)
+                )
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.exception(
+                    "Memory scope '%s' failed to provide session history", candidate_scope
+                )
+                continue
+
+            for record in fetched:
+                if record.record_id in seen_ids:
+                    continue
+                seen_ids.add(record.record_id)
+                collected.append((candidate_scope, record))
+
+        if not collected:
+            return []
+
+        ordered: List[MemoryRecord] = []
+        seen_conversation_keys: Set[Tuple[Any, ...]] = set()
+        for scope_name, record in sorted(
+            collected,
+            key=lambda item: self._session_history_sort_key(item[0], item[1]),
+        ):
+            dedup_key = self._session_history_dedup_key(record)
+            if dedup_key in seen_conversation_keys:
+                continue
+            seen_conversation_keys.add(dedup_key)
+            ordered.append(record)
+
+        return ordered
+
     def add(
         self,
         content: str,
@@ -3194,6 +3272,31 @@ class MemoryFacade:
         normalized = scope.lower().replace("-", "_")
         return self.router.get_store(normalized)
 
+    def _normalize_history_scopes(
+        self, scope: str | Sequence[str] | None
+    ) -> Tuple[str, ...]:
+        available = {candidate.lower().replace("-", "_") for candidate in self.router.scopes()}
+        if scope is None:
+            preferred: List[str] = []
+            for candidate in (MemoryRouter.SHORT_TERM, MemoryRouter.LONG_TERM):
+                if candidate in available:
+                    preferred.append(candidate)
+            if not preferred:
+                if self.default_scope in available:
+                    preferred.append(self.default_scope)
+                else:
+                    preferred.extend(sorted(available))
+            return tuple(dict.fromkeys(preferred))
+
+        if isinstance(scope, str):
+            normalized = scope.lower().replace("-", "_")
+            return (normalized,)
+
+        normalized: List[str] = []
+        for candidate in scope:
+            normalized.append(str(candidate).lower().replace("-", "_"))
+        return tuple(normalized)
+
     def _build_metadata(
         self,
         *,
@@ -3219,6 +3322,70 @@ class MemoryFacade:
         )
         metadata.touch()
         return metadata
+
+    def _session_history_sort_key(self, scope: str, record: MemoryRecord) -> Tuple[Any, ...]:
+        attributes: Mapping[str, Any] | None = record.metadata.attributes
+        round_index: int | None = None
+        if isinstance(attributes, Mapping):
+            round_index = self._coerce_int(attributes.get("round_index"))
+
+        timestamp = record.metadata.updated_at or record.metadata.created_at
+        timestamp_value = timestamp.timestamp() if isinstance(timestamp, datetime) else 0.0
+
+        role = self._extract_record_role(record)
+        role_priority = {"system": -1, "user": 0, "assistant": 1, "tool": 2}.get(role, 3)
+
+        missing_round_flag = 1 if round_index is None else 0
+        round_value = round_index if round_index is not None else 0
+
+        normalized_scope = scope.lower().replace("-", "_")
+        if normalized_scope == MemoryRouter.SHORT_TERM:
+            scope_priority = 0
+        elif normalized_scope == MemoryRouter.LONG_TERM:
+            scope_priority = 1
+        else:
+            scope_priority = 2
+
+        return (
+            missing_round_flag,
+            round_value,
+            timestamp_value,
+            role_priority,
+            scope_priority,
+            record.record_id,
+        )
+
+    def _session_history_dedup_key(self, record: MemoryRecord) -> Tuple[Any, ...]:
+        attributes: Mapping[str, Any] | None = record.metadata.attributes
+        round_index: int | None = None
+        if isinstance(attributes, Mapping):
+            round_index = self._coerce_int(attributes.get("round_index"))
+
+        role = self._extract_record_role(record)
+
+        if round_index is not None:
+            return ("round", round_index, role)
+
+        timestamp = record.metadata.created_at
+        timestamp_value = timestamp.timestamp() if isinstance(timestamp, datetime) else 0.0
+        return ("record", role, timestamp_value, record.record_id)
+
+    @staticmethod
+    def _extract_record_role(record: MemoryRecord) -> str:
+        attributes: Mapping[str, Any] | None = record.metadata.attributes
+        if isinstance(attributes, Mapping):
+            role = attributes.get("role")
+            if isinstance(role, str):
+                normalized_role = role.lower()
+                if normalized_role in {"system", "user", "assistant", "tool"}:
+                    return normalized_role
+
+        tags = {str(tag).lower() for tag in record.metadata.tags}
+        for candidate in ("system", "user", "assistant", "tool"):
+            if candidate in tags:
+                return candidate
+
+        return "assistant"
 
     def _sanitize_attributes(self, attributes: Mapping[str, Any] | None) -> Dict[str, Any]:
         if not attributes:

--- a/tests/test_manager_memory_replay.py
+++ b/tests/test_manager_memory_replay.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Mapping
+
+import pytest
+
+class _StubModel:
+    def respond(self, *_, **__):
+        return {"choices": [{"message": {"content": "stub"}}]}
+
+    def respond_stream(self, *_, **__):
+        return iter(())
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None) -> None:
+        self.messages: list[Mapping[str, Any]] = []
+        if system_prompt is not None:
+            self.messages.append({"role": "system", "content": system_prompt})
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":
+        instance = cls()
+        if isinstance(history, Mapping):
+            messages = history.get("messages", [])
+            if isinstance(messages, list):
+                instance.messages = list(messages)
+        elif isinstance(history, str):
+            instance.messages = [{"role": "user", "content": history}]
+        return instance
+
+    def add_user_message(self, content: str) -> None:
+        self.messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        self.messages.append({"role": "assistant", "content": content})
+
+    def append(self, message: Mapping[str, Any]) -> None:
+        self.messages.append(dict(message))
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *_, **__: _StubModel(),
+        Chat=_StubChat,
+        ToolFunctionDef=types.SimpleNamespace,
+    ),
+)
+
+
+class _StubProcess:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+    def kill(self) -> None:
+        return None
+
+    def terminate(self) -> None:
+        return None
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return 0
+
+    def is_running(self) -> bool:
+        return False
+
+    def as_dict(self, attrs: list[str] | None = None) -> dict[str, Any]:
+        del attrs
+        return {"pid": self.pid}
+
+    def children(self, recursive: bool = False) -> list["_StubProcess"]:
+        del recursive
+        return []
+
+
+sys.modules.setdefault(
+    "psutil",
+    types.SimpleNamespace(
+        Process=_StubProcess,
+        NoSuchProcess=RuntimeError,
+        TimeoutExpired=TimeoutError,
+        process_iter=lambda *_, **__: [],
+    ),
+)
+
+from agents.manager import ManagerAgent
+from memory import InMemoryMemoryStore, MemoryFacade, MemoryRouter
+
+
+class _ReplayableChat:
+    def __init__(self) -> None:
+        self.messages: list[Mapping[str, Any]] = [
+            {"role": "system", "content": "You are a helpful assistant."}
+        ]
+
+    def append(self, message: Mapping[str, Any]) -> None:
+        self.messages.append(dict(message))
+
+
+class _ReplayableChatSession:
+    def __init__(self) -> None:
+        self.chat = _ReplayableChat()
+
+
+class ReplayableSession:
+    def __init__(self) -> None:
+        self.chat_session = _ReplayableChatSession()
+        self.rounds: list[Any] = []
+
+    def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:
+        del on_round_start, on_round_end
+
+
+@pytest.fixture()
+def memory_facade() -> MemoryFacade:
+    short_store = InMemoryMemoryStore()
+    long_store = InMemoryMemoryStore()
+    router = MemoryRouter(
+        {
+            MemoryRouter.SHORT_TERM: short_store,
+            MemoryRouter.LONG_TERM: long_store,
+        }
+    )
+    facade = MemoryFacade(router, combined_scope=MemoryRouter.SHORT_TERM)
+    return facade
+
+
+def test_manager_replays_conversation_history(memory_facade: MemoryFacade) -> None:
+    session_id = "replay-session"
+
+    memory_facade.add(
+        "Prior question",
+        scope=MemoryRouter.SHORT_TERM,
+        tags=("conversation", "user"),
+        attributes={"role": "user", "round_index": 0},
+        session_id=session_id,
+    )
+    memory_facade.add(
+        "Prior answer",
+        scope=MemoryRouter.SHORT_TERM,
+        tags=("conversation", "assistant"),
+        attributes={"role": "assistant", "round_index": 0},
+        session_id=session_id,
+    )
+    memory_facade.add(
+        "Follow-up question",
+        scope=MemoryRouter.LONG_TERM,
+        tags=("conversation", "user"),
+        attributes={"role": "user", "round_index": 1},
+        session_id=session_id,
+    )
+    memory_facade.add(
+        "Follow-up answer",
+        scope=MemoryRouter.LONG_TERM,
+        tags=("conversation", "assistant"),
+        attributes={"role": "assistant", "round_index": 1},
+        session_id=session_id,
+    )
+
+    session = ReplayableSession()
+
+    ManagerAgent(
+        session=session,
+        memory_facade=memory_facade,
+        memory_router=memory_facade.router,
+        session_id=session_id,
+    )
+
+    messages = session.chat_session.chat.messages
+    assert messages, "Expected chat history to contain seeded messages"
+
+    conversation = [
+        (message["role"], message["content"])
+        for message in messages
+        if message.get("role") != "system"
+    ]
+
+    assert conversation == [
+        ("user", "Prior question"),
+        ("assistant", "Prior answer"),
+        ("user", "Follow-up question"),
+        ("assistant", "Follow-up answer"),
+    ]


### PR DESCRIPTION
## Summary
- add a `MemoryFacade.iter_session_messages` helper that collects ordered records for a session across short- and long-term stores
- preload `ManagerAgent` chat history from persisted memory when a session_id is supplied
- add regression coverage ensuring stored conversations are replayed before handling a new prompt

## Testing
- pytest tests/test_manager_memory_replay.py

------
https://chatgpt.com/codex/tasks/task_b_68e8ac84a5d8832f804eb8d8a66784b3