### PR TITLE
Implement core runtime orchestrator and runtime tests

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,1 +1,730 @@
-# core.py
+"""Core runtime orchestration utilities for Auto-Coder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import contextlib
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from agents import AgentBuilder
+from agents.dependency import DependencyBuildAgent
+from agents.doc import DocAgent
+from agents.db_migration import DBMigrationAgent
+from agents.eval import EvalAgent
+from agents.integrations import IntegrationsAgent
+from agents.manager import ManagerAgent
+from agents.repo_context import RepoContextAgent
+from agents.research import ResearchAgent
+from agents.runner import RunnerAgent
+from agents.security import SecurityAgent
+from agents.tester import TestCriticAgent
+from session import AgentSession
+from tooling import ToolRegistry
+from memory import (
+    MemoryFacade,
+    MemoryRouter,
+    build_memory_router,
+    load_config_json,
+    load_memory_configuration,
+    set_shared_memory_facade,
+)
+from mcp_tooling import MCPServerRegistry, MCPConfigurationError, register_mcp_servers
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PathSettings:
+    """Filesystem locations used by the runtime.
+
+    Attributes
+    ----------
+    repo_root:
+        Absolute path to the repository that should be inspected by context-aware
+        agents. Defaults to the current working directory when not configured.
+    workspace_root:
+        Optional directory for ephemeral artifacts (for example, generated
+        documentation or cached command outputs). When omitted the repository
+        root is reused.
+    artifact_root:
+        Directory used by helper agents such as :class:`RunnerAgent` for
+        persisted artifacts. Defaults to ``workspace_root / ".autocoder"`` when
+        neither configured nor provided via environment variables.
+    """
+
+    repo_root: Path
+    workspace_root: Path | None = None
+    artifact_root: Path | None = None
+
+
+@dataclass(slots=True)
+class ModelSettings:
+    """Model selection and agent-wide behavioural flags."""
+
+    default_model: str | None = None
+    reasoning_model: str | None = None
+    research_model: str | None = None
+    allow_external_browsing: bool = False
+
+
+@dataclass(slots=True)
+class RepoContextSettings:
+    """Filters applied when building the repository semantic index."""
+
+    include_exts: tuple[str, ...] | None = None
+    exclude_dirs: tuple[str, ...] | None = None
+    auto_refresh: bool = True
+    refresh_interval: float = 900.0
+
+
+@dataclass(slots=True)
+class AgentToggleSettings:
+    """Enable/disable specialist agents without code changes."""
+
+    repo_context: bool = True
+    research: bool = True
+    documentation: bool = True
+    dependency: bool = True
+    runner: bool = True
+    db_migration: bool = False
+    security: bool = False
+    integrations: bool = False
+    eval: bool = False
+    test_critic: bool = True
+
+
+@dataclass(slots=True)
+class MemorySettings:
+    """Overrides controlling memory configuration resolution."""
+
+    config_path: Path | None = None
+    default_scope: str = MemoryRouter.SHORT_TERM
+    combined_scope: str = MemoryRouter.COMBINED
+    share_globally: bool = True
+
+
+@dataclass(slots=True)
+class MCPSettings:
+    """Configuration for MCP server discovery and lifecycle management."""
+
+    config_path: Path | None = None
+    servers: Mapping[str, Any] | None = None
+    auto_start: bool = False
+
+
+@dataclass(slots=True)
+class AutoCoderConfig:
+    """Aggregate configuration consumed by :class:`AutoCoderCore`."""
+
+    paths: PathSettings
+    models: ModelSettings
+    repo_context: RepoContextSettings
+    agents: AgentToggleSettings
+    memory: MemorySettings
+    mcp: MCPSettings
+
+
+def _as_mapping(payload: Any | None) -> Mapping[str, Any]:
+    if isinstance(payload, Mapping):
+        return payload
+    return {}
+
+
+def _coerce_path(value: Any | None) -> Path | None:
+    if value is None:
+        return None
+    if isinstance(value, Path):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    return Path(text).expanduser().resolve()
+
+
+def _coerce_bool(value: Any | None) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def _coerce_sequence(value: Any | None) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple, set)):
+        return tuple(str(item).strip() for item in value if str(item).strip()) or None
+    if isinstance(value, str):
+        parts = [segment.strip() for segment in value.split(",")]
+        return tuple(part for part in parts if part) or None
+    return None
+
+
+def _first_non_empty(*candidates: Any | None) -> Any | None:
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, str) and not candidate.strip():
+            continue
+        return candidate
+    return None
+
+
+def _resolve_config_path(
+    config_path: Path | str | None,
+    env: Mapping[str, str],
+) -> Path | None:
+    if config_path:
+        return Path(config_path).expanduser().resolve()
+    env_path = env.get("AUTO_CODER_CONFIG_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+    return None
+
+
+def _merge_sections(
+    base: Mapping[str, Any],
+    override: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    merged = dict(base)
+    if not override:
+        return merged
+    for key, value in override.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _merge_sections(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_core_configuration(
+    config_path: Path | str | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    overrides: Mapping[str, Any] | None = None,
+) -> AutoCoderConfig:
+    """Load :class:`AutoCoderConfig` by merging config file, env, and overrides."""
+
+    env_map = dict(env or os.environ)
+    resolved_path = _resolve_config_path(config_path, env_map)
+    config_payload = load_config_json(resolved_path) if resolved_path else load_config_json()
+    core_section = _as_mapping(config_payload.get("core"))
+    override_section = _as_mapping(overrides)
+    if "core" in override_section:
+        override_section = _as_mapping(override_section.get("core"))
+    core_section = _merge_sections(core_section, override_section)
+
+    paths_config = _as_mapping(core_section.get("paths"))
+    models_config = _as_mapping(core_section.get("models"))
+    repo_config = _as_mapping(core_section.get("repo_context"))
+    agent_config = _as_mapping(core_section.get("agents"))
+    memory_config = _as_mapping(core_section.get("memory"))
+    mcp_config = _as_mapping(core_section.get("mcp"))
+
+    repo_root = _coerce_path(
+        _first_non_empty(
+            paths_config.get("repo_root"),
+            env_map.get("AUTO_CODER_REPO_ROOT"),
+        )
+    ) or Path.cwd()
+
+    workspace_root = _coerce_path(
+        _first_non_empty(
+            paths_config.get("workspace_root"),
+            env_map.get("AUTO_CODER_WORKSPACE_ROOT"),
+        )
+    )
+    artifact_root = _coerce_path(
+        _first_non_empty(
+            paths_config.get("artifact_root"),
+            env_map.get("AUTO_CODER_ARTIFACT_ROOT"),
+        )
+    )
+    if workspace_root is None:
+        workspace_root = repo_root
+    if artifact_root is None:
+        artifact_root = workspace_root / ".autocoder"
+
+    paths = PathSettings(
+        repo_root=repo_root,
+        workspace_root=workspace_root,
+        artifact_root=artifact_root,
+    )
+
+    default_model = _first_non_empty(
+        override_section.get("default_model"),
+        env_map.get("AUTO_CODER_MODEL"),
+        models_config.get("default_model"),
+    )
+    reasoning_model = _first_non_empty(
+        override_section.get("reasoning_model"),
+        env_map.get("AUTO_CODER_REASONING_MODEL"),
+        models_config.get("reasoning_model"),
+    )
+    research_model = _first_non_empty(
+        override_section.get("research_model"),
+        env_map.get("AUTO_CODER_RESEARCH_MODEL"),
+        models_config.get("research_model"),
+    )
+    allow_browsing = _first_non_empty(
+        override_section.get("allow_external_browsing"),
+        env_map.get("AUTO_CODER_ALLOW_BROWSING"),
+        models_config.get("allow_external_browsing"),
+    )
+    allow_browsing_flag = _coerce_bool(allow_browsing)
+    models = ModelSettings(
+        default_model=str(default_model) if default_model is not None else None,
+        reasoning_model=str(reasoning_model) if reasoning_model is not None else None,
+        research_model=str(research_model) if research_model is not None else None,
+        allow_external_browsing=bool(allow_browsing_flag) if allow_browsing_flag is not None else False,
+    )
+
+    include_exts = _coerce_sequence(
+        _first_non_empty(
+            repo_config.get("include_exts"),
+            env_map.get("AUTO_CODER_REPO_INCLUDE_EXTS"),
+        )
+    )
+    exclude_dirs = _coerce_sequence(
+        _first_non_empty(
+            repo_config.get("exclude_dirs"),
+            env_map.get("AUTO_CODER_REPO_EXCLUDE_DIRS"),
+        )
+    )
+    auto_refresh = _coerce_bool(
+        _first_non_empty(
+            repo_config.get("auto_refresh"),
+            env_map.get("AUTO_CODER_REPO_AUTO_REFRESH"),
+        )
+    )
+    refresh_interval_candidate = _first_non_empty(
+        repo_config.get("refresh_interval"),
+        env_map.get("AUTO_CODER_REPO_REFRESH_INTERVAL"),
+    )
+    try:
+        refresh_interval = float(refresh_interval_candidate) if refresh_interval_candidate is not None else 900.0
+    except (TypeError, ValueError):
+        refresh_interval = 900.0
+    repo_context = RepoContextSettings(
+        include_exts=include_exts,
+        exclude_dirs=exclude_dirs,
+        auto_refresh=bool(auto_refresh) if auto_refresh is not None else True,
+        refresh_interval=max(60.0, refresh_interval),
+    )
+
+    def _toggle(name: str, default: bool) -> bool:
+        raw = _first_non_empty(
+            agent_config.get(name),
+            env_map.get(f"AUTO_CODER_ENABLE_{name.upper()}"),
+        )
+        coerced = _coerce_bool(raw)
+        if coerced is None:
+            raw_disable = env_map.get(f"AUTO_CODER_DISABLE_{name.upper()}")
+            disable_flag = _coerce_bool(raw_disable)
+            if disable_flag is True:
+                return False
+            return default
+        return coerced
+
+    agents = AgentToggleSettings(
+        repo_context=_toggle("repo_context", True),
+        research=_toggle("research", True),
+        documentation=_toggle("documentation", True),
+        dependency=_toggle("dependency", True),
+        runner=_toggle("runner", True),
+        db_migration=_toggle("db_migration", False),
+        security=_toggle("security", False),
+        integrations=_toggle("integrations", False),
+        eval=_toggle("eval", False),
+        test_critic=_toggle("test_critic", True),
+    )
+
+    memory_path = _coerce_path(
+        _first_non_empty(
+            memory_config.get("config_path"),
+            env_map.get("AUTO_CODER_MEMORY_CONFIG"),
+        )
+    )
+    default_scope = str(
+        _first_non_empty(
+            memory_config.get("default_scope"),
+            env_map.get("AUTO_CODER_MEMORY_DEFAULT_SCOPE"),
+            MemoryRouter.SHORT_TERM,
+        )
+    ).lower()
+    combined_scope = str(
+        _first_non_empty(
+            memory_config.get("combined_scope"),
+            env_map.get("AUTO_CODER_MEMORY_COMBINED_SCOPE"),
+            MemoryRouter.COMBINED,
+        )
+    ).lower()
+    share_globally = _coerce_bool(
+        _first_non_empty(
+            memory_config.get("share_globally"),
+            env_map.get("AUTO_CODER_MEMORY_SHARE"),
+        )
+    )
+    memory = MemorySettings(
+        config_path=memory_path,
+        default_scope=default_scope,
+        combined_scope=combined_scope,
+        share_globally=True if share_globally is None else bool(share_globally),
+    )
+
+    mcp_path = _coerce_path(
+        _first_non_empty(
+            mcp_config.get("config_path"),
+            env_map.get("AUTO_CODER_MCP_CONFIG"),
+        )
+    )
+    servers_raw = mcp_config.get("servers") if isinstance(mcp_config.get("servers"), Mapping) else None
+    auto_start_flag = _coerce_bool(
+        _first_non_empty(
+            mcp_config.get("auto_start"),
+            env_map.get("AUTO_CODER_MCP_AUTO_START"),
+        )
+    )
+    mcp = MCPSettings(
+        config_path=mcp_path,
+        servers=servers_raw,
+        auto_start=bool(auto_start_flag) if auto_start_flag is not None else False,
+    )
+
+    return AutoCoderConfig(
+        paths=paths,
+        models=models,
+        repo_context=repo_context,
+        agents=agents,
+        memory=memory,
+        mcp=mcp,
+    )
+
+
+class AutoCoderCore:
+    """Central orchestrator responsible for wiring high-level agents together."""
+
+    def __init__(
+        self,
+        config: AutoCoderConfig | None = None,
+        *,
+        config_path: Path | str | None = None,
+        overrides: Mapping[str, Any] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self.config = config or load_core_configuration(
+            config_path,
+            env=env,
+            overrides=overrides,
+        )
+        self.tool_registry = ToolRegistry()
+        self._memory_config = load_memory_configuration(self.config.memory.config_path)
+        self.memory_router = build_memory_router(self._memory_config)
+        self.memory_facade = MemoryFacade(
+            self.memory_router,
+            default_scope=self.config.memory.default_scope,
+            combined_scope=self.config.memory.combined_scope,
+        )
+        self._shared_memory_installed = False
+        if self.config.memory.share_globally:
+            set_shared_memory_facade(self.memory_facade)
+            self._shared_memory_installed = True
+
+        self._mcp_registry: MCPServerRegistry | None = None
+        self._mcp_specs: tuple[Any, ...] = ()
+        self._setup_mcp_registry()
+
+        self._repo_context_agent: RepoContextAgent | None = None
+        self._research_agent: ResearchAgent | None = None
+        self._doc_agent: DocAgent | None = None
+        self._runner_agent: RunnerAgent | None = None
+        self._dependency_agent: DependencyBuildAgent | None = None
+        self._db_migration_agent: DBMigrationAgent | None = None
+        self._security_agent: SecurityAgent | None = None
+        self._integrations_agent: IntegrationsAgent | None = None
+        self._eval_agent: EvalAgent | None = None
+        self._test_critic_agent: TestCriticAgent | None = None
+
+    # ------------------------------------------------------------------
+    # MCP setup
+    # ------------------------------------------------------------------
+    def _setup_mcp_registry(self) -> None:
+        settings = self.config.mcp
+        registry: MCPServerRegistry | None = None
+        if settings.servers:
+            registry = MCPServerRegistry(settings.servers)
+        else:
+            path_hint = settings.config_path
+            try:
+                registry = MCPServerRegistry.from_loaded_config(path_hint)
+            except MCPConfigurationError:
+                LOGGER.debug("MCP configuration not available; continuing without MCP integration", exc_info=True)
+                registry = None
+            except FileNotFoundError:
+                LOGGER.debug("MCP configuration file %s not found", path_hint)
+                registry = None
+        if registry:
+            try:
+                specs = registry.build_specs(auto_start=settings.auto_start)
+            except (MCPConfigurationError, TimeoutError, OSError):
+                LOGGER.warning("Failed to initialise MCP servers; continuing without MCP tools", exc_info=True)
+                specs = []
+            self._mcp_registry = registry
+            self._mcp_specs = tuple(specs)
+        else:
+            self._mcp_registry = None
+            self._mcp_specs = ()
+
+    # ------------------------------------------------------------------
+    # Agent factories
+    # ------------------------------------------------------------------
+    def _get_repo_context(self) -> RepoContextAgent | None:
+        if not self.config.agents.repo_context:
+            return None
+        if self._repo_context_agent is None:
+            try:
+                repo_root = str(self.config.paths.repo_root)
+                include_exts = self.config.repo_context.include_exts
+                exclude_dirs = self.config.repo_context.exclude_dirs
+                agent = RepoContextAgent(
+                    repo_root,
+                    include_exts=include_exts,
+                    exclude_dirs=exclude_dirs,
+                    auto_refresh=self.config.repo_context.auto_refresh,
+                    refresh_interval=self.config.repo_context.refresh_interval,
+                )
+                self._repo_context_agent = agent
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise RepoContextAgent; repository features disabled", exc_info=True)
+                self._repo_context_agent = None
+        return self._repo_context_agent
+
+    def _get_research_agent(self) -> ResearchAgent | None:
+        if not self.config.agents.research:
+            return None
+        if self._research_agent is None:
+            try:
+                self._research_agent = ResearchAgent(
+                    anonymous_browsing=not self.config.models.allow_external_browsing,
+                )
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise ResearchAgent; disabling research features", exc_info=True)
+                self._research_agent = None
+        return self._research_agent
+
+    def _get_runner(self) -> RunnerAgent | None:
+        if not self.config.agents.runner:
+            return None
+        if self._runner_agent is None:
+            try:
+                self._runner_agent = RunnerAgent(
+                    repo_root=str(self.config.paths.repo_root),
+                    artifact_root=str(self.config.paths.artifact_root),
+                )
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise RunnerAgent; disabling command execution helpers", exc_info=True)
+                self._runner_agent = None
+        return self._runner_agent
+
+    def _get_dependency_agent(self) -> DependencyBuildAgent | None:
+        if not self.config.agents.dependency:
+            return None
+        if self._dependency_agent is None:
+            runner = self._get_runner()
+            try:
+                self._dependency_agent = DependencyBuildAgent(
+                    runner=runner,
+                    repo_root=self.config.paths.repo_root,
+                )
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise DependencyBuildAgent; disabling dependency workflows", exc_info=True)
+                self._dependency_agent = None
+        return self._dependency_agent
+
+    def _get_doc_agent(self) -> DocAgent | None:
+        if not self.config.agents.documentation:
+            return None
+        repo_context = self._get_repo_context()
+        if repo_context is None:
+            return None
+        research = self._get_research_agent()
+        if self._doc_agent is None:
+            try:
+                self._doc_agent = DocAgent(
+                    repo_context,
+                    research_agent=research,
+                    artifact_dir=self.config.paths.workspace_root / ".doc_artifacts",
+                )
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise DocAgent; documentation support disabled", exc_info=True)
+                self._doc_agent = None
+        else:
+            self._doc_agent.attach_research_agent(research)
+        return self._doc_agent
+
+    def _get_db_migration_agent(self) -> DBMigrationAgent | None:
+        if not self.config.agents.db_migration:
+            return None
+        repo_context = self._get_repo_context()
+        if repo_context is None:
+            return None
+        runner = self._get_runner()
+        if self._db_migration_agent is None:
+            try:
+                self._db_migration_agent = DBMigrationAgent(
+                    repo_context,
+                    runner=runner,
+                )
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise DBMigrationAgent; migration workflows disabled", exc_info=True)
+                self._db_migration_agent = None
+        return self._db_migration_agent
+
+    def _get_security_agent(self) -> SecurityAgent | None:
+        if not self.config.agents.security:
+            return None
+        runner = self._get_runner()
+        if self._security_agent is None:
+            try:
+                self._security_agent = SecurityAgent(runner=runner)
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise SecurityAgent; security scanning disabled", exc_info=True)
+                self._security_agent = None
+        return self._security_agent
+
+    def _get_integrations_agent(self) -> IntegrationsAgent | None:
+        if not self.config.agents.integrations:
+            return None
+        repo_context = self._get_repo_context()
+        if repo_context is None:
+            return None
+        runner = self._get_runner()
+        if self._integrations_agent is None:
+            try:
+                self._integrations_agent = IntegrationsAgent(
+                    repo_context=repo_context,
+                    runner=runner,
+                )
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise IntegrationsAgent; integrations support disabled", exc_info=True)
+                self._integrations_agent = None
+        return self._integrations_agent
+
+    def _get_eval_agent(self) -> EvalAgent | None:
+        if not self.config.agents.eval:
+            return None
+        if self._eval_agent is None:
+            try:
+                self._eval_agent = EvalAgent(
+                    session_factory=self._create_session,
+                )
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise EvalAgent; evaluation disabled", exc_info=True)
+                self._eval_agent = None
+        return self._eval_agent
+
+    def _get_test_critic(self) -> TestCriticAgent | None:
+        if not self.config.agents.test_critic:
+            return None
+        if self._test_critic_agent is None:
+            try:
+                self._test_critic_agent = TestCriticAgent(repo_root=str(self.config.paths.repo_root))
+            except Exception:  # pragma: no cover - safeguard
+                LOGGER.warning("Failed to initialise TestCriticAgent; gating disabled", exc_info=True)
+                self._test_critic_agent = None
+        return self._test_critic_agent
+
+    def _create_session(self) -> AgentSession:
+        builder = AgentBuilder()
+        builder.using_registry(self.tool_registry)
+        builder.with_toolsets("memory")
+        if self.config.models.default_model:
+            builder.with_model(model_name=self.config.models.default_model)
+        if self._mcp_specs:
+            builder.with_mcp_servers(*self._mcp_specs)
+        return builder.build()
+
+    # ------------------------------------------------------------------
+    # Manager construction
+    # ------------------------------------------------------------------
+    def build_manager(
+        self,
+        *,
+        status_callback: Callable[[Any], None] | None = None,
+    ) -> ManagerAgent:
+        session = self._create_session()
+        repo_context = self._get_repo_context()
+        research_agent = self._get_research_agent()
+        doc_agent = self._get_doc_agent()
+        dependency_agent = self._get_dependency_agent()
+        db_agent = self._get_db_migration_agent()
+        security_agent = self._get_security_agent()
+        integrations_agent = self._get_integrations_agent()
+        eval_agent = self._get_eval_agent()
+        test_critic = self._get_test_critic()
+
+        manager = ManagerAgent(
+            session=session,
+            status_callback=status_callback,
+            repo_context=repo_context,
+            test_critic=test_critic,
+            research_agent=research_agent,
+            dependency_agent=dependency_agent,
+            db_migration_agent=db_agent,
+            eval_agent=eval_agent,
+            security_agent=security_agent,
+            doc_agent=doc_agent,
+            external_browsing_default=self.config.models.allow_external_browsing,
+            memory_router=self.memory_router,
+            memory_facade=self.memory_facade,
+            mcp_registry=self._mcp_registry,
+        )
+
+        if integrations_agent is not None:
+            manager._integrations_agent = integrations_agent
+        if research_agent is not None:
+            manager.attach_research_agent(research_agent)
+        if repo_context is not None:
+            manager.attach_repo_context(repo_context)
+        if dependency_agent is not None:
+            manager.attach_dependency_agent(dependency_agent)
+        if test_critic is not None:
+            manager.attach_test_critic(test_critic)
+        if eval_agent is not None:
+            manager.attach_eval_agent(eval_agent)
+
+        if self._mcp_specs:
+            specs = register_mcp_servers(self.tool_registry, self._mcp_specs, replace=True)
+            with contextlib.suppress(Exception):
+                session.replace_mcp_tools(specs)
+
+        return manager
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    # ------------------------------------------------------------------
+    def shutdown(self) -> None:
+        if self._repo_context_agent is not None:
+            with contextlib.suppress(Exception):
+                self._repo_context_agent.stop_background_refresh()
+            self._repo_context_agent = None
+        if self._mcp_registry is not None:
+            with contextlib.suppress(Exception):
+                self._mcp_registry.shutdown_all()
+        if self._shared_memory_installed:
+            set_shared_memory_facade(None)
+            self._shared_memory_installed = False
+
+    def __enter__(self) -> "AutoCoderCore":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.shutdown()

--- a/tests/test_core_runtime.py
+++ b/tests/test_core_runtime.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+
+class _StubModel:
+    def respond(self, *_, **__):
+        return {"choices": [{"message": {"content": "stub"}}]}
+
+    def respond_stream(self, *_, **__):
+        yield {"choices": [{"delta": {"content": "stub"}}]}
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None) -> None:
+        self.messages: list[Mapping[str, Any]] = []
+        if system_prompt is not None:
+            self.messages.append({"role": "system", "content": system_prompt})
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":
+        instance = cls()
+        if isinstance(history, Mapping):
+            instance.messages = list(history.get("messages", []))
+        elif isinstance(history, str):
+            instance.messages = [{"role": "user", "content": history}]
+        return instance
+
+    def add_user_message(self, content: str) -> None:
+        self.messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        self.messages.append({"role": "assistant", "content": content})
+
+
+class _StubToolFunctionDef:
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters: Mapping[str, Any] | None = None,
+        implementation: Any = None,
+        **_: Any,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.parameters = dict(parameters or {})
+        if implementation is None:
+            self.implementation = lambda *args, **kwargs: None
+        else:
+            self.implementation = implementation
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *_, **__: _StubModel(),
+        Chat=_StubChat,
+        ToolFunctionDef=_StubToolFunctionDef,
+    ),
+)
+
+_psutil_stub = types.ModuleType("psutil")
+
+
+class _StubProcess:
+    def __init__(self, pid: int | None = None) -> None:
+        self.pid = pid or 0
+
+
+_psutil_stub.Process = _StubProcess
+sys.modules.setdefault("psutil", _psutil_stub)
+
+from core import (  # noqa: E402  (import after stubbing lmstudio)
+    AutoCoderCore,
+    load_core_configuration,
+)
+from memory import get_shared_memory_facade  # noqa: E402
+
+
+class StubRepoContext:
+    def __init__(self, repo_root: str, **_: Any) -> None:
+        self.repo_root = Path(repo_root)
+        self.stopped = False
+
+    def stop_background_refresh(self) -> None:
+        self.stopped = True
+
+
+class StubResearchAgent:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+class StubRunnerAgent:
+    def __init__(self, *, repo_root: str | Path | None = None, **kwargs: Any) -> None:
+        self.repo_root = Path(repo_root) if repo_root else None
+        self.kwargs = kwargs
+
+
+class StubDependencyAgent:
+    def __init__(self, *, runner: Any = None, repo_root: Any = None) -> None:
+        self.runner = runner
+        self.repo_root = repo_root
+
+
+class StubDocAgent:
+    def __init__(self, repo_context: StubRepoContext, *, research_agent: Any = None, artifact_dir: Any = None) -> None:
+        self.repo_context = repo_context
+        self.research_agent = research_agent
+        self.artifact_dir = artifact_dir
+
+    def attach_research_agent(self, agent: Any) -> None:
+        self.research_agent = agent
+
+
+class StubDBMigrationAgent:
+    def __init__(self, repo_context: StubRepoContext, *, runner: Any = None, **_: Any) -> None:
+        self.repo_context = repo_context
+        self.runner = runner
+
+
+class StubSecurityAgent:
+    def __init__(self, *, runner: Any = None, **_: Any) -> None:
+        self.runner = runner
+
+
+class StubIntegrationsAgent:
+    def __init__(self, *, repo_context: StubRepoContext, runner: Any = None, **_: Any) -> None:
+        self.repo_context = repo_context
+        self.runner = runner
+
+
+class StubEvalAgent:
+    def __init__(self, *, session: Any = None, session_factory: Any = None, **_: Any) -> None:
+        self.session = session
+        self.session_factory = session_factory
+
+
+class StubTestCriticAgent:
+    def __init__(self, *, repo_root: str | None = None, **_: Any) -> None:
+        self.repo_root = repo_root
+        self.callback = None
+
+    def set_status_callback(self, callback: Any) -> None:
+        self.callback = callback
+
+
+@pytest.fixture(autouse=True)
+def stub_agents(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.RepoContextAgent", StubRepoContext)
+    monkeypatch.setattr("core.ResearchAgent", StubResearchAgent)
+    monkeypatch.setattr("core.RunnerAgent", StubRunnerAgent)
+    monkeypatch.setattr("core.DependencyBuildAgent", StubDependencyAgent)
+    monkeypatch.setattr("core.DocAgent", StubDocAgent)
+    monkeypatch.setattr("core.DBMigrationAgent", StubDBMigrationAgent)
+    monkeypatch.setattr("core.SecurityAgent", StubSecurityAgent)
+    monkeypatch.setattr("core.IntegrationsAgent", StubIntegrationsAgent)
+    monkeypatch.setattr("core.EvalAgent", StubEvalAgent)
+    monkeypatch.setattr("core.TestCriticAgent", StubTestCriticAgent)
+
+
+def test_core_builds_manager_with_specialists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    replaced_specs: list[Any] = []
+
+    def fake_register(registry, servers, replace=False):  # noqa: ANN001
+        specs: list[Any] = []
+        for server in servers:
+            label = getattr(getattr(server, "config", server), "label", "stub")
+            spec = types.SimpleNamespace(name=label, tool_type="mcp")
+            specs.append(spec)
+        return specs
+
+    monkeypatch.setattr("core.register_mcp_servers", fake_register)
+
+    class SessionRecorder:
+        def __init__(self) -> None:
+            self.tool_registry = None
+            self.tools: list[Any] = []
+            self.round_hooks: list[tuple[Any, Any]] = []
+            self.rounds: list[Any] = []
+
+        def replace_mcp_tools(self, new_specs):  # noqa: ANN001
+            replaced_specs.extend(list(new_specs))
+            self.tools.extend(list(new_specs))
+            return list(new_specs)
+
+        def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:
+            self.round_hooks.append((on_round_start, on_round_end))
+
+    def fake_create_session(self) -> SessionRecorder:
+        session = SessionRecorder()
+        session.tool_registry = self.tool_registry
+        return session
+
+    monkeypatch.setattr(AutoCoderCore, "_create_session", fake_create_session)
+
+    config = load_core_configuration(
+        overrides={
+            "paths": {"repo_root": str(tmp_path)},
+            "agents": {
+                "db_migration": True,
+                "security": True,
+                "integrations": True,
+                "eval": True,
+            },
+            "mcp": {
+                "servers": {
+                    "demo": {"type": "remote", "url": "https://example.invalid"}
+                }
+            },
+        }
+    )
+
+    core = AutoCoderCore(config=config)
+    manager = core.build_manager()
+
+    assert isinstance(manager.repo_context, StubRepoContext)
+    assert manager.test_critic is core._test_critic_agent
+    assert manager.research_agent is core._research_agent
+    assert manager._dependency_agent is core._dependency_agent
+    assert manager._db_migration_agent is core._db_migration_agent
+    assert manager._security_agent is core._security_agent
+    assert manager._integrations_agent is core._integrations_agent
+    assert manager._doc_agent is core._doc_agent
+    assert manager._doc_agent.research_agent is manager.research_agent
+    assert core._eval_agent is not None
+
+    assert replaced_specs and replaced_specs[0].name == "demo"
+    assert get_shared_memory_facade() is core.memory_facade
+
+    core.shutdown()
+
+
+def test_core_shutdown_tears_down(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config = load_core_configuration(overrides={"paths": {"repo_root": str(tmp_path)}})
+    core = AutoCoderCore(config=config)
+
+    repo_context = StubRepoContext(str(tmp_path))
+    core._repo_context_agent = repo_context
+
+    class StubRegistry:
+        def __init__(self) -> None:
+            self.shutdown_called = False
+
+        def shutdown_all(self) -> None:
+            self.shutdown_called = True
+
+    registry = StubRegistry()
+    core._mcp_registry = registry  # type: ignore[assignment]
+
+    core.shutdown()
+
+    assert repo_context.stopped is True
+    assert registry.shutdown_called is True
+    assert get_shared_memory_facade() is not core.memory_facade


### PR DESCRIPTION
## Summary
- add structured configuration loaders for runtime paths, models, agent toggles, and MCP/memory settings
- implement an AutoCoderCore orchestrator that builds shared memory, tool registries, and specialist agents before constructing the manager
- add unit tests that verify manager wiring, MCP tool registration stubs, memory sharing, and shutdown cleanup

## Testing
- pytest tests/test_core_runtime.py

------
https://chatgpt.com/codex/tasks/task_b_68ea69236284832fa1ed622032318fdd