### PR TITLE
Add MCP server configuration support

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -373,6 +373,7 @@ def create_agent(
         on_tool_result=on_tool_result,
         on_round_start=on_round_start,
         on_round_end=on_round_end,
+        tool_registry=registry,
     )
 
 
@@ -394,6 +395,7 @@ class AgentBuilder:
     _toolsets: MutableSequence[str] = field(default_factory=list)
     _tools: MutableSequence[ToolSpec | Any] = field(default_factory=list)
     _tool_names: MutableSequence[str] = field(default_factory=list)
+    _mcp_servers: MutableSequence[Any] = field(default_factory=list)
 
     def with_toolsets(self, *names: str) -> "AgentBuilder":
         self._toolsets.extend(names)
@@ -405,6 +407,13 @@ class AgentBuilder:
 
     def with_tool_names(self, *names: str) -> "AgentBuilder":
         self._tool_names.extend(names)
+        return self
+
+    def with_mcp_servers(self, *configs: Any) -> "AgentBuilder":
+        """Schedule MCP server configurations to be registered at build time."""
+
+        if configs:
+            self._mcp_servers.extend(configs)
         return self
 
     def with_model(self, *, model: Any | None = None, model_name: str | None = None) -> "AgentBuilder":
@@ -419,15 +428,23 @@ class AgentBuilder:
         return self
 
     def build(self) -> AgentSession:
