### PR TITLE
Add CLI argument support to TUI launcher

### DIFF
--- a/TUI.py
+++ b/TUI.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import contextlib
+import sys
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
@@ -20,7 +22,9 @@ from textual.widgets import Footer, Header, Input, RichLog, Static
 from textual.worker import Worker
 
 from agents.manager import ManagerAgent, ManagerResult, ManagerStatusUpdate
-from core import AutoCoderCore
+from core import AgentToggleSettings, AutoCoderCore
+from mcp_tooling import MCPConfigurationError
+from main import _build_overrides
 
 
 class ManagerStatusMessage(Message):
@@ -290,8 +294,15 @@ class AutoCoderApp(App[None]):
         Binding("escape", "cancel_request", "Cancel"),
     ]
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        config_path: str | None = None,
+        overrides: Mapping[str, Any] | None = None,
+    ) -> None:
         super().__init__()
+        self._config_path = config_path
+        self._overrides = dict(overrides or {})
         self._core: AutoCoderCore | None = None
         self._manager: ManagerAgent | None = None
         self._worker: Worker[ManagerResult] | None = None
@@ -320,11 +331,29 @@ class AutoCoderApp(App[None]):
         status_feed.add_message("Starting AutoCoderCore…")
         try:
             await self._initialise_runtime()
+        except MCPConfigurationError as exc:
+            status_feed.add_message(
+                f"Failed to initialise MCP integration: {exc}", style="red"
+            )
+            transcript.add_system_message(
+                "A configuration error occurred while setting up MCP."
+            )
+            if hasattr(self, "notify"):
+                try:
+                    self.notify(
+                        f"MCP configuration error: {exc}",
+                        severity="error",
+                    )
+                except Exception:  # pragma: no cover - safety net
+                    pass
+            await asyncio.sleep(0)
+            self.exit(result=2)
+            return
         except Exception as exc:  # pragma: no cover - defensive
             status_feed.add_message(f"Failed to initialise Auto-Coder: {exc}", style="red")
             transcript.add_system_message("Shutting down due to initialisation failure.")
             await asyncio.sleep(0)
-            self.exit()
+            self.exit(result=1)
             return
         status_feed.add_message("Auto-Coder manager ready", style="green")
         transcript.add_system_message("Manager ready. Type /quit to exit or /cancel to cancel a request.")
@@ -346,7 +375,7 @@ class AutoCoderApp(App[None]):
         prompt.is_busy = True
 
         def builder() -> tuple[AutoCoderCore, ManagerAgent]:
-            core = AutoCoderCore()
+            core = AutoCoderCore(config_path=self._config_path, overrides=self._overrides)
             manager = core.build_manager(status_callback=self._handle_status_callback)
             return core, manager
 
@@ -482,5 +511,142 @@ class AutoCoderApp(App[None]):
         await super().on_key(event)
 
 
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Launch the Auto-Coder Textual UI")
+    parser.add_argument(
+        "--config",
+        dest="config_path",
+        help="Path to config.json providing memory and MCP settings",
+    )
+    parser.add_argument(
+        "--mcp-config",
+        dest="mcp_config_path",
+        help="Optional override for the MCP server configuration file",
+    )
+    parser.add_argument(
+        "--default-model",
+        dest="default_model",
+        help="Override the default LLM model used by Auto-Coder",
+    )
+    parser.add_argument(
+        "--reasoning-model",
+        dest="reasoning_model",
+        help="Override the reasoning model used for complex planning",
+    )
+    parser.add_argument(
+        "--research-model",
+        dest="research_model",
+        help="Override the research model for web lookups",
+    )
+    parser.add_argument(
+        "--allow-browsing",
+        dest="allow_browsing",
+        action="store_true",
+        help="Enable external browsing tools for the research agent",
+    )
+    parser.add_argument(
+        "--disable-browsing",
+        dest="allow_browsing",
+        action="store_false",
+        help="Disable external browsing tools for the research agent",
+    )
+    parser.set_defaults(allow_browsing=None)
+
+    agent_choices = sorted(AgentToggleSettings.__annotations__.keys())
+    parser.add_argument(
+        "--enable-agent",
+        dest="enable_agent",
+        choices=agent_choices,
+        action="append",
+        help="Explicitly enable a specialist agent",
+    )
+    parser.add_argument(
+        "--disable-agent",
+        dest="disable_agent",
+        choices=agent_choices,
+        action="append",
+        help="Explicitly disable a specialist agent",
+    )
+
+    parser.add_argument(
+        "--repo-include-ext",
+        dest="repo_include_ext",
+        action="append",
+        help="File extensions to include when indexing the repository context",
+    )
+    parser.add_argument(
+        "--repo-exclude-dir",
+        dest="repo_exclude_dir",
+        action="append",
+        help="Directories to exclude from the repository context index",
+    )
+    parser.add_argument(
+        "--repo-auto-refresh",
+        dest="repo_auto_refresh",
+        action="store_true",
+        help="Enable background refresh of the repository semantic index",
+    )
+    parser.add_argument(
+        "--repo-no-auto-refresh",
+        dest="repo_auto_refresh",
+        action="store_false",
+        help="Disable background refresh of the repository semantic index",
+    )
+    parser.set_defaults(repo_auto_refresh=None)
+    parser.add_argument(
+        "--repo-refresh-interval",
+        dest="repo_refresh_interval",
+        type=float,
+        help="Seconds between repository context refreshes",
+    )
+
+    parser.add_argument(
+        "--memory-config",
+        dest="memory_config_path",
+        help="Override the memory configuration file path",
+    )
+    parser.add_argument(
+        "--shared-memory",
+        dest="share_memory",
+        action="store_true",
+        help="Share the constructed memory facade globally",
+    )
+    parser.add_argument(
+        "--no-shared-memory",
+        dest="share_memory",
+        action="store_false",
+        help="Avoid sharing the constructed memory facade globally",
+    )
+    parser.set_defaults(share_memory=None)
+
+    parser.add_argument(
+        "--mcp-auto-start",
+        dest="mcp_auto_start",
+        action="store_true",
+        help="Automatically start configured MCP servers",
+    )
+    parser.add_argument(
+        "--no-mcp-auto-start",
+        dest="mcp_auto_start",
+        action="store_false",
+        help="Skip automatic MCP server startup",
+    )
+    parser.set_defaults(mcp_auto_start=None)
+
+    return parser
+
+
+def run_tui(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    overrides = _build_overrides(args)
+
+    app = AutoCoderApp(config_path=args.config_path, overrides=overrides)
+    result = app.run()
+    if isinstance(result, int):
+        return result
+    return 0
+
+
 if __name__ == "__main__":
-    AutoCoderApp().run()
+    sys.exit(run_tui())


### PR DESCRIPTION
## Summary
- add CLI argument parsing for the Textual UI mirroring the main CLI
- pass configuration overrides into the Textual app and surface MCP configuration errors with a toast before exiting
- expose a run_tui() entry point and wire __main__ to it for direct execution

## Testing
- python -m compileall TUI.py main.py

------
https://chatgpt.com/codex/tasks/task_b_68eb2ed104c0832fa8587be0b4cac3c8