### PR TITLE
Add MCP tooling tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [Development Workflow](#development-workflow)
   - [Running Tests](#running-tests)
   - [Playwright Browser Support](#playwright-browser-support)
+- [MCP Server Integration](#mcp-server-integration)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 - [Community & Support](#community--support)
@@ -114,6 +115,64 @@ playwright install
 ```
 
 This unlocks the Playwright-backed search pipeline in `internal/web_playwright.py` and `internal/RAG.py`.
+
+## MCP Server Integration
+
+Auto-Coder can treat [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) servers as first-class tools alongside local Python callables. The `mcp_tooling` module normalises configuration, launches command-based servers, and registers remote/local descriptors with the default `ToolRegistry` so that every entry serialises to `{"type": "mcp", ...}` during `model.act` calls.
+
+- Define MCP servers inside the `mcp_servers` section of your `config.json`. Override the config path with the `MCP_CONFIG_PATH` environment variable when running custom deployments.
+- Use `AgentBuilder.with_mcp_servers()` to inject MCP descriptors (raw mappings, `MCPServerConfig`, or `MCPServerSpec` instances) before calling `.build()`. The builder defers to `register_mcp_servers()` under the hood, ensuring deduplication and seamless mixing with callable tools.
+- `MCPServerRegistry` and `CommandServerLifecycle` manage validation and command lifecycle (stdout readiness patterns, probe URLs, graceful shutdown signals, etc.).
+
+### Configuration Examples
+
+| Scenario | Example |
+| --- | --- |
+| Local HTTP server | ```json
+{
+  "mcp_servers": {
+    "filesystem": {
+      "type": "local",
+      "url": "http://127.0.0.1:3030",
+      "allowed_tools": ["fs.read", "fs.write"],
+      "headers": {"Authorization": "Bearer local-token"}
+    }
+  }
+}
+``` |
+| Remote HTTPS server | ```json
+{
+  "mcp_servers": {
+    "knowledge-base": {
+      "type": "remote",
+      "url": "https://mcp.example.com/api",
+      "verify_tls": false,
+      "allowed_tools": ["search", "summarize"],
+      "metadata": {"tier": "beta"}
+    }
+  }
+}
+``` |
+| Command-launched server | ```json
+{
+  "mcp_servers": {
+    "git-helper": {
+      "type": "command",
+      "command": ["python", "-m", "git_mcp"],
+      "env": {"MCP_API_KEY": "${GIT_MCP_TOKEN}"},
+      "cwd": "/srv/mcp/git",
+      "ready_pattern": "Server ready",
+      "ready_timeout": 15,
+      "ready_probe_url": "http://127.0.0.1:4040/health",
+      "shutdown_command": ["python", "-m", "git_mcp", "--shutdown"],
+      "shutdown_signal": 15,
+      "capture_output": true
+    }
+  }
+}
+``` |
+
+Each descriptor supports optional `allowed_tools`, `headers`, and `metadata` fields in addition to lifecycle controls such as `ready_pattern`, `ready_timeout`, and graceful shutdown commands or signals. When combined with callable tools, the registry keeps payload ordering intact so mixed tool sets continue to serialise without regression.
 
 ## Documentation
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [ ] Flesh out Agents
 - [ ] Get memory working (Redis + PostgreSQL)
 - [ ] Get session saving and active sessions working (Redis + PostgreSQL)
-- [ ] Enable external tooling through MCP server connectivity with full configurability
+- [x] Enable external tooling through MCP server connectivity with full configurability
 - [ ] Flesh out the core and connect everything together
 - [ ] Flesh out the TUI (Text-based console UI)
 - [ ] Set up `main.py` as the main entry point for the application (using the TUI)

--- a/docs/autocoder/directory-overview.md
+++ b/docs/autocoder/directory-overview.md
@@ -10,6 +10,7 @@ and notable standalone modules.
 | `chat.py` | High-level helpers around the LM Studio Python SDK to send prompts, stream responses, and normalise outputs into structured responses. |
 | `session.py` | Defines `AgentSession` and `AgentRound`, wrapping the chat helpers with tool management, callback hooks, and transcript tracking. |
 | `tooling.py` | Implements the tool registry, normalisation logic, and helpers for discovering/validating callables that can be exposed to models. |
+| `mcp_tooling.py` | Normalises Model Context Protocol server configs (`mcp_servers`) and honours the `MCP_CONFIG_PATH` override for command, local, and remote MCP integrations. |
 | `main.py` | Command-line entry point that builds the manager agent, renders status updates, and runs an interactive REPL loop. |
 | `TUI.py`, `core.py`, `memory.py` | Reserved placeholders for future terminal UI, application core, and memory subsystems respectively. |
 | `internal/` | Shared libraries used across agents (retrieval, speech, schemas, tool wrappers, web automation, etc.). |

--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -50,6 +50,76 @@
 - Includes discovery helpers (`discover_module_tools`, `discover_package_tools`)
   to automatically register tools from modules or packages. [`tooling.py`](../../tooling.py)
 
+## MCP Server Integration (`mcp_tooling.py`)
+
+- `MCPServerRegistry` validates `mcp_servers` entries loaded from `config.json`
+  (or the path pointed to by the `MCP_CONFIG_PATH` environment variable),
+  coercing headers, metadata, and allowed tool lists before constructing
+  `MCPServerSpec` objects. [`mcp_tooling.py`](../../mcp_tooling.py)
+- `CommandServerLifecycle` starts command-based MCP servers, waits for readiness
+  via stdout patterns or probe URLs, and issues shutdown commands, signals, or
+  process kills on teardown. [`mcp_tooling.py`](../../mcp_tooling.py)
+- `register_mcp_servers` mirrors `ToolRegistry.register_mcp_tool`, ensuring each
+  MCP descriptor serialises to a `{"type": "mcp", ...}` payload that can live
+  alongside callable tools inside `model.act`. [`mcp_tooling.py`](../../mcp_tooling.py)
+- `AgentBuilder.with_mcp_servers()` wires descriptors into the same code path as
+  `with_tools`, allowing sessions to mix local callables with remote/local MCP
+  endpoints without manual registry plumbing. [`agents/__init__.py`](../../agents/__init__.py)
+- Example configuration snippets:
+
+  - Local server:
+
+    ```json
+    {
+      "mcp_servers": {
+        "filesystem": {
+          "type": "local",
+          "url": "http://127.0.0.1:3030",
+          "allowed_tools": ["fs.read"]
+        }
+      }
+    }
+    ```
+
+  - Remote server:
+
+    ```json
+    {
+      "mcp_servers": {
+        "knowledge-base": {
+          "type": "remote",
+          "url": "https://mcp.example.com/api",
+          "verify_tls": false,
+          "allowed_tools": ["search", "summarize"]
+        }
+      }
+    }
+    ```
+
+  - Command-launched server:
+
+    ```json
+    {
+      "mcp_servers": {
+        "git-helper": {
+          "type": "command",
+          "command": ["python", "-m", "git_mcp"],
+          "ready_pattern": "Server ready",
+          "ready_timeout": 15,
+          "ready_probe_url": "http://127.0.0.1:4040/health",
+          "shutdown_command": ["python", "-m", "git_mcp", "--shutdown"],
+          "shutdown_signal": 15,
+          "env": {"MCP_API_KEY": "${GIT_MCP_TOKEN}"},
+          "capture_output": true
+        }
+      }
+    }
+    ```
+
+  Optional keys such as `headers`, `metadata`, `cwd`, and `allowed_tools` work
+  uniformly across server types, ensuring consistent payloads during tool
+  resolution and `model.act` execution.
+
 ## Placeholder Modules
 
 - `core.py`, `memory.py`, and `TUI.py` currently contain module headers only,

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -215,9 +215,25 @@ def test_get_tools_by_name_deduplicates(lmstudio_env):
 
 def test_resolve_tools_combines_sources(lmstudio_env):
     tooling = lmstudio_env.tooling
-    first, second = tooling.get_all_tools()[:2]
-    resolved = tooling.resolve_tools(tools=[first], tool_names=[second.name, first.name])
-    assert resolved == [first, second]
+    mcp_spec = tooling.register_mcp_tool(
+        "resolve-mcp",
+        {
+            "label": "resolve-mcp",
+            "url": "https://example.com/resolve",
+            "allowed_tools": ["inspect"],
+        },
+    )
+    try:
+        first, second = tooling.get_all_tools()[:2]
+        resolved = tooling.resolve_tools(
+            tools=[first, mcp_spec],
+            tool_names=[second.name, first.name],
+        )
+        assert resolved == [first, mcp_spec, second]
+        payload_types = [spec.to_payload()["type"] for spec in resolved]
+        assert payload_types[1] == "mcp"
+    finally:
+        tooling.unregister_tool("resolve-mcp")
 
 
 def test_resolve_tools_accepts_callable(lmstudio_env):
@@ -353,11 +369,26 @@ def test_act_invokes_model_with_resolved_tools(lmstudio_env):
     tooling = lmstudio_env.tooling
     model = lmstudio_env.stub.FakeModel()
     tool = tooling.get_all_tools()[0]
-    text, result = chat_mod.act("hi", tools=[tool], model=model)
-    assert text == "act result"
-    assert result.content == "act result"
-    assert result.parsed is None
-    assert model.act_calls[0][1] == [tool.to_payload()]
+    mcp_spec = tooling.register_mcp_tool(
+        "act-mcp",
+        {
+            "label": "act-mcp",
+            "url": "https://example.com/act",
+            "allowed_tools": ["call"],
+        },
+    )
+    try:
+        text, result = chat_mod.act("hi", tools=[tool, mcp_spec], model=model)
+        assert text == "act result"
+        assert result.content == "act result"
+        assert result.parsed is None
+        payloads = model.act_calls[0][1]
+        assert payloads[0]["type"] == "function"
+        assert payloads[0]["function"]["name"] == tool.name
+        assert payloads[1]["type"] == "mcp"
+        assert payloads[1]["server_label"] == "act-mcp"
+    finally:
+        tooling.unregister_tool("act-mcp")
 
 
 def test_chat_session_act_updates_history_and_tools(lmstudio_env):
@@ -367,13 +398,30 @@ def test_chat_session_act_updates_history_and_tools(lmstudio_env):
     chat_instance = stub.Chat("system")
     model = stub.FakeModel()
     tool = tooling.get_all_tools()[0]
-    session = chat_mod.ChatSession(chat=chat_instance, model=model, tools=[tool])
-    text, structured = session.act("do something")
-    assert text == "act result"
-    assert chat_instance.messages[-1]["content"] == "act result"
-    assert session.tools == [tool]
-    assert structured.parsed is None
-    assert model.act_calls[0][1] == [tool.to_payload()]
+    mcp_spec = tooling.register_mcp_tool(
+        "session-mcp",
+        {
+            "label": "session-mcp",
+            "url": "https://example.com/session",
+            "allowed_tools": ["inspect"],
+        },
+    )
+    try:
+        session = chat_mod.ChatSession(
+            chat=chat_instance,
+            model=model,
+            tools=[tool, mcp_spec],
+        )
+        text, structured = session.act("do something")
+        assert text == "act result"
+        assert chat_instance.messages[-1]["content"] == "act result"
+        assert session.tools == [tool, mcp_spec]
+        assert structured.parsed is None
+        payloads = model.act_calls[0][1]
+        assert payloads[0]["function"]["name"] == tool.name
+        assert payloads[1]["type"] == "mcp"
+    finally:
+        tooling.unregister_tool("session-mcp")
 
 
 def test_chat_session_act_requires_tools(lmstudio_env):

--- a/tests/test_mcp_tooling.py
+++ b/tests/test_mcp_tooling.py
@@ -1,0 +1,260 @@
+import sys
+import time
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from mcp_tooling import (
+    CommandMCPServerConfig,
+    CommandServerLifecycle,
+    MCPServerRegistry,
+    register_mcp_servers,
+)
+LMSTUDIO_STUB = ModuleType("lmstudio")
+
+
+class _StubToolFunctionDef:
+    def __init__(self, name, description="", parameters=None, implementation=None):
+        self.name = name
+        self.description = description
+        self.parameters = parameters or {}
+        self.implementation = implementation
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None):  # pragma: no cover - import hook
+        self.system_prompt = system_prompt
+
+
+def _stub_llm(name=None, **kwargs):  # pragma: no cover - import hook
+    class _FakeModel:
+        def respond(self, *args, **kwargs):
+            return None
+
+        def respond_stream(self, *args, **kwargs):
+            return []
+
+        def act(self, *args, **kwargs):
+            return {}
+
+    return _FakeModel()
+
+
+LMSTUDIO_STUB.ToolFunctionDef = _StubToolFunctionDef
+LMSTUDIO_STUB.Chat = _StubChat
+LMSTUDIO_STUB.llm = _stub_llm
+sys.modules.setdefault("lmstudio", LMSTUDIO_STUB)
+
+PSUTIL_STUB = ModuleType("psutil")
+
+
+class _StubPsutilProcess:
+    def __init__(self, pid):  # pragma: no cover - import hook
+        self.pid = pid
+
+    def kill(self):  # pragma: no cover - import hook
+        return None
+
+    def terminate(self):  # pragma: no cover - import hook
+        return None
+
+    def wait(self, timeout=None):  # pragma: no cover - import hook
+        return 0
+
+    def is_running(self):  # pragma: no cover - import hook
+        return False
+
+    def as_dict(self, attrs=None):  # pragma: no cover - import hook
+        return {attr: None for attr in (attrs or [])}
+
+    def children(self, recursive=False):  # pragma: no cover - import hook
+        return []
+
+
+def _stub_process_iter(attrs=None):  # pragma: no cover - import hook
+    return iter(())
+
+
+PSUTIL_STUB.Process = _StubPsutilProcess
+PSUTIL_STUB.NoSuchProcess = RuntimeError
+PSUTIL_STUB.TimeoutExpired = RuntimeError
+PSUTIL_STUB.process_iter = _stub_process_iter
+sys.modules.setdefault("psutil", PSUTIL_STUB)
+
+from tooling import ToolRegistry, ToolSpec
+
+
+class _FakeStream:
+    def __init__(self, *lines: str) -> None:
+        self._lines = list(lines)
+        self.closed = False
+
+    def readline(self) -> str:
+        if self._lines:
+            return self._lines.pop(0)
+        # Give the lifecycle loop time to observe the ready flag before finishing.
+        time.sleep(0.01)
+        return ""
+
+    def close(self) -> None:  # pragma: no cover - exercised via lifecycle shutdown
+        self.closed = True
+
+
+class _FakeProcess:
+    def __init__(self, command, **kwargs) -> None:  # noqa: D401 - pytest helper
+        self.command = list(command)
+        self.kwargs = kwargs
+        self.stdout = _FakeStream("READY\n") if kwargs.get("stdout") is not None else None
+        self.stderr = _FakeStream("") if kwargs.get("stderr") is not None else None
+        self.pid = 4321
+        self.returncode = None
+        self.terminate_called = False
+        self.kill_called = False
+        self.signal_sent = None
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):  # pragma: no cover - defensive
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def terminate(self):
+        self.terminate_called = True
+        self.returncode = 0
+        return 0
+
+    def kill(self):
+        self.kill_called = True
+        self.returncode = -9
+        return -9
+
+    def send_signal(self, sig):
+        self.signal_sent = sig
+        self.returncode = 0
+        return 0
+
+
+@pytest.fixture()
+def fake_popen(monkeypatch):
+    calls: list[_FakeProcess] = []
+
+    def _launcher(command, **kwargs):
+        proc = _FakeProcess(command, **kwargs)
+        calls.append(proc)
+        return proc
+
+    monkeypatch.setattr("subprocess.Popen", _launcher)
+    return SimpleNamespace(calls=calls)
+
+
+@pytest.fixture()
+def agent_builder_cls(monkeypatch):
+    stub = LMSTUDIO_STUB
+    monkeypatch.setitem(sys.modules, "lmstudio", stub)
+    for module_name in ["chat", "session", "agents"]:
+        sys.modules.pop(module_name, None)
+    import agents
+
+    return agents.AgentBuilder
+
+
+def test_command_lifecycle_start_and_cleanup(fake_popen):
+    config = CommandMCPServerConfig(
+        label="demo",
+        command=("python", "-m", "demo"),
+        ready_pattern="READY",
+        ready_timeout=1.0,
+    )
+    lifecycle = CommandServerLifecycle(config)
+    process = lifecycle.start()
+
+    assert fake_popen.calls, "Command launcher should be invoked"
+    assert process.pid == 4321
+    assert lifecycle.pid == 4321
+
+    lifecycle.shutdown()
+    assert fake_popen.calls[0].terminate_called is True
+    assert lifecycle.process is None
+
+
+def test_registry_specs_emit_mcp_payload():
+    registry = MCPServerRegistry(
+        {
+            "remote-search": {
+                "type": "remote",
+                "url": "https://mcp.example.com/search",
+                "allowed_tools": ["search"],
+                "headers": {"Authorization": "Bearer demo"},
+            }
+        }
+    )
+    tool_registry = ToolRegistry()
+    specs = register_mcp_servers(tool_registry, registry.build_specs())
+    assert len(specs) == 1
+    payload = specs[0].to_payload()
+    assert payload["type"] == "mcp"
+    assert payload["server_label"] == "remote-search"
+    assert payload["server_url"] == "https://mcp.example.com/search"
+    assert payload["allowed_tools"] == ["search"]
+    assert payload["headers"]["Authorization"] == "Bearer demo"
+
+
+def test_agent_builder_injects_mcp_specs(monkeypatch, agent_builder_cls):
+    registry = ToolRegistry()
+
+    def echo(value: int) -> int:
+        """Return the provided integer."""
+
+        return value
+
+    function_spec = registry.register(
+        echo,
+        name="echo",
+        description="Return the provided integer.",
+        parameters={"value": int},
+    )
+
+    mcp_spec = ToolSpec(
+        name="demo-mcp",
+        description="Demo MCP",
+        parameters={"label": "demo-mcp"},
+        implementation=None,
+        source={"label": "demo-mcp"},
+        tool_type="mcp",
+    )
+
+    captured = {}
+
+    def fake_register_mcp_servers(registry_arg, configs, *, replace):
+        captured["registry"] = registry_arg
+        captured["configs"] = list(configs)
+        captured["replace"] = replace
+        return [mcp_spec]
+
+    def fake_create_agent(**kwargs):
+        captured["kwargs"] = kwargs
+        return "session"
+
+    import agents
+    import mcp_tooling as mcp_module
+
+    monkeypatch.setattr(mcp_module, "register_mcp_servers", fake_register_mcp_servers)
+    monkeypatch.setattr(agents, "create_agent", fake_create_agent)
+
+    AgentBuilder = agent_builder_cls
+
+    builder = AgentBuilder(system_prompt="hi").using_registry(registry)
+    session = (
+        builder.with_tools(function_spec)
+        .with_mcp_servers({"label": "demo-mcp"})
+        .build()
+    )
+
+    assert session == "session"
+    assert captured["registry"] is registry
+    assert captured["configs"] == [{"label": "demo-mcp"}]
+    assert captured["replace"] is True
+    tools = captured["kwargs"]["tools"]
+    assert tools == [function_spec, mcp_spec]


### PR DESCRIPTION
## Summary
- add dedicated MCP tooling regression tests that cover command lifecycle stubs, registry payloads, and AgentBuilder integration
- extend chat tooling tests to exercise mixed MCP/function tool resolution and model.act payloads
- document MCP server integration details across the README and runtime guide, update directory overview, and mark the MCP TODO complete

## Testing
- pytest tests/test_mcp_tooling.py tests/test_chat_tools.py

------
https://chatgpt.com/codex/tasks/task_b_68ea07d3a590832f8e254a0aac684569