### PR TITLE
Refactor CLI to build managers via AutoCoderCore

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,59 +3,48 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import functools
 import sys
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Iterable
 
-from agents import AgentBuilder
 from agents.manager import ManagerAgent, ManagerResult, ManagerStatusUpdate
-from memory import MemoryFacade, build_memory_router, set_shared_memory_facade
-from mcp_tooling import MCPConfigurationError, MCPServerRegistry
+from core import AgentToggleSettings, AutoCoderCore
+from mcp_tooling import MCPConfigurationError
 
 
-def _build_manager(
+def _status_printer(update: ManagerStatusUpdate) -> None:
+    prefix = update.kind.upper()
+    task_label = f" [{update.task}]" if update.task else ""
+    print(f"[{prefix}{task_label}] {update.message}")
+
+
+def _interactive_loop(
+    manager_or_factory: ManagerAgent | Callable[[], ManagerAgent],
     *,
-    mcp_servers: Sequence[Any] | None = None,
-    mcp_registry: MCPServerRegistry | None = None,
-) -> ManagerAgent:
-    router = build_memory_router()
-    facade = MemoryFacade(router)
-    set_shared_memory_facade(facade)
+    runtime: AutoCoderCore | None = None,
+) -> int:
+    context: contextlib.AbstractContextManager[Any]
+    if runtime is None:
+        context = contextlib.nullcontext()
+    else:
+        context = runtime
 
-    builder = AgentBuilder()
-    builder.with_toolsets("memory")
-    if mcp_servers:
-        builder.with_mcp_servers(*mcp_servers)
-    session = builder.build()
-
-    def status_printer(update: ManagerStatusUpdate) -> None:
-        prefix = update.kind.upper()
-        task_label = f" [{update.task}]" if update.task else ""
-        print(f"[{prefix}{task_label}] {update.message}")
-
-    return ManagerAgent(
-        session=session,
-        status_callback=status_printer,
-        memory_router=router,
-        memory_facade=facade,
-        mcp_registry=mcp_registry,
-    )
-
-
-def _interactive_loop(manager_factory: Callable[[], ManagerAgent]) -> int:
-    manager = manager_factory()
-    print("Auto-Coder manager ready. Type 'exit' or 'quit' to stop.")
-    while True:
-        try:
-            user_input = input("You: ")
-        except EOFError:
-            print()
-            break
-        if not user_input.strip():
-            continue
-        if user_input.strip().lower() in {"exit", "quit"}:
-            break
-        result = manager.run(user_input)
-        _render_result(result)
+    with context:
+        manager = manager_or_factory() if callable(manager_or_factory) else manager_or_factory
+        print("Auto-Coder manager ready. Type 'exit' or 'quit' to stop.")
+        while True:
+            try:
+                user_input = input("You: ")
+            except EOFError:
+                print()
+                break
+            if not user_input.strip():
+                continue
+            if user_input.strip().lower() in {"exit", "quit"}:
+                break
+            result = manager.run(user_input)
+            _render_result(result)
     return 0
 
 
@@ -67,6 +56,64 @@ def _render_result(result: ManagerResult) -> None:
         task_label = f" [{update.task}]" if update.task else ""
         print(f"[{prefix}{task_label}] {update.message}")
     print(f"Manager: {result.response_text}")