+        registry = self.registry or _DEFAULT_TOOL_REGISTRY
+        tools: list[ToolSpec | Any] = list(self._tools)
+        if self._mcp_servers:
+            from mcp_tooling import register_mcp_servers
+
+            mcp_specs = register_mcp_servers(registry, self._mcp_servers, replace=True)
+            tools.extend(mcp_specs)
+
         return create_agent(
             system_prompt=self.system_prompt,
             history=self.history,
             model=self.model,
             model_name=self.model_name,
             toolsets=self._toolsets,
-            tools=self._tools,
+            tools=tools,
             tool_names=self._tool_names,
-            registry=self.registry,
+            registry=registry,
             callbacks=self.callbacks,
             on_message=self.on_message,
             on_tool_call=self.on_tool_call,

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from internal.DAG import DAG
 from internal.structures import StructuredResponse
 from session import AgentRound, AgentSession
+from tooling import ToolRegistry, ToolSpec
 from memory import (
     ConversationMemoryHooks,
     MemoryFacade,
@@ -36,6 +37,7 @@ from .repo_context import (
 from .security import SecurityAgent, SecurityScanResult
 
 if TYPE_CHECKING:
+    from mcp_tooling import MCPServerRegistry
     from .research import ResearchAgent, ResearchResult, ResearchSnippet
     from .tester import CriticStatusEvent, TestCriticAgent, TestCriticReport
     from .eval import PromptComparison
@@ -177,12 +179,15 @@ class ManagerAgent:
         memory_router: MemoryRouter | None = None,
         memory_facade: MemoryFacade | None = None,
         session_id: str | None = None,
+        mcp_registry: "MCPServerRegistry" | None = None,
     ) -> None:
         if session is None:
             if session_factory is None:
                 raise ValueError("ManagerAgent requires a session or session_factory")
             session = session_factory()
         self.session = session
+        self.tool_registry: ToolRegistry | None = getattr(session, "tool_registry", None)
+        self.mcp_registry = mcp_registry
         self.session_id = session_id or uuid4().hex
         self._status_callback = status_callback
         self._plan_builder = plan_builder or self._default_plan_builder
@@ -550,6 +555,32 @@ class ManagerAgent:
             key = audience.lower()
             snippets = list(snapshot.get(key, ()))
         return [snippet.to_dict() if hasattr(snippet, "to_dict") else snippet for snippet in snippets]
+
+    # ------------------------------------------------------------------
+    # MCP server integration helpers
+    # ------------------------------------------------------------------
+    def refresh_mcp_tools(
+        self,
+        *,
+        registry: "MCPServerRegistry" | None = None,
+        tool_registry: ToolRegistry | None = None,
+        auto_start: bool = False,
+    ) -> list[ToolSpec]:
+        """Refresh MCP tool metadata using live descriptors from ``registry``."""
+
+        target_registry: "MCPServerRegistry" | None = registry or self.mcp_registry
+        if target_registry is None:
+            raise ValueError("No MCP server registry is available for refresh")
+
+        active_tool_registry = tool_registry or self.tool_registry
+        if active_tool_registry is None:
+            raise ValueError("The manager session is not associated with a tool registry")
+
+        server_specs = target_registry.build_specs(auto_start=auto_start)
+        from mcp_tooling import register_mcp_servers
+
+        updated_specs = register_mcp_servers(active_tool_registry, server_specs, replace=True)
+        return self.session.replace_mcp_tools(updated_specs)
 
     def _record_research_evidence(
         self,

--- a/main.py
+++ b/main.py
@@ -4,20 +4,27 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Callable
+from typing import Any, Callable, Sequence
 
 from agents import AgentBuilder
 from agents.manager import ManagerAgent, ManagerResult, ManagerStatusUpdate
 from memory import MemoryFacade, build_memory_router, set_shared_memory_facade
+from mcp_tooling import MCPConfigurationError, MCPServerRegistry
 
 
-def _build_manager() -> ManagerAgent:
+def _build_manager(
+    *,
+    mcp_servers: Sequence[Any] | None = None,
+    mcp_registry: MCPServerRegistry | None = None,
+) -> ManagerAgent:
     router = build_memory_router()
     facade = MemoryFacade(router)
     set_shared_memory_facade(facade)
 
     builder = AgentBuilder()
     builder.with_toolsets("memory")
+    if mcp_servers:
+        builder.with_mcp_servers(*mcp_servers)
     session = builder.build()
 
     def status_printer(update: ManagerStatusUpdate) -> None:
@@ -30,6 +37,7 @@ def _build_manager() -> ManagerAgent:
         status_callback=status_printer,
         memory_router=router,
         memory_facade=facade,
+        mcp_registry=mcp_registry,
     )
 
 
@@ -63,8 +71,38 @@ def _render_result(result: ManagerResult) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Start the Auto-Coder manager agent")
-    _ = parser.parse_args(argv)
-    return _interactive_loop(_build_manager)
+    parser.add_argument(
+        "--config",
+        dest="config_path",
+        help="Path to config.json providing memory and MCP settings",
+    )
+    parser.add_argument(
+        "--mcp-config",
+        dest="mcp_config_path",
+        help="Optional override for the MCP server configuration file",
+    )
+    args = parser.parse_args(argv)
+
+    config_override = args.mcp_config_path or args.config_path
+
+    try:
+        mcp_registry = MCPServerRegistry.from_loaded_config(config_override)
+    except MCPConfigurationError as exc:
+        print(f"Failed to load MCP configuration: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        mcp_specs = mcp_registry.build_specs(auto_start=True)
+    except (MCPConfigurationError, TimeoutError, OSError) as exc:
+        print(f"Failed to start MCP servers: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        return _interactive_loop(
+            lambda: _build_manager(mcp_servers=mcp_specs, mcp_registry=mcp_registry)
+        )
+    finally:
+        mcp_registry.shutdown_all()
 
 
 if __name__ == "__main__":

--- a/mcp_tooling.py
+++ b/mcp_tooling.py
@@ -18,7 +18,7 @@ import re
 import subprocess
 import threading
 import time
-from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence
+from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence, TYPE_CHECKING
 import urllib.request
 
 
@@ -378,11 +378,17 @@ class MCPServerSpec:
     lifecycle: Optional[CommandServerLifecycle] = None
 
 
+if TYPE_CHECKING:
+    from tooling import ToolRegistry, ToolSpec
+
+
 class MCPServerRegistry:
     """Validate and normalise MCP server configuration entries."""
 
     def __init__(self, entries: Optional[Mapping[str, Any]] = None) -> None:
         self._configs: dict[str, MCPServerConfig] = {}
+        self._lifecycles: dict[str, CommandServerLifecycle] = {}
+        self._specs: dict[str, MCPServerSpec] = {}
         if entries:
             self.update(entries)
 
@@ -395,6 +401,11 @@ class MCPServerRegistry:
         for label, payload in entries.items():
             config = self._normalise_entry(label, payload)
             self._configs[config.label] = config
+            self._specs.pop(config.label, None)
+            lifecycle = self._lifecycles.get(config.label)
+            if lifecycle is not None and lifecycle.config != config:
+                lifecycle.shutdown()
+                self._lifecycles.pop(config.label, None)
 
     def _normalise_entry(self, label: str, payload: Any) -> MCPServerConfig:
         if not isinstance(payload, Mapping):
@@ -477,33 +488,112 @@ class MCPServerRegistry:
     def all(self) -> list[MCPServerConfig]:
         return list(self._configs.values())
 
+    def _ensure_lifecycle(self, config: CommandMCPServerConfig) -> CommandServerLifecycle:
+        lifecycle = self._lifecycles.get(config.label)
+        if lifecycle is not None and lifecycle.config != config:
+            lifecycle.shutdown()
+            lifecycle = None
+        if lifecycle is None:
+            lifecycle = CommandServerLifecycle(config)
+            self._lifecycles[config.label] = lifecycle
+        return lifecycle
+
     def build_specs(self, *, auto_start: bool = False) -> list[MCPServerSpec]:
         specs: list[MCPServerSpec] = []
         for config in self._configs.values():
             lifecycle: Optional[CommandServerLifecycle] = None
             descriptor = config.descriptor()
             if isinstance(config, CommandMCPServerConfig):
-                lifecycle = CommandServerLifecycle(config)
-                descriptor["pid"] = None
+                lifecycle = self._ensure_lifecycle(config)
                 if auto_start:
                     lifecycle.start()
-                    descriptor["pid"] = lifecycle.pid
+                descriptor["pid"] = lifecycle.pid
+            elif config.label in self._lifecycles:
+                lifecycle = self._lifecycles[config.label]
+                descriptor.setdefault("pid", lifecycle.pid)
+            descriptor.setdefault("server_type", config.kind)
             spec = MCPServerSpec(
                 config=config,
                 descriptor=descriptor,
                 lifecycle=lifecycle,
             )
             specs.append(spec)
+            self._specs[config.label] = spec
         return specs
 
     def start_all(self) -> list[CommandServerLifecycle]:
         lifecycles: list[CommandServerLifecycle] = []
         for config in self._configs.values():
             if isinstance(config, CommandMCPServerConfig):
-                lifecycle = CommandServerLifecycle(config)
+                lifecycle = self._ensure_lifecycle(config)
                 lifecycle.start()
                 lifecycles.append(lifecycle)
         return lifecycles
 
     def labels(self) -> Iterable[str]:
         return list(self._configs.keys())
+
+    def get_spec(self, label: str) -> MCPServerSpec:
+        return self._specs[label]
+
+    def specs(self) -> list[MCPServerSpec]:
+        return list(self._specs.values())
+
+    def get_lifecycle(self, label: str) -> Optional[CommandServerLifecycle]:
+        return self._lifecycles.get(label)
+
+    def shutdown_all(self) -> None:
+        for lifecycle in self._lifecycles.values():
+            lifecycle.shutdown()
+
+
+def _coerce_server_descriptor(
+    server: MCPServerSpec | MCPServerConfig | Mapping[str, Any]
+) -> tuple[str, dict[str, Any], str | None]:
+    if isinstance(server, MCPServerSpec):
+        descriptor = dict(server.descriptor)
+        descriptor.setdefault("label", server.config.label)
+        descriptor.setdefault("type", server.config.kind)
+        descriptor.setdefault("server_type", server.config.kind)
+        if server.lifecycle is not None:
+            descriptor.setdefault("pid", server.lifecycle.pid)
+        return descriptor["label"], descriptor, descriptor.get("description")
+    if isinstance(server, MCPServerConfig):
+        descriptor = server.descriptor()
+        descriptor.setdefault("label", server.label)
+        descriptor.setdefault("type", server.kind)
+        descriptor.setdefault("server_type", server.kind)
+        return descriptor["label"], descriptor, descriptor.get("description")
+    if isinstance(server, Mapping):
+        descriptor = {str(key): value for key, value in server.items()}
+        label = str(descriptor.get("label") or descriptor.get("name") or "").strip()
+        if not label:
+            raise MCPConfigurationError("MCP server descriptors must include a non-empty label")
+        descriptor["label"] = label
+        server_type = descriptor.get("type") or descriptor.get("server_type")
+        if server_type:
+            descriptor.setdefault("type", server_type)
+            descriptor.setdefault("server_type", server_type)
+        return label, descriptor, descriptor.get("description")
+    raise TypeError(f"Unsupported MCP server specification: {type(server)!r}")
+
+
+def register_mcp_servers(
+    registry: "ToolRegistry",
+    servers: Iterable[MCPServerSpec | MCPServerConfig | Mapping[str, Any]],
+    *,
+    replace: bool = False,
+) -> list["ToolSpec"]:
+    from tooling import ToolSpec as _ToolSpec
+
+    registered: list[_ToolSpec] = []
+    for server in servers:
+        label, descriptor, description = _coerce_server_descriptor(server)
+        spec = registry.register_mcp_tool(
+            label,
+            descriptor,
+            description=str(description) if description else None,
+            replace=replace,
+        )
+        registered.append(spec)
+    return registered

--- a/session.py
+++ b/session.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 from chat import CallbackMap, ChatSession
 from internal.structures import StructuredResponse
-from tooling import ToolSpec
+from tooling import ToolRegistry, ToolSpec
 
 __all__ = ["AgentRound", "AgentSession"]
 
@@ -91,6 +91,7 @@ class AgentSession:
         on_tool_result: Hook | None = None,
         on_round_start: Hook | None = None,
         on_round_end: Hook | None = None,
+        tool_registry: ToolRegistry | None = None,
     ) -> None:
         self.chat_session = ChatSession.create(
             system_prompt=system_prompt,
@@ -110,6 +111,7 @@ class AgentSession:
         self._on_round_start = on_round_start
         self._on_round_end = on_round_end
         self.rounds: list[AgentRound] = []
+        self.tool_registry = tool_registry
 
     @property
     def model(self) -> Any:
@@ -134,6 +136,32 @@ class AgentSession:
         tool_names: Sequence[str] | None = None,
     ) -> None:
         self.chat_session.set_tools(tools, tool_names)
+
+    def replace_mcp_tools(self, new_specs: Iterable[ToolSpec]) -> list[ToolSpec]:
+        """Update the active MCP tool definitions while preserving other tools."""
+
+        replacements = {spec.name: spec for spec in new_specs}
+        updated: list[ToolSpec] = []
+        seen: set[str] = set()
+
+        for spec in self.tools:
+            if spec.tool_type == "mcp":
+                replacement = replacements.get(spec.name)
+                if replacement is not None:
+                    updated.append(replacement)
+                    seen.add(spec.name)
+                else:
+                    updated.append(spec)
+            else:
+                updated.append(spec)
+
+        for spec in new_specs:
+            if spec.name not in seen and all(existing.name != spec.name for existing in updated):
+                updated.append(spec)
+                seen.add(spec.name)
+
+        self.set_tools(updated)
+        return [spec for spec in updated if spec.tool_type == "mcp"]
 
     def append_user_input(self, content: str) -> None:
         self.chat_session.append_user_input(content)


### PR DESCRIPTION
## Summary
- extend `AgentBuilder` with MCP server support and teach sessions to track the tool registry
- add lifecycle-aware MCP registry helpers and a utility for registering MCP servers as tools
- wire the CLI to load MCP configs, auto-start command servers, and shut them down cleanly while exposing refresh hooks on the manager

## Testing
- `pytest` *(fails: missing numpy dependency required by speech tests)*

------
https://chatgpt.com/codex/tasks/task_b_68e9be1e37b8832f9b1d868e5473718f