### PR TITLE
Document Text UI usage and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Launch the Interactive Manager](#launch-the-interactive-manager)
+- [Text UI](#text-ui)
 - [Development Workflow](#development-workflow)
   - [Running Tests](#running-tests)
   - [Playwright Browser Support](#playwright-browser-support)
@@ -91,6 +92,41 @@ python main.py
 ```
 
 You will enter an interactive loop; type your request and watch the manager agent coordinate the supporting agents. Use `exit` or `quit` to leave the session.
+
+## Text UI
+
+![Auto-Coder Text UI overview](docs/assets/text-ui-demo.png)
+
+Auto-Coder ships with an optional terminal UI built on [Textual](https://textual.textualize.io/). It layers a live plan tracker and status feeds on top of the classic CLI so you can monitor each agent while a request runs.
+
+### Installation Requirements
+
+- Ensure the core dependencies are installed via `pip install -r requirements.txt`. If you only need the Text UI, install `textual>=0.56.4` and `rich>=13.7` alongside the base prerequisites listed above.
+- The UI renders best in terminals with **true colour** and **Unicode** support (iTerm2, Windows Terminal, Kitty, Alacritty, and most modern Linux terminals).
+- Optional: configure LM Studio and any MCP servers referenced by your `config.json` when you want the UI to orchestrate live agent runs.
+
+### Launch Command
+
+```bash
+python TUI.py --config path/to/config.json
+```
+
+Run the command from the repository root. All CLI flags accepted by `main.py` (for example, memory overrides or MCP startup settings) are available here as well.
+
+### Feature Highlights
+
+- **Transcript panel** retains the full conversation between you and Auto-Coder, including system events.
+- **Plan tracker** surfaces the manager's execution plan and updates each task as agents make progress.
+- **Budget meter** visualises consumption for per-task round budgets so you can see when a workflow is close to its limits.
+- **Status feed** streams structured status updates (planning, progress, successes, and errors) in real time.
+- **Prompt input** mirrors the CLI experience with `/cancel` and `/quit` helpers for graceful shutdowns.
+
+### Troubleshooting & Fallbacks
+
+- **Terminal quirks** – If colours look incorrect, export `TERM=xterm-256color` or switch to a terminal emulator with true-colour support.
+- **Dependency errors** – Install Textual with `pip install textual>=0.56.4 rich>=13.7` or reinstall using the full `requirements.txt` to pick up Rich and Textual dependencies.
+- **Conflicting keybindings** – Some terminals intercept `Ctrl+C`; press `Esc` followed by `/quit` to exit safely.
+- **Switch back to the classic CLI** – Run `python main.py` for the original command-line flow whenever a minimal environment is required.
 
 ## Development Workflow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Welcome to the central guide for everything packaged under the `docs/` directory
 
 | Area | Audience | Highlights |
 | --- | --- | --- |
-| [Auto-Coder](./autocoder/README.md) | Contributors building or maintaining this repository. | Repository layout, runtime architecture, agent catalogue, internal libraries, and test strategy. |
+| [Auto-Coder](./autocoder/README.md) | Contributors building or maintaining this repository. | Repository layout, runtime architecture, agent catalogue, internal libraries, Text UI usage, and test strategy. |
 | [LM Studio](./LMStudio/index.md) | Developers embedding LM Studio into products. | Application walkthroughs, REST/SDK references, tool calling guides, and structured output recipes. |
 | [LMF2 Model Family](./LMF2/index.md) | Practitioners deploying Liquid LMF2 models. | Model cards, context limits, licensing details, and download instructions. |
 
@@ -14,6 +14,7 @@ Welcome to the central guide for everything packaged under the `docs/` directory
 
 - Browse upcoming enhancements and historical notes inside [`docs/plans/`](./plans).
 - Jump straight to the Auto-Coder runtime deep dive with [`runtime.md`](./autocoder/runtime.md).
+- Preview the new terminal interface in the [Text UI overview](./autocoder/README.md#%F0%9F%96%A5%EF%B8%8F-text-ui-overview).
 - Need API coverage? Start at [`app/api/`](./LMStudio/app/api/) inside the LM Studio docs for endpoint and tool-call specifics.
 - Looking for evaluation data? Review the [`LMF2-2.6B`](./LMF2/LMF2-2.6B) folder for example prompts and benchmarks.
 

--- a/docs/assets/text-ui-demo.png
+++ b/docs/assets/text-ui-demo.png
@@ -1,0 +1,165 @@
+<svg class="rich-terminal" viewBox="0 0 1580 660.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1515165708-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1515165708-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1515165708-r1 { fill: #c5c8c6 }
+.terminal-1515165708-r2 { fill: #e3e3e3 }
+.terminal-1515165708-r3 { fill: #fd971f;font-weight: bold }
+.terminal-1515165708-r4 { fill: #e1e1e1 }
+.terminal-1515165708-r5 { fill: #f4005f }
+.terminal-1515165708-r6 { fill: #58d1eb;font-weight: bold }
+.terminal-1515165708-r7 { fill: #98e024;font-weight: bold }
+.terminal-1515165708-r8 { fill: #9d65ff }
+.terminal-1515165708-r9 { fill: #1e1e1e }
+.terminal-1515165708-r10 { fill: #121212 }
+.terminal-1515165708-r11 { fill: #e2e2e2 }
+.terminal-1515165708-r12 { fill: #dde8f3;font-weight: bold }
+.terminal-1515165708-r13 { fill: #ddedf9 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1515165708-clip-terminal">
+      <rect x="0" y="0" width="1560.6" height="609.0" />
+    </clipPath>
+    <clipPath id="terminal-1515165708-line-0">
+    <rect x="0" y="1.5" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-1">
+    <rect x="0" y="25.9" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-2">
+    <rect x="0" y="50.3" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-3">
+    <rect x="0" y="74.7" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-4">
+    <rect x="0" y="99.1" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-5">
+    <rect x="0" y="123.5" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-6">
+    <rect x="0" y="147.9" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-7">
+    <rect x="0" y="172.3" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-8">
+    <rect x="0" y="196.7" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-9">
+    <rect x="0" y="221.1" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-10">
+    <rect x="0" y="245.5" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-11">
+    <rect x="0" y="269.9" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-12">
+    <rect x="0" y="294.3" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-13">
+    <rect x="0" y="318.7" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-14">
+    <rect x="0" y="343.1" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-15">
+    <rect x="0" y="367.5" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-16">
+    <rect x="0" y="391.9" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-17">
+    <rect x="0" y="416.3" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-18">
+    <rect x="0" y="440.7" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-19">
+    <rect x="0" y="465.1" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-20">
+    <rect x="0" y="489.5" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-21">
+    <rect x="0" y="513.9" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-22">
+    <rect x="0" y="538.3" width="1561.6" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1515165708-line-23">
+    <rect x="0" y="562.7" width="1561.6" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1578" height="658" rx="8"/><text class="terminal-1515165708-title" fill="#c5c8c6" text-anchor="middle" x="789" y="27">DemoTextUI</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1515165708-clip-terminal)">
+    <rect fill="#282828" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="97.6" y="1.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="707.6" y="1.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="829.6" y="1.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="1439.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="1451.8" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="1451.8" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="1549.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="1561.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="50.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="109.8" y="50.3" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="378.2" y="50.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="427" y="50.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="536.8" y="50.3" width="219.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="50.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="866.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="878.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="902.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="915" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="927.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="939.4" y="50.3" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="74.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="73.2" y="74.7" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="451.4" y="74.7" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="866.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="878.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="902.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="915" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="927.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="939.4" y="74.7" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="99.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="158.6" y="99.1" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="463.6" y="99.1" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="866.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="878.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="902.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="915" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="927.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="939.4" y="99.1" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="123.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="123.5" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="147.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="147.9" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="172.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="172.3" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="196.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="196.7" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="221.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="221.1" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="245.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="756.4" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="245.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="245.5" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1195.6" y="245.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1512.8" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="1561.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="1561.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="36.6" y="318.7" width="1488.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1525" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="36.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="61" y="343.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="122" y="343.1" width="1378.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1500.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1525" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="24.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="36.6" y="367.5" width="1488.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1525" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="391.9" width="1512.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="416.3" width="1512.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="440.7" width="1512.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="465.1" width="1512.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="489.5" width="1512.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="513.9" width="1512.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="538.3" width="1512.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1537.2" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="1561.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="587.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="97.6" y="587.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="170.8" y="587.1" width="1390.8" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1515165708-matrix">
+    <text class="terminal-1515165708-r2" x="12.2" y="20" textLength="12.2" clip-path="url(#terminal-1515165708-line-0)">⭘</text><text class="terminal-1515165708-r2" x="707.6" y="20" textLength="122" clip-path="url(#terminal-1515165708-line-0)">DemoTextUI</text><text class="terminal-1515165708-r1" x="1561.6" y="20" textLength="12.2" clip-path="url(#terminal-1515165708-line-0)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="44.4" textLength="12.2" clip-path="url(#terminal-1515165708-line-1)">
+</text><text class="terminal-1515165708-r3" x="24.4" y="68.8" textLength="85.4" clip-path="url(#terminal-1515165708-line-2)">System:</text><text class="terminal-1515165708-r4" x="109.8" y="68.8" textLength="256.2" clip-path="url(#terminal-1515165708-line-2)">&#160;Manager&#160;ready.&#160;Type&#160;</text><text class="terminal-1515165708-r5" x="366" y="68.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-2)">/</text><text class="terminal-1515165708-r5" x="378.2" y="68.8" textLength="48.8" clip-path="url(#terminal-1515165708-line-2)">quit</text><text class="terminal-1515165708-r4" x="427" y="68.8" textLength="109.8" clip-path="url(#terminal-1515165708-line-2)">&#160;to&#160;exit.</text><text class="terminal-1515165708-r4" x="780.8" y="68.8" textLength="85.4" clip-path="url(#terminal-1515165708-line-2)">outline</text><text class="terminal-1515165708-r4" x="878.4" y="68.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-2)">1</text><text class="terminal-1515165708-r4" x="902.8" y="68.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-2)">1</text><text class="terminal-1515165708-r4" x="927.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-2)">0</text><text class="terminal-1515165708-r1" x="1561.6" y="68.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-2)">
+</text><text class="terminal-1515165708-r6" x="24.4" y="93.2" textLength="48.8" clip-path="url(#terminal-1515165708-line-3)">You:</text><text class="terminal-1515165708-r4" x="73.2" y="93.2" textLength="378.2" clip-path="url(#terminal-1515165708-line-3)">&#160;Document&#160;the&#160;Text&#160;UI&#160;workflow.</text><text class="terminal-1515165708-r4" x="780.8" y="93.2" textLength="85.4" clip-path="url(#terminal-1515165708-line-3)">tests&#160;&#160;</text><text class="terminal-1515165708-r4" x="878.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-3)">1</text><text class="terminal-1515165708-r4" x="902.8" y="93.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-3)">3</text><text class="terminal-1515165708-r4" x="927.2" y="93.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-3)">2</text><text class="terminal-1515165708-r1" x="1561.6" y="93.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-3)">
+</text><text class="terminal-1515165708-r7" x="24.4" y="117.6" textLength="134.2" clip-path="url(#terminal-1515165708-line-4)">Auto-Coder:</text><text class="terminal-1515165708-r4" x="158.6" y="117.6" textLength="305" clip-path="url(#terminal-1515165708-line-4)">&#160;Starting&#160;plan&#160;execution…</text><text class="terminal-1515165708-r4" x="780.8" y="117.6" textLength="85.4" clip-path="url(#terminal-1515165708-line-4)">docs&#160;&#160;&#160;</text><text class="terminal-1515165708-r4" x="878.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-4)">0</text><text class="terminal-1515165708-r4" x="902.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-4)">2</text><text class="terminal-1515165708-r4" x="927.2" y="117.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-4)">2</text><text class="terminal-1515165708-r1" x="1561.6" y="117.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-4)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="142" textLength="12.2" clip-path="url(#terminal-1515165708-line-5)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="166.4" textLength="12.2" clip-path="url(#terminal-1515165708-line-6)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="190.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-7)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="215.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-8)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="239.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-9)">
+</text><text class="terminal-1515165708-r8" x="780.8" y="264" textLength="109.8" clip-path="url(#terminal-1515165708-line-10)">PLANNING&#160;</text><text class="terminal-1515165708-r8" x="890.6" y="264" textLength="305" clip-path="url(#terminal-1515165708-line-10)">:&#160;Drafting&#160;execution&#160;plan</text><text class="terminal-1515165708-r1" x="1561.6" y="264" textLength="12.2" clip-path="url(#terminal-1515165708-line-10)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="288.4" textLength="12.2" clip-path="url(#terminal-1515165708-line-11)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="312.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-12)">
+</text><text class="terminal-1515165708-r9" x="24.4" y="337.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-13)">▊</text><text class="terminal-1515165708-r10" x="36.6" y="337.2" textLength="1488.4" clip-path="url(#terminal-1515165708-line-13)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-1515165708-r10" x="1525" y="337.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-13)">▎</text><text class="terminal-1515165708-r1" x="1561.6" y="337.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-13)">
+</text><text class="terminal-1515165708-r9" x="24.4" y="361.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-14)">▊</text><text class="terminal-1515165708-r11" x="61" y="361.6" textLength="61" clip-path="url(#terminal-1515165708-line-14)">/help</text><text class="terminal-1515165708-r10" x="1525" y="361.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-14)">▎</text><text class="terminal-1515165708-r1" x="1561.6" y="361.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-14)">
+</text><text class="terminal-1515165708-r9" x="24.4" y="386" textLength="12.2" clip-path="url(#terminal-1515165708-line-15)">▊</text><text class="terminal-1515165708-r10" x="36.6" y="386" textLength="1488.4" clip-path="url(#terminal-1515165708-line-15)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-1515165708-r10" x="1525" y="386" textLength="12.2" clip-path="url(#terminal-1515165708-line-15)">▎</text><text class="terminal-1515165708-r1" x="1561.6" y="386" textLength="12.2" clip-path="url(#terminal-1515165708-line-15)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="410.4" textLength="12.2" clip-path="url(#terminal-1515165708-line-16)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="434.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-17)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="459.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-18)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="483.6" textLength="12.2" clip-path="url(#terminal-1515165708-line-19)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="508" textLength="12.2" clip-path="url(#terminal-1515165708-line-20)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="532.4" textLength="12.2" clip-path="url(#terminal-1515165708-line-21)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="556.8" textLength="12.2" clip-path="url(#terminal-1515165708-line-22)">
+</text><text class="terminal-1515165708-r1" x="1561.6" y="581.2" textLength="12.2" clip-path="url(#terminal-1515165708-line-23)">
+</text><text class="terminal-1515165708-r12" x="0" y="605.6" textLength="97.6" clip-path="url(#terminal-1515165708-line-24)">&#160;CTRL+C&#160;</text><text class="terminal-1515165708-r13" x="97.6" y="605.6" textLength="73.2" clip-path="url(#terminal-1515165708-line-24)">&#160;Quit&#160;</text>
+    </g>
+    </g>
+</svg>

--- a/docs/autocoder/README.md
+++ b/docs/autocoder/README.md
@@ -12,6 +12,7 @@ Welcome to the Auto-Coder documentation set. This hub explains how the repositor
 | [Internal Libraries](./internal.md) | Shared building blocks in the `internal/` namespace plus bundled tool implementations. |
 | [Memory Backends](./memory.md) | Redis/PostgreSQL setup instructions, environment variables, and troubleshooting tips. |
 | [Testing Strategy](./testing.md) | Coverage summary for the automated test suite and the behaviours it exercises. |
+| [Text UI Overview](#%F0%9F%96%A5%EF%B8%8F-text-ui-overview) | Launching and operating the Textual-powered terminal interface. |
 
 ## 🔄 Keeping Docs Fresh
 
@@ -25,3 +26,38 @@ Welcome to the Auto-Coder documentation set. This hub explains how the repositor
 - Broader documentation for LM Studio and the LMF2 model family is indexed in the [docs hub](../README.md).
 
 Your future self (and teammates) will thank you for keeping this knowledge base accurate. 🙌
+
+## 🖥️ Text UI Overview
+
+![Auto-Coder Text UI](../assets/text-ui-demo.png)
+
+The Text UI layers a Rich/Textual interface on top of the Auto-Coder manager so you can observe execution plans, status feeds, and resource budgets without leaving the terminal.
+
+### Installation Checklist
+
+- Install the project dependencies with `pip install -r requirements.txt`. For lean environments, ensure `textual>=0.56.4` and `rich>=13.7` are available alongside Python 3.10+.
+- Use a terminal emulator with 24-bit colour and Unicode rendering for the best experience. Setting `TERM=xterm-256color` resolves most palette issues.
+- (Optional) Populate `config.json` with LM Studio settings, memory overrides, and MCP server definitions so the UI can bootstrap the full manager stack.
+
+### Launching the Interface
+
+```bash
+python TUI.py --config config.json
+```
+
+Run the command from the repository root. All configuration flags exposed by `main.py` are mirrored, including memory routing, repository index refresh intervals, and MCP lifecycle toggles.
+
+### Feature Tour
+
+- **Transcript** – Streams user prompts, agent responses, and system notices with syntax highlighting.
+- **Plan tracker** – Displays the manager plan and updates rows as tasks move from pending to in-progress, completed, or errored states.
+- **Budget meter** – Reports consumed, remaining, and total round budgets for each task.
+- **Status feed** – Renders structured status updates so you can follow planning, progress, and error events in real time.
+- **Prompt bar** – Accepts prompts, `/cancel`, and `/quit` commands without leaving the UI.
+
+### Troubleshooting
+
+- **Terminal compatibility** – If borders look jagged or colours are muted, switch to a Nerd Font or powerline-friendly font and confirm the terminal advertises true-colour support.
+- **Dependency import errors** – Install Textual and Rich individually (`pip install textual rich`) or rerun the main requirements install.
+- **Keyboard shortcuts** – `Ctrl+C` triggers a graceful exit; `Esc` + `/cancel` cancels the active request when the manager is busy.
+- **Classic CLI fallback** – Run `python main.py` whenever you need a no-frills interface (for example, inside restricted CI shells).

--- a/scripts/demo_textui.py
+++ b/scripts/demo_textui.py
@@ -1,0 +1,173 @@
+"""Generate a static screenshot of the Auto-Coder Text UI layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.table import Table
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Vertical
+from textual.widgets import Footer, Header, Input, RichLog, Static
+
+ASSET_PATH = Path(__file__).resolve().parents[1] / "docs" / "assets" / "text-ui-demo.png"
+
+
+class TranscriptWidget(RichLog):
+    def __init__(self) -> None:
+        super().__init__(highlight=True, markup=True, wrap=True, id="transcript")
+        self.border_title = "Transcript"
+
+
+class PlanWidget(Static):
+    def __init__(self) -> None:
+        super().__init__(id="plan")
+        self.border_title = "Plan"
+
+    def load_sample(self) -> None:
+        table = Table.grid(padding=(0, 1))
+        table.add_column("Task", overflow="fold")
+        table.add_column("Status", overflow="fold")
+        table.add_column("Notes", overflow="fold")
+        table.add_row("outline", "completed", "Summarise requested change")
+        table.add_row("tests", "in progress", "1/3")
+        table.add_row("docs", "pending", "Awaiting manager")
+        self.update(table)
+
+
+class BudgetWidget(Static):
+    def __init__(self) -> None:
+        super().__init__(id="budgets")
+        self.border_title = "Budgets"
+
+    def load_sample(self) -> None:
+        table = Table.grid(padding=(0, 1))
+        table.add_column("Task", overflow="fold")
+        table.add_column("Consumed", justify="right")
+        table.add_column("Limit", justify="right")
+        table.add_column("Remaining", justify="right")
+        table.add_row("outline", "1", "1", "0")
+        table.add_row("tests", "1", "3", "2")
+        table.add_row("docs", "0", "2", "2")
+        self.update(table)
+
+
+class StatusWidget(RichLog):
+    def __init__(self) -> None:
+        super().__init__(highlight=True, markup=True, wrap=True, id="status")
+        self.border_title = "Status"
+
+    def load_sample(self) -> None:
+        messages = [
+            ("blue", "PLANNING [outline]: Drafting execution plan"),
+            ("magenta", "ROUND_START [tests]: Evaluating repository"),
+            ("cyan", "PROGRESS [tests]: Running pytest -q"),
+            ("green", "SUCCESS [outline]: Outline approved"),
+        ]
+        for style, message in messages:
+            self.write(f"[{style}]{message}[/{style}]")
+
+
+class PromptInput(Input):
+    is_busy = False
+
+    def __init__(self) -> None:
+        super().__init__(id="prompt", placeholder="Type a prompt and press Enter…")
+
+
+class DemoTextUI(App[None]):
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+
+    #content {
+        height: 1fr;
+        layout: horizontal;
+        padding: 1 2;
+    }
+
+    #left, #right {
+        layout: vertical;
+        width: 1fr;
+    }
+
+    #transcript {
+        height: 1fr;
+        min-height: 16;
+    }
+
+    #plan {
+        min-height: 10;
+    }
+
+    #budgets {
+        min-height: 8;
+    }
+
+    #status {
+        height: 1fr;
+        min-height: 12;
+    }
+
+    #prompt-container {
+        layout: horizontal;
+        padding: 1 2;
+    }
+
+    #prompt {
+        width: 1fr;
+    }
+    """
+
+    BINDINGS = [
+        Binding("ctrl+c", "quit", "Quit"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Container(id="content"):
+            with Vertical(id="left"):
+                yield TranscriptWidget()
+                yield PlanWidget()
+            with Vertical(id="right"):
+                yield BudgetWidget()
+                yield StatusWidget()
+        with Container(id="prompt-container"):
+            yield PromptInput()
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        transcript = self.query_one(TranscriptWidget)
+        plan = self.query_one(PlanWidget)
+        budgets = self.query_one(BudgetWidget)
+        status = self.query_one(StatusWidget)
+        prompt = self.query_one(PromptInput)
+
+        transcript.write("[bold yellow]System:[/bold yellow] Manager ready. Type /quit to exit.")
+        transcript.write("[bold cyan]You:[/bold cyan] Document the Text UI workflow.")
+        transcript.write("[bold green]Auto-Coder:[/bold green] Starting plan execution…")
+
+        plan.load_sample()
+        budgets.load_sample()
+        status.load_sample()
+
+        prompt.value = "/help"
+
+        # Allow the UI to render for a few frames before capturing a screenshot.
+        self.set_timer(0.3, self._capture_and_quit)
+
+    async def _capture_and_quit(self) -> None:
+        ASSET_PATH.parent.mkdir(parents=True, exist_ok=True)
+        self.save_screenshot(str(ASSET_PATH))
+        await self.action_quit()
+
+
+def main() -> None:
+    app = DemoTextUI()
+    app.run(headless=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Text UI section to the root README covering setup, launch, features, and fallbacks
- update the docs hub and Auto-Coder guide with Text UI highlights and embed the new screenshot
- script the Text UI demo capture and check in the generated screenshot asset

## Testing
- python scripts/demo_textui.py

------
https://chatgpt.com/codex/tasks/task_b_68eb9c980d88832f8e83b7bb22bd20b0