+
+
+def _split_multi(values: Iterable[str] | None) -> list[str]:
+    items: list[str] = []
+    if not values:
+        return items
+    for raw in values:
+        segments = [segment.strip() for segment in str(raw).split(",")]
+        items.extend(segment for segment in segments if segment)
+    return items
+
+
+def _build_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+
+    def section(name: str) -> dict[str, Any]:
+        return overrides.setdefault(name, {})  # type: ignore[return-value]
+
+    if args.default_model:
+        section("models")["default_model"] = args.default_model
+    if args.reasoning_model:
+        section("models")["reasoning_model"] = args.reasoning_model
+    if args.research_model:
+        section("models")["research_model"] = args.research_model
+    if args.allow_browsing is not None:
+        section("models")["allow_external_browsing"] = bool(args.allow_browsing)
+
+    include_exts = _split_multi(getattr(args, "repo_include_ext", None))
+    if include_exts:
+        section("repo_context")["include_exts"] = include_exts
+    exclude_dirs = _split_multi(getattr(args, "repo_exclude_dir", None))
+    if exclude_dirs:
+        section("repo_context")["exclude_dirs"] = exclude_dirs
+    if args.repo_auto_refresh is not None:
+        section("repo_context")["auto_refresh"] = bool(args.repo_auto_refresh)
+    if args.repo_refresh_interval is not None:
+        section("repo_context")["refresh_interval"] = float(args.repo_refresh_interval)
+
+    enabled = getattr(args, "enable_agent", None) or []
+    disabled = getattr(args, "disable_agent", None) or []
+    if enabled or disabled:
+        agent_section = section("agents")
+        for name in enabled:
+            agent_section[name] = True
+        for name in disabled:
+            agent_section[name] = False
+
+    if args.memory_config_path:
+        section("memory")["config_path"] = args.memory_config_path
+    if args.share_memory is not None:
+        section("memory")["share_globally"] = bool(args.share_memory)
+
+    if args.mcp_config_path:
+        section("mcp")["config_path"] = args.mcp_config_path
+    if args.mcp_auto_start is not None:
+        section("mcp")["auto_start"] = bool(args.mcp_auto_start)
+
+    return overrides
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -81,28 +128,128 @@ def main(argv: list[str] | None = None) -> int:
         dest="mcp_config_path",
         help="Optional override for the MCP server configuration file",
     )
+    parser.add_argument(
+        "--default-model",
+        dest="default_model",
+        help="Override the default LLM model used by Auto-Coder",
+    )
+    parser.add_argument(
+        "--reasoning-model",
+        dest="reasoning_model",
+        help="Override the reasoning model used for complex planning",
+    )
+    parser.add_argument(
+        "--research-model",
+        dest="research_model",
+        help="Override the research model for web lookups",
+    )
+    parser.add_argument(
+        "--allow-browsing",
+        dest="allow_browsing",
+        action="store_true",
+        help="Enable external browsing tools for the research agent",
+    )
+    parser.add_argument(
+        "--disable-browsing",
+        dest="allow_browsing",
+        action="store_false",
+        help="Disable external browsing tools for the research agent",
+    )
+    parser.set_defaults(allow_browsing=None)
+
+    agent_choices = sorted(AgentToggleSettings.__annotations__.keys())
+    parser.add_argument(
+        "--enable-agent",
+        dest="enable_agent",
+        choices=agent_choices,
+        action="append",
+        help="Explicitly enable a specialist agent",
+    )
+    parser.add_argument(
+        "--disable-agent",
+        dest="disable_agent",
+        choices=agent_choices,
+        action="append",
+        help="Explicitly disable a specialist agent",
+    )
+
+    parser.add_argument(
+        "--repo-include-ext",
+        dest="repo_include_ext",
+        action="append",
+        help="File extensions to include when indexing the repository context",
+    )
+    parser.add_argument(
+        "--repo-exclude-dir",
+        dest="repo_exclude_dir",
+        action="append",
+        help="Directories to exclude from the repository context index",
+    )
+    parser.add_argument(
+        "--repo-auto-refresh",
+        dest="repo_auto_refresh",
+        action="store_true",
+        help="Enable background refresh of the repository semantic index",
+    )
+    parser.add_argument(
+        "--repo-no-auto-refresh",
+        dest="repo_auto_refresh",
+        action="store_false",
+        help="Disable background refresh of the repository semantic index",
+    )
+    parser.set_defaults(repo_auto_refresh=None)
+    parser.add_argument(
+        "--repo-refresh-interval",
+        dest="repo_refresh_interval",
+        type=float,
+        help="Seconds between repository context refreshes",
+    )
+
+    parser.add_argument(
+        "--memory-config",
+        dest="memory_config_path",
+        help="Override the memory configuration file path",
+    )
+    parser.add_argument(
+        "--shared-memory",
+        dest="share_memory",
+        action="store_true",
+        help="Share the constructed memory facade globally",
+    )
+    parser.add_argument(
+        "--no-shared-memory",
+        dest="share_memory",
+        action="store_false",
+        help="Avoid sharing the constructed memory facade globally",
+    )
+    parser.set_defaults(share_memory=None)
+
+    parser.add_argument(
+        "--mcp-auto-start",
+        dest="mcp_auto_start",
+        action="store_true",
+        help="Automatically start configured MCP servers",
+    )
+    parser.add_argument(
+        "--no-mcp-auto-start",
+        dest="mcp_auto_start",
+        action="store_false",
+        help="Skip automatic MCP server startup",
+    )
+    parser.set_defaults(mcp_auto_start=None)
+
     args = parser.parse_args(argv)
 
