### PR TITLE
Ensure composite memory router is always returned

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -3252,7 +3252,7 @@ def build_memory_router(config: Optional[MemoryConfiguration] = None) -> MemoryR
     else:
         stores[MemoryRouter.COMBINED] = build_memory_store(config.combined.copy())
 
-        return MemoryRouter(stores)
+    return MemoryRouter(stores)
 
 
 class MemoryFacade:

--- a/tests/test_memory_backends.py
+++ b/tests/test_memory_backends.py
@@ -13,7 +13,9 @@ from typing import Dict, Iterator
 import pytest
 
 from memory import (
+    CompositeMemoryStore,
     InMemoryMemoryStore,
+    MemoryConfiguration,
     MemoryMetadata,
     MemoryQuery,
     MemoryRecord,
@@ -21,6 +23,7 @@ from memory import (
     PostgresSettings,
     RedisSettings,
     StoreConfig,
+    build_memory_router,
     build_memory_store,
     clear_embedding_providers,
     register_embedding_provider,
@@ -34,6 +37,33 @@ def _reset_embedding_cache() -> Iterator[None]:
     clear_embedding_providers()
     yield
     clear_embedding_providers()
+
+
+def test_build_memory_router_with_composite_combined_scope() -> None:
+    config = MemoryConfiguration(
+        short_term=StoreConfig(scope="short_term", backend="memory"),
+        long_term=StoreConfig(scope="long_term", backend="memory"),
+        combined=StoreConfig(
+            scope="combined",
+            backend="composite",
+            options={"scopes": ["short_term", "long_term"]},
+        ),
+    )
+
+    router = build_memory_router(config)
+
+    combined_store = router.combined
+    assert isinstance(combined_store, CompositeMemoryStore)
+
+    record = MemoryRecord(
+        content="Composite record",
+        metadata=MemoryMetadata(source="unit-test", attributes={"session_id": "combo"}),
+    )
+
+    stored = combined_store.add(record)
+
+    assert router.short_term.get(stored.record_id).content == "Composite record"
+    assert router.long_term.get(stored.record_id).content == "Composite record"
 
 
 def _find_free_port() -> int:


### PR DESCRIPTION
## Summary
- ensure `build_memory_router` always returns the configured router regardless of combined backend
- add a regression test that verifies composite combined memory scopes expose the expected stores

## Testing
- pytest tests/test_memory_backends.py

------
https://chatgpt.com/codex/tasks/task_b_68eb2311035c832fbe410e3a7f4d2300