### PR TITLE
Document AutoCoderCore runtime orchestration

### DIFF
--- a/docs/autocoder/directory-overview.md
+++ b/docs/autocoder/directory-overview.md
@@ -12,7 +12,8 @@ and notable standalone modules.
 | `tooling.py` | Implements the tool registry, normalisation logic, and helpers for discovering/validating callables that can be exposed to models. |
 | `mcp_tooling.py` | Normalises Model Context Protocol server configs (`mcp_servers`) and honours the `MCP_CONFIG_PATH` override for command, local, and remote MCP integrations. |
 | `main.py` | Command-line entry point that builds the manager agent, renders status updates, and runs an interactive REPL loop. |
-| `TUI.py`, `core.py`, `memory.py` | Reserved placeholders for future terminal UI, application core, and memory subsystems respectively. |
+| `core.py` | Implements the `AutoCoderCore` runtime that wires together sessions, tools, memory, MCP servers, and specialist agents. |
+| `TUI.py`, `memory.py` | Planned terminal UI surface and shared memory helpers that supplement the runtime. |
 | `internal/` | Shared libraries used across agents (retrieval, speech, schemas, tool wrappers, web automation, etc.). |
 | `tests/` | Pytest-based regression suite covering agents, toolchains, schema helpers, and speech/retrieval integrations. |
 | `docs/` | Existing documentation space housing LM Studio quick-start notes, plans, and this Auto-Coder reference. |
@@ -20,3 +21,16 @@ and notable standalone modules.
 | `TODO.md` | High-level backlog or future improvements list. |
 
 Refer to the other documents in this directory for deeper dives into each area.
+
+### Quick runtime usage
+
+Embed Auto-Coder in an ad-hoc script by instantiating the core runtime and
+requesting a manager agent:
+
+```python
+from core import AutoCoderCore
+
+with AutoCoderCore() as core:
+    manager = core.build_manager()
+    print(manager.run("List outstanding documentation tasks"))
+```

--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -1,127 +1,118 @@
-# Core Runtime Components
+# Core Runtime (`core.py`)
 
-## Command-Line Interface (`main.py`)
+The core runtime is implemented in [`core.py`](../../core.py) and provides a
+single orchestration class, `AutoCoderCore`, that wires together every
+subsystem needed to run the Auto-Coder agents. It replaces the earlier
+placeholder module and is now the preferred entry point for CLIs, TUIs, and
+embedding Auto-Coder inside other applications.
 
-- Bootstraps an `AgentBuilder` and constructs a `ManagerAgent` with a status
-  callback that prints real-time updates. [`main.py`](../../main.py)
-- Provides an interactive loop that accepts user prompts until `exit`/`quit`
-  are entered, forwarding each message to the manager and rendering any
-  additional status updates before printing the final response. [`main.py`](../../main.py)
+## Configuration model
 
-## Chat Abstractions (`chat.py`)
+`AutoCoderCore` accepts an explicit [`AutoCoderConfig`](../../core.py) instance
+or can load configuration automatically via `load_core_configuration()`. The
+loader merges three sources in the following order:
 
-- Wraps LM Studio's SDK (`lmstudio.llm`) via `get_model`, returning a handle to
-  the configured model. [`chat.py`](../../chat.py)
-- Normalises prompt inputs through `_prepare_input` so callers can supply plain
-  strings, `lms.Chat` histories, or mapping payloads. [`chat.py`](../../chat.py)
-- Provides `_call_model`, `_extract_text`, and `_coerce_response_mapping` to
-  standardise the various return types produced by the SDK. [`chat.py`](../../chat.py)
-- Implements `ChatSession` to manage conversation history, append tool
-  responses, and issue `respond`/`respond_stream` calls with optional
-  callbacks/tool definitions. [`chat.py`](../../chat.py)
-- Supports structured outputs through `_resolve_response_format` and
-  `StructuredResponse`, enabling schema-guided replies. [`chat.py`](../../chat.py)
+1. `config.json` (or the file referenced by `AUTO_CODER_CONFIG_PATH`) under the
+   `{"core": { ... }}` section.
+2. Environment variables.
+3. Runtime overrides supplied to the constructor.
 
-## Session Management (`session.py`)
+The configuration is broken down into a handful of nested sections:
 
