### PR TITLE
Optimize ranking top-k selection

### DIFF
--- a/internal/RAG.py
+++ b/internal/RAG.py
@@ -1,6 +1,7 @@
 import os
 import re
 import math
+import heapq
 import time
 import json
 import html
@@ -76,9 +77,15 @@ class _BM25:
         return score
 
     def topk(self, q: List[str], k: int) -> List[Tuple[int, float]]:
-        scores = [(i, self.score(q, i)) for i in range(self.N)]
-        scores.sort(key=lambda x: x[1], reverse=True)
-        return scores[:k]
+        if k < 0:
+            k = max(self.N + k, 0)
+        if k == 0 or self.N == 0:
+            return []
+        return heapq.nlargest(
+            k,
+            ((i, self.score(q, i)) for i in range(self.N)),
+            key=lambda item: (item[1], -item[0]),
+        )
 
 
 class _TfIdf:
@@ -117,10 +124,16 @@ class _TfIdf:
         return sum(qvec.get(t, 0.0) * v for t, v in dvec.items())
 
     def topk(self, q: List[str], k: int) -> List[Tuple[int, float]]:
+        if k < 0:
+            k = max(self.N + k, 0)
+        if k == 0 or self.N == 0:
+            return []
         qvec = self.embed_query(q)
-        scores = [(i, self.cosine(qvec, i)) for i in range(self.N)]
-        scores.sort(key=lambda x: x[1], reverse=True)
-        return scores[:k]
+        return heapq.nlargest(
+            k,
+            ((i, self.cosine(qvec, i)) for i in range(self.N)),
+            key=lambda item: (item[1], -item[0]),
+        )
 
 
 class _HybridRanker:

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,6 +1,6 @@
 import pytest
 
-from internal.RAG import DocumentChunk, _RagIndex
+from internal.RAG import DocumentChunk, _RagIndex, _BM25, _TfIdf
 
 
 def _build_index() -> _RagIndex:
@@ -108,3 +108,38 @@ def test_rerank_orders_multiple_candidates_consistently():
     ] == [
         (entry["path"], entry["offset"]) for entry in expected_order
     ]
+
+
+def test_bm25_topk_matches_manual_sort():
+    docs = [
+        ["alpha", "beta", "gamma"],
+        ["beta", "delta", "epsilon"],
+        ["alpha", "epsilon", "zeta"],
+        ["alpha", "beta", "zeta"],
+    ]
+    ranker = _BM25(docs)
+    query = ["alpha", "epsilon"]
+
+    manual_scores = [(i, ranker.score(query, i)) for i in range(len(docs))]
+    manual_scores.sort(key=lambda x: x[1], reverse=True)
+
+    for k in range(1, len(docs) + 2):
+        assert ranker.topk(query, k) == manual_scores[: min(k, len(docs))]
+
+
+def test_tfidf_topk_matches_manual_sort():
+    docs = [
+        ["alpha", "beta", "gamma"],
+        ["beta", "delta", "epsilon"],
+        ["alpha", "epsilon", "zeta"],
+        ["alpha", "beta", "zeta"],
+    ]
+    ranker = _TfIdf(docs)
+    query = ["alpha", "epsilon"]
+
+    qvec = ranker.embed_query(query)
+    manual_scores = [(i, ranker.cosine(qvec, i)) for i in range(len(docs))]
+    manual_scores.sort(key=lambda x: x[1], reverse=True)
+
+    for k in range(1, len(docs) + 2):
+        assert ranker.topk(query, k) == manual_scores[: min(k, len(docs))]


### PR DESCRIPTION
## Summary
- stream BM25 and TF-IDF scoring results into heapq.nlargest to avoid full list sorts
- preserve previous top-k behaviour for edge cases while maintaining deterministic ordering
- extend ranking tests to verify heap-based top-k matches manual sort expectations

## Testing
- pytest tests/test_rag.py

------
https://chatgpt.com/codex/tasks/task_b_68ea1fe94ad8832fa897db13b4fd129f