### PR TITLE
Add tests for tool payload overrides

### DIFF
--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -36,11 +36,17 @@
 ## Tool Registry (`tooling.py`)
 
 - Defines `ToolSpec`, a dataclass capturing tool metadata, callable
-  implementation, and parameters required by LM Studio's tool interface.
-  [`tooling.py`](../../tooling.py)
+  implementation, parameters, and payload overrides for LM Studio's tool
+  interface. The spec now differentiates between standard function tools and
+  MCP integrations via the `tool_type` attribute, allowing non-callable
+  metadata-only tools to be registered safely. [`tooling.py`](../../tooling.py)
 - Offers `ToolRegistry` for registering callables, resolving tool references by
   name, preventing duplicates, and ensuring each tool exposes type annotations
-  and documentation. [`tooling.py`](../../tooling.py)
+  and documentation. Registry helpers deduplicate by tool name and support
+  pre-built `ToolSpec` instances alongside callables. [`tooling.py`](../../tooling.py)
+- Provides `register_mcp_tool` for registering MCP servers from JSON payloads,
+  merging header/metadata overrides while co-existing with standard tools.
+  [`tooling.py`](../../tooling.py)
 - Includes discovery helpers (`discover_module_tools`, `discover_package_tools`)
   to automatically register tools from modules or packages. [`tooling.py`](../../tooling.py)
 

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -294,6 +294,54 @@ def test_register_mcp_tool_supports_payloads(lmstudio_env):
         tooling.unregister_tool("demo-mcp")
 
 
+def test_tool_spec_payload_overrides_merge_into_function_payload(lmstudio_env):
+    tooling_mod = lmstudio_env.tooling
+
+    def echo(value: int) -> int:
+        """Return the provided integer value."""
+
+        return value
+
+    spec = tooling_mod.register_tool(
+        echo,
+        name="echo_payload",
+        description="Return the provided integer value.",
+        parameters={"value": int},
+    )
+    try:
+        spec.payload_overrides = {
+            "function": {
+                "parameters": {"value": {"type": "integer", "minimum": 0}}
+            }
+        }
+        payload = spec.to_payload()
+        assert payload["function"]["parameters"]["value"]["minimum"] == 0
+        assert payload["function"]["implementation"] is echo
+    finally:
+        tooling_mod.unregister_tool("echo_payload")
+
+
+def test_mcp_tool_payload_respects_overrides(lmstudio_env):
+    tooling_mod = lmstudio_env.tooling
+    payload = {
+        "label": "overridden-mcp",
+        "server_url": "https://example.org/mcp",
+        "allowed_tools": ["inspect"],
+    }
+    overrides = {"allowed_tools": ["inspect", "summarize"], "metadata": {"tier": "gold"}}
+    spec = tooling_mod.register_mcp_tool(
+        "overridden-mcp",
+        payload,
+        payload_overrides=overrides,
+    )
+    try:
+        payload_out = spec.to_payload()
+        assert payload_out["allowed_tools"] == ["inspect", "summarize"]
+        assert payload_out["metadata"]["tier"] == "gold"
+    finally:
+        tooling_mod.unregister_tool("overridden-mcp")
+
+
 def test_act_requires_tools(lmstudio_env):
     chat = lmstudio_env.chat
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- add regression coverage ensuring ToolSpec payload overrides merge into function payloads
- add tests verifying MCP tool overrides are preserved when generating payloads
- update the runtime documentation to reflect tool_type and MCP registration support

## Testing
- pytest tests/test_chat_tools.py -k "mcp or overrides" -q

------
https://chatgpt.com/codex/tasks/task_b_68e9ffc3a4cc832fa7a467abac78625a