-- `AgentSession` builds on `ChatSession`, capturing each round in an
-  `AgentRound` object with transcript, messages, tool history, and metadata.
-  [`session.py`](../../session.py)
-- Exposes hooks (`on_message`, `on_tool_call`, `on_tool_result`, `on_round_start`,
-  `on_round_end`) that external orchestrators can use to observe the workflow.
-  [`session.py`](../../session.py)
-- Provides convenience helpers to mutate tools, append user input, and append
-  tool responses, while keeping callbacks in sync. [`session.py`](../../session.py)
+| Section | Purpose | Representative keys | Environment overrides |
+| --- | --- | --- | --- |
+| `paths` | Locate the repository and scratch space. | `repo_root`, `workspace_root`, `artifact_root` | `AUTO_CODER_REPO_ROOT`, `AUTO_CODER_WORKSPACE_ROOT`, `AUTO_CODER_ARTIFACT_ROOT` |
+| `models` | Select default/reasoning/research models and browsing defaults. | `default_model`, `reasoning_model`, `research_model`, `allow_external_browsing` | `AUTO_CODER_MODEL`, `AUTO_CODER_REASONING_MODEL`, `AUTO_CODER_RESEARCH_MODEL`, `AUTO_CODER_ALLOW_BROWSING` |
+| `repo_context` | Control semantic indexing. | `include_exts`, `exclude_dirs`, `auto_refresh`, `refresh_interval` | `AUTO_CODER_REPO_INCLUDE_EXTS`, `AUTO_CODER_REPO_EXCLUDE_DIRS`, `AUTO_CODER_REPO_AUTO_REFRESH`, `AUTO_CODER_REPO_REFRESH_INTERVAL` |
+| `agents` | Enable/disable specialist helpers. | Flags for `repo_context`, `research`, `documentation`, `dependency`, `runner`, `db_migration`, `security`, `integrations`, `eval`, `test_critic` | `AUTO_CODER_ENABLE_<NAME>`, `AUTO_CODER_DISABLE_<NAME>` |
+| `memory` | Configure vector-memory backends. | `config_path`, `default_scope`, `combined_scope`, `share_globally` | `AUTO_CODER_MEMORY_CONFIG`, `AUTO_CODER_MEMORY_DEFAULT_SCOPE`, `AUTO_CODER_MEMORY_COMBINED_SCOPE`, `AUTO_CODER_MEMORY_SHARE` |
+| `mcp` | Discover Model Context Protocol servers. | `config_path`, `servers`, `auto_start` | `AUTO_CODER_MCP_CONFIG`, `AUTO_CODER_MCP_AUTO_START` |
 
-## Tool Registry (`tooling.py`)
+Additional helper variables include `AUTO_CODER_CONFIG_PATH` (alternate core
+config file) and `AUTO_CODER_WORKSPACE_ROOT`/`AUTO_CODER_ARTIFACT_ROOT` when the
+workspace layout should deviate from the repository root.
 
-- Defines `ToolSpec`, a dataclass capturing tool metadata, callable
-  implementation, parameters, and payload overrides for LM Studio's tool
-  interface. The spec now differentiates between standard function tools and
-  MCP integrations via the `tool_type` attribute, allowing non-callable
-  metadata-only tools to be registered safely. [`tooling.py`](../../tooling.py)
-- Offers `ToolRegistry` for registering callables, resolving tool references by
-  name, preventing duplicates, and ensuring each tool exposes type annotations
-  and documentation. Registry helpers deduplicate by tool name and support
-  pre-built `ToolSpec` instances alongside callables. [`tooling.py`](../../tooling.py)
-- Provides `register_mcp_tool` for registering MCP servers from JSON payloads,
-  merging header/metadata overrides while co-existing with standard tools.
-  [`tooling.py`](../../tooling.py)
-- Includes discovery helpers (`discover_module_tools`, `discover_package_tools`)
-  to automatically register tools from modules or packages. [`tooling.py`](../../tooling.py)
+## Orchestration pipeline
 
-## MCP Server Integration (`mcp_tooling.py`)
+When instantiated, `AutoCoderCore` performs the following orchestration steps:
 
-- `MCPServerRegistry` validates `mcp_servers` entries loaded from `config.json`
-  (or the path pointed to by the `MCP_CONFIG_PATH` environment variable),
-  coercing headers, metadata, and allowed tool lists before constructing
-  `MCPServerSpec` objects. [`mcp_tooling.py`](../../mcp_tooling.py)
-- `CommandServerLifecycle` starts command-based MCP servers, waits for readiness
-  via stdout patterns or probe URLs, and issues shutdown commands, signals, or
-  process kills on teardown. [`mcp_tooling.py`](../../mcp_tooling.py)
-- `register_mcp_servers` mirrors `ToolRegistry.register_mcp_tool`, ensuring each
-  MCP descriptor serialises to a `{"type": "mcp", ...}` payload that can live
-  alongside callable tools inside `model.act`. [`mcp_tooling.py`](../../mcp_tooling.py)
-- `AgentBuilder.with_mcp_servers()` wires descriptors into the same code path as
-  `with_tools`, allowing sessions to mix local callables with remote/local MCP
-  endpoints without manual registry plumbing. [`agents/__init__.py`](../../agents/__init__.py)
-- Example configuration snippets:
+1. **Tool registry** – Creates a shared [`ToolRegistry`](../../tooling.py) and
+   exposes it to every session built through the core.
+2. **Memory routing** – Loads the memory configuration using
+   [`memory.load_memory_configuration`](../../memory.py), builds a
+   [`MemoryRouter`](../../memory.py), and mounts a `MemoryFacade`. When
+   `share_globally` is true, the facade is registered as the global shared
+   memory instance so individual agents can access it without additional
+   plumbing.
+3. **MCP registry** – Hydrates [`MCPServerRegistry`](../../mcp_tooling.py) from
+   inline descriptors or from a JSON file, optionally starting command-based
+   servers when `auto_start` is enabled. The resulting specs are registered in
+   the tool registry and applied to any sessions the core creates.
+4. **Agent wiring** – Lazily constructs specialist agents (`RepoContextAgent`,
+   `ResearchAgent`, `DocAgent`, `RunnerAgent`, `DependencyBuildAgent`,
+   `DBMigrationAgent`, `SecurityAgent`, `IntegrationsAgent`, `EvalAgent`, and
+   `TestCriticAgent`) based on the toggles in the configuration. Each agent
+   shares the session, memory, and tool infrastructure initialised by the core.
+5. **Manager construction** – `build_manager()` assembles a fully-wired
+   [`ManagerAgent`](../../agents/manager.py) with callbacks, context attachments,
+   and MCP tools already installed. The returned manager is ready to receive
+   prompts immediately.
+6. **Lifecycle management** – The core exposes `shutdown()` and implements the
+   context-manager protocol to tear down background repo refreshers, MCP
+   processes, and shared memory state cleanly.
 