-    config_override = args.mcp_config_path or args.config_path
+    overrides = _build_overrides(args)
 
     try:
-        mcp_registry = MCPServerRegistry.from_loaded_config(config_override)
+        core = AutoCoderCore(config_path=args.config_path, overrides=overrides)
     except MCPConfigurationError as exc:
-        print(f"Failed to load MCP configuration: {exc}", file=sys.stderr)
+        print(f"Failed to initialise MCP integration: {exc}", file=sys.stderr)
         return 2
 
-    try:
-        mcp_specs = mcp_registry.build_specs(auto_start=True)
-    except (MCPConfigurationError, TimeoutError, OSError) as exc:
-        print(f"Failed to start MCP servers: {exc}", file=sys.stderr)
-        return 2
-
-    try:
-        return _interactive_loop(
-            lambda: _build_manager(mcp_servers=mcp_specs, mcp_registry=mcp_registry)
-        )
-    finally:
-        mcp_registry.shutdown_all()
+    manager_factory = functools.partial(core.build_manager, status_callback=_status_printer)
+    return _interactive_loop(manager_factory, runtime=core)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import builtins
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+class _StubModel:
+    def respond(self, *_, **__):
+        return {"choices": [{"message": {"content": "stub"}}]}
+
+    def respond_stream(self, *_, **__):
+        yield {"choices": [{"delta": {"content": "stub"}}]}
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None) -> None:
+        self.messages: list[dict[str, Any]] = []
+        if system_prompt is not None:
+            self.messages.append({"role": "system", "content": system_prompt})
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":
+        instance = cls()
+        if isinstance(history, dict):
+            instance.messages = list(history.get("messages", []))
+        elif isinstance(history, str):
+            instance.messages = [{"role": "user", "content": history}]
+        return instance
+
+    def add_user_message(self, content: str) -> None:
+        self.messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        self.messages.append({"role": "assistant", "content": content})
+
+
+class _StubToolFunctionDef:
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        implementation: Any | None = None,
+        parameters: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.parameters = dict(parameters or {})
+        if implementation is None:
+            self.implementation = lambda *args, **kwargs: None
+        else:
+            self.implementation = implementation
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *_, **__: _StubModel(),
+        Chat=_StubChat,
+        ToolFunctionDef=_StubToolFunctionDef,
+    ),
+)
+
+_psutil_stub = types.ModuleType("psutil")
+
+
+class _StubProcess:
+    def __init__(self, pid: int | None = None) -> None:
+        self.pid = pid or 0
+
+
+_psutil_stub.Process = _StubProcess
+sys.modules.setdefault("psutil", _psutil_stub)
+
+import main
+
+
+class StubManager:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run(self, message: str) -> SimpleNamespace:
+        self.calls.append(message)
+        return SimpleNamespace(
+            status_updates=[],
+            response_text="ok",
+            plan=[],
+            budgets={},
+            rounds=[],
+            structured_response=None,
+        )
+
+
+def test_main_constructs_core_with_cli_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    inputs = iter(["quit"])
+    monkeypatch.setattr(builtins, "input", lambda *_: next(inputs))
+    monkeypatch.setattr(builtins, "print", lambda *_, **__: None)
+
+    stub_manager = StubManager()
+    instances: list[StubCore] = []
+
+    class StubCore:
+        def __init__(self, *, config_path=None, overrides=None, env=None):  # noqa: ANN001
+            self.config_path = config_path
+            self.overrides = overrides
+            self.env = env
+            self.entered = False
+            self.exited = False
+            self.shutdown_called = False
+            self.status_callback = None
+            instances.append(self)
+
+        def __enter__(self) -> "StubCore":
+            self.entered = True
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            self.exited = True
+            self.shutdown()
+
+        def build_manager(self, *, status_callback=None):  # noqa: ANN001
+            self.status_callback = status_callback
+            return stub_manager
+
+        def shutdown(self) -> None:
+            self.shutdown_called = True
+
+    monkeypatch.setattr(main, "AutoCoderCore", StubCore)
+
+    exit_code = main.main(
+        [
+            "--config",
+            "/tmp/config.json",
+            "--mcp-config",
+            "/tmp/mcp.json",
+            "--default-model",
+            "gpt-mini",
+            "--reasoning-model",
+            "gpt-pro",
+            "--research-model",
+            "gpt-research",
+            "--allow-browsing",
+            "--enable-agent",
+            "db_migration",
+            "--disable-agent",
+            "research",
+            "--repo-include-ext",
+            "py",
+            "--repo-include-ext",
+            "md,txt",
+            "--repo-exclude-dir",
+            "node_modules",
+            "--repo-no-auto-refresh",
+            "--repo-refresh-interval",
+            "120",
+            "--memory-config",
+            "/tmp/memory.json",
+            "--no-shared-memory",
+            "--mcp-auto-start",
+        ]
+    )
+
+    assert exit_code == 0
+    assert instances, "core should have been instantiated"
+    instance = instances[0]
+    assert instance.config_path == "/tmp/config.json"
+    assert instance.entered and instance.exited
+    assert instance.shutdown_called
+    assert callable(instance.status_callback)
+    assert stub_manager.calls == []
+
+    overrides = instance.overrides or {}
+    assert overrides.get("models", {}) == {
+        "default_model": "gpt-mini",
+        "reasoning_model": "gpt-pro",
+        "research_model": "gpt-research",
+        "allow_external_browsing": True,
+    }
+    assert overrides.get("agents", {}) == {
+        "db_migration": True,
+        "research": False,
+    }
+    assert overrides.get("repo_context", {}) == {
+        "include_exts": ["py", "md", "txt"],
+        "exclude_dirs": ["node_modules"],
+        "auto_refresh": False,
+        "refresh_interval": 120.0,
+    }
+    assert overrides.get("memory", {}) == {
+        "config_path": "/tmp/memory.json",
+        "share_globally": False,
+    }
+    assert overrides.get("mcp", {}) == {
+        "config_path": "/tmp/mcp.json",
+        "auto_start": True,
+    }
+
+
+def test_interactive_loop_uses_runtime_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[Any] = []
+
+    class DummyRuntime:
+        def __enter__(self) -> "DummyRuntime":
+            events.append("enter")
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            events.append("exit")
+
+    class DummyManager:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def run(self, message: str) -> SimpleNamespace:
+            self.calls.append(message)
+            events.append(("run", message))
+            return SimpleNamespace(
+                status_updates=[],
+                response_text="ack",
+                plan=[],
+                budgets={},
+                rounds=[],
+                structured_response=None,
+            )
+
+    inputs = iter(["hello", "quit"])
+    monkeypatch.setattr(builtins, "input", lambda *_: next(inputs))
+    printed: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    monkeypatch.setattr(builtins, "print", lambda *args, **kwargs: printed.append((args, kwargs)))
+
+    manager_holder: list[DummyManager] = []
+
+    def factory() -> DummyManager:
+        events.append("factory")
+        manager = DummyManager()
+        manager_holder.append(manager)
+        return manager
+
+    runtime = DummyRuntime()
+
+    exit_code = main._interactive_loop(factory, runtime=runtime)
+
+    assert exit_code == 0
+    assert events == ["enter", "factory", ("run", "hello"), "exit"]
+    assert manager_holder and manager_holder[0].calls == ["hello"]
+    # Ensure interactive banner and response were printed
+    assert any("Auto-Coder manager ready" in args[0] for args, _ in printed)
+    assert any(args[0].startswith("Manager:") for args, _ in printed)


### PR DESCRIPTION
## Summary
- construct the AutoCoderCore runtime from CLI options and use it to build the manager agent within the interactive loop
- surface additional CLI overrides for model selection, agent toggles, repository indexing, memory, and MCP startup behaviour
- add CLI-focused unit tests that stub the runtime and verify overrides plus lifecycle handling

## Testing
- pytest tests/test_main_cli.py

------
https://chatgpt.com/codex/tasks/task_b_68eafb492d5c832f8b22d5d2a07206c9