### PR TITLE
Update documentation for Textual UI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-### Launch the Interactive Manager
+### Quick start
 
 ```bash
-python main.py
+python main.py --config path/to/config.json --default-model anthropic/claude-3-sonnet
 ```
 
-You will enter an interactive loop; type your request and watch the manager agent coordinate the supporting agents. Use `exit` or `quit` to leave the session.
+Run the command from the repository root to launch the Textual-powered interface. The entry point honours every shared flag defined in [`cli/overrides.py`](./cli/overrides.py), so you can pass model overrides, repository indexing preferences, memory settings, and MCP options directly on the command line. Existing automation that shells into `python TUI.py` continues to work and boots the same UI when you prefer the module-level target.
 
 ## Text UI
 
 ![Auto-Coder Text UI overview](docs/assets/text-ui-demo.png)
 
-Auto-Coder ships with an optional terminal UI built on [Textual](https://textual.textualize.io/). It layers a live plan tracker and status feeds on top of the classic CLI so you can monitor each agent while a request runs.
+Auto-Coder now launches its Textual terminal interface by default. The UI layers a live plan tracker, transcript, and status feeds on top of the manager runtime so you can monitor each agent while a request runs.
 
 ### Installation Requirements
 
@@ -108,10 +108,10 @@ Auto-Coder ships with an optional terminal UI built on [Textual](https://textual
 ### Launch Command
 
 ```bash
-python TUI.py --config path/to/config.json
+python main.py --config path/to/config.json --repo-refresh-interval 120
 ```
 
-Run the command from the repository root. All CLI flags accepted by `main.py` (for example, memory overrides or MCP startup settings) are available here as well.
+`main.py` directly boots the Textual UI and accepts the full suite of shared flags (model overrides, repository indexing controls, memory settings, MCP startup options, and more). If you prefer calling the UI module explicitly, `python TUI.py` remains supported and recognises the exact same arguments.
 
 ### Feature Highlights
 
@@ -126,7 +126,7 @@ Run the command from the repository root. All CLI flags accepted by `main.py` (f
 - **Terminal quirks** – If colours look incorrect, export `TERM=xterm-256color` or switch to a terminal emulator with true-colour support.
 - **Dependency errors** – Install Textual with `pip install textual>=0.56.4 rich>=13.7` or reinstall using the full `requirements.txt` to pick up Rich and Textual dependencies.
 - **Conflicting keybindings** – Some terminals intercept `Ctrl+C`; press `Esc` followed by `/quit` to exit safely.
-- **Switch back to the classic CLI** – Run `python main.py` for the original command-line flow whenever a minimal environment is required.
+  
 
 ## Development Workflow
 

--- a/docs/autocoder/README.md
+++ b/docs/autocoder/README.md
@@ -31,7 +31,7 @@ Your future self (and teammates) will thank you for keeping this knowledge base 
 
 ![Auto-Coder Text UI](../assets/text-ui-demo.png)
 
-The Text UI layers a Rich/Textual interface on top of the Auto-Coder manager so you can observe execution plans, status feeds, and resource budgets without leaving the terminal.
+The Text UI is now the default front end for Auto-Coder. It wraps the manager runtime with a Rich/Textual layout so you can observe execution plans, status feeds, and resource budgets without leaving the terminal.
 
 ### Installation Checklist
 
@@ -42,10 +42,10 @@ The Text UI layers a Rich/Textual interface on top of the Auto-Coder manager so 
 ### Launching the Interface
 
 ```bash
-python TUI.py --config config.json
+python main.py --config config.json --allow-browsing --repo-refresh-interval 300
 ```
 
-Run the command from the repository root. All configuration flags exposed by `main.py` are mirrored, including memory routing, repository index refresh intervals, and MCP lifecycle toggles.
+Invoke the command from the repository root to launch the Textual interface. Every shared flag defined in [`cli/overrides.py`](../../cli/overrides.py)—model overrides, repository index tuning, memory configuration, and MCP lifecycle controls—works here. When you need to target the module directly (for example, custom wrappers that import `TUI.py`), `python TUI.py` remains available and accepts the same arguments.
 
 ### Feature Tour
 
@@ -60,4 +60,3 @@ Run the command from the repository root. All configuration flags exposed by `ma
 - **Terminal compatibility** – If borders look jagged or colours are muted, switch to a Nerd Font or powerline-friendly font and confirm the terminal advertises true-colour support.
 - **Dependency import errors** – Install Textual and Rich individually (`pip install textual rich`) or rerun the main requirements install.
 - **Keyboard shortcuts** – `Ctrl+C` triggers a graceful exit; `Esc` + `/cancel` cancels the active request when the manager is busy.
-- **Classic CLI fallback** – Run `python main.py` whenever you need a no-frills interface (for example, inside restricted CI shells).

--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -63,13 +63,13 @@ When instantiated, `AutoCoderCore` performs the following orchestration steps:
 
 ## Front-end integrations
 
-Existing front ends, such as [`main.py`](../../main.py) (CLI) and the planned
-[`TUI.py`](../../TUI.py), use the core runtime to obtain a manager agent while
-handling user interaction themselves. The CLI, for example, instantiates
-`AutoCoderCore`, calls `build_manager(status_callback=...)`, and then enters a
-prompt loop. Alternative surfaces—web services, batch scripts, notebooks—can
-follow the same pattern to reuse the orchestration logic without duplicating the
-setup.
+Existing front ends, such as [`main.py`](../../main.py) (Textual UI) and custom
+automation harnesses, use the core runtime to obtain a manager agent while
+handling user interaction themselves. The Textual entry point instantiates
+`AutoCoderCore`, calls `build_manager(status_callback=...)`, and feeds events
+into the UI's message loop. Alternative surfaces—web services, batch scripts,
+notebooks—can follow the same pattern to reuse the orchestration logic without
+duplicating the setup.
 
 ## Usage examples
 


### PR DESCRIPTION
## Summary
- update the Quick start instructions to reflect that `python main.py` now boots the Textual UI and mention shared flags
- refresh Text UI docs to highlight the new default entry point while keeping the module-level command as an alias
- align the runtime documentation with the Textual UI flow instead of the deprecated readline loop

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68eca5ab74f8832facd056ec828e5595