-  - Local server:
+## Front-end integrations
 
-    ```json
-    {
-      "mcp_servers": {
-        "filesystem": {
-          "type": "local",
-          "url": "http://127.0.0.1:3030",
-          "allowed_tools": ["fs.read"]
-        }
-      }
+Existing front ends, such as [`main.py`](../../main.py) (CLI) and the planned
+[`TUI.py`](../../TUI.py), use the core runtime to obtain a manager agent while
+handling user interaction themselves. The CLI, for example, instantiates
+`AutoCoderCore`, calls `build_manager(status_callback=...)`, and then enters a
+prompt loop. Alternative surfaces—web services, batch scripts, notebooks—can
+follow the same pattern to reuse the orchestration logic without duplicating the
+setup.
+
+## Usage examples
+
+Create and tear down the runtime manually:
+
+```python
+from core import AutoCoderCore
+
+core = AutoCoderCore()
+manager = core.build_manager()
+try:
+    response = manager.run("Add a unit test for the new parser")
+    print(response)
+finally:
+    core.shutdown()
+```
+
+Or rely on the context-manager shorthand:
+
+```python
+from core import AutoCoderCore
+
+with AutoCoderCore() as core:
+    manager = core.build_manager()
+    print(manager.run("Summarise the latest commit"))
+```
+
+To override settings from a script, supply overrides or a custom environment:
+
+```python
+from core import AutoCoderCore
+
+overrides = {
+    "core": {
+        "models": {"default_model": "anthropic/claude-3-sonnet"},
+        "mcp": {"auto_start": True},
     }
-    ```
+}
 
-  - Remote server:
+with AutoCoderCore(overrides=overrides) as core:
+    manager = core.build_manager()
+    print(manager.run("Scan the repo for TODO comments"))
+```
 
-    ```json
-    {
-      "mcp_servers": {
-        "knowledge-base": {
-          "type": "remote",
-          "url": "https://mcp.example.com/api",
-          "verify_tls": false,
-          "allowed_tools": ["search", "summarize"]
-        }
-      }
-    }
-    ```
-
-  - Command-launched server:
-
-    ```json
-    {
-      "mcp_servers": {
-        "git-helper": {
-          "type": "command",
-          "command": ["python", "-m", "git_mcp"],
-          "ready_pattern": "Server ready",
-          "ready_timeout": 15,
-          "ready_probe_url": "http://127.0.0.1:4040/health",
-          "shutdown_command": ["python", "-m", "git_mcp", "--shutdown"],
-          "shutdown_signal": 15,
-          "env": {"MCP_API_KEY": "${GIT_MCP_TOKEN}"},
-          "capture_output": true
-        }
-      }
-    }
-    ```
-
-  Optional keys such as `headers`, `metadata`, `cwd`, and `allowed_tools` work
-  uniformly across server types, ensuring consistent payloads during tool
-  resolution and `model.act` execution.
-
-## Placeholder Modules
-
-- `core.py`, `memory.py`, and `TUI.py` currently contain module headers only,
-  indicating planned areas for core orchestration, long-term memory, and a
-  terminal UI. [`core.py`](../../core.py), [`memory.py`](../../memory.py), [`TUI.py`](../../TUI.py)
+These snippets apply equally to shell entry points, notebook cells, or
+long-running daemons that wish to embed Auto-Coder.


### PR DESCRIPTION
## Summary
- rewrite the runtime reference to describe the implemented AutoCoderCore configuration, orchestration steps, and front-end usage
- update the directory overview to reflect the non-placeholder core runtime and show a quick instantiation example

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68eafdc0d4f8832fb92fd3b5caf7a1db