### PR TITLE
Add centralized logging configuration helper

### DIFF
--- a/TUI.py
+++ b/TUI.py
@@ -24,6 +24,7 @@ from textual.worker import Worker
 from agents.manager import ManagerAgent, ManagerResult, ManagerStatusUpdate
 from cli.overrides import apply_common_flags, build_overrides
 from core import AutoCoderCore
+from logging_config import configure_logging
 from mcp_tooling import MCPConfigurationError
 
 
@@ -517,6 +518,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def run_tui(argv: list[str] | None = None) -> int:
+    configure_logging()
+
     parser = _build_parser()
     args = parser.parse_args(argv)
     overrides = build_overrides(args)

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,167 @@
+"""Centralized logging configuration utilities for Auto-Coder entrypoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from logging.config import dictConfig
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping
+
+__all__ = ["configure_logging"]
+
+_DEFAULT_ENV_VAR = "AUTO_CODER_LOGGING_CONFIG"
+_LAST_FINGERPRINT: str | None = None
+
+
+def _normalise_mapping(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of *config* with dictionaries sorted for hashing."""
+
+    def _convert(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(key): _convert(value[key]) for key in sorted(value.keys(), key=str)}
+        if isinstance(value, (list, tuple)):
+            return [_convert(item) for item in value]
+        return value
+
+    return _convert(dict(config))  # type: ignore[return-value]
+
+
+def _fingerprint(config: Mapping[str, Any]) -> str:
+    """Return a stable fingerprint for *config* used to avoid reconfiguration."""
+
+    normalised = _normalise_mapping(config)
+    try:
+        return json.dumps(normalised, sort_keys=True, default=str)
+    except TypeError:
+        return repr(normalised)
+
+
+def _coerce_level(default: str = "INFO") -> str:
+    level = os.getenv("AUTO_CODER_LOG_LEVEL", default)
+    if not level:
+        return default
+    return str(level).upper()
+
+
+def _build_default_config() -> dict[str, Any]:
+    """Return the default logging configuration used across entrypoints."""
+
+    level = _coerce_level()
+    console_level = os.getenv("AUTO_CODER_CONSOLE_LEVEL", level)
+    file_level = os.getenv("AUTO_CODER_FILE_LEVEL", level)
+    log_file = os.getenv("AUTO_CODER_LOG_FILE")
+
+    handlers: dict[str, MutableMapping[str, Any]] = {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": str(console_level).upper(),
+            "formatter": "structured",
+            "stream": "ext://sys.stderr",
+        }
+    }
+    handler_names: list[str] = ["console"]
+
+    if log_file:
+        path = Path(log_file).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handlers["file"] = {
+            "class": "logging.FileHandler",
+            "level": str(file_level).upper(),
+            "formatter": "structured",
+            "filename": str(path),
+            "encoding": "utf-8",
+        }
+        handler_names.append("file")
+
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "structured": {
+                "format": (
+                    "{" "\"timestamp\":\"%(asctime)s\"," "\"level\":\"%(levelname)s\"," "\"name\":\"%(name)s\"," "\"message\":\"%(message)s\"}"
+                ),
+                "datefmt": "%Y-%m-%dT%H:%M:%S%z",
+            }
+        },
+        "handlers": handlers,
+        "root": {
+            "level": level,
+            "handlers": handler_names,
+        },
+    }
+
+
+def _load_config_from_path(path: Path) -> Mapping[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - configuration error
+        msg = f"Failed to parse logging configuration from {path}: {exc}"
+        raise ValueError(msg) from exc
+
+
+def _load_config_from_payload(payload: str) -> Mapping[str, Any]:
+    path = Path(payload)
+    if path.exists():
+        return _load_config_from_path(path)
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:  # pragma: no cover - configuration error
+        msg = "Logging configuration overrides must be valid JSON or file paths"
+        raise ValueError(msg) from exc
+
+
+def _resolve_configuration(
+    config: Mapping[str, Any] | None,
+    config_path: str | os.PathLike[str] | None,
+    env_var: str,
+) -> Mapping[str, Any]:
+    if config is not None:
+        return config
+    if config_path is not None:
+        return _load_config_from_payload(str(config_path))
+    env_override = os.getenv(env_var)
+    if env_override:
+        return _load_config_from_payload(env_override)
+    return _build_default_config()
+
+
+def configure_logging(
+    config: Mapping[str, Any] | None = None,
+    *,
+    config_path: str | os.PathLike[str] | None = None,
+    env_var: str = _DEFAULT_ENV_VAR,
+    force: bool = False,
+) -> None:
+    """Install the Auto-Coder logging configuration.
+
+    Parameters
+    ----------
+    config:
+        Explicit configuration mapping compatible with :func:`logging.config.dictConfig`.
+    config_path:
+        Path to a JSON file or a JSON string containing the configuration.  When
+        provided it takes precedence over ``env_var``.
+    env_var:
+        Name of the environment variable providing overrides (defaults to
+        ``AUTO_CODER_LOGGING_CONFIG``).
+    force:
+        When ``True`` the configuration is always applied, even if it matches the
+        previous invocation.
+    """
+
+    global _LAST_FINGERPRINT
+
+    resolved = _resolve_configuration(config, config_path, env_var)
+    fingerprint = _fingerprint(resolved)
+
+    if not force and _LAST_FINGERPRINT == fingerprint:
+        return
+
+    dictConfig(resolved)
+    _LAST_FINGERPRINT = fingerprint
+
+    logging.captureWarnings(True)

--- a/main.py
+++ b/main.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import sys
 
 from TUI import run_tui
+from logging_config import configure_logging
 
 
 def main(argv: list[str] | None = None) -> int:
     """Launch the Textual TUI entrypoint."""
 
+    configure_logging()
     return run_tui(argv)
 
 

--- a/scripts/demo_textui.py
+++ b/scripts/demo_textui.py
@@ -11,6 +11,8 @@ from textual.binding import Binding
 from textual.containers import Container, Vertical
 from textual.widgets import Footer, Header, Input, RichLog, Static
 
+from logging_config import configure_logging
+
 ASSET_PATH = Path(__file__).resolve().parents[1] / "docs" / "assets" / "text-ui-demo.png"
 
 
@@ -165,6 +167,8 @@ class DemoTextUI(App[None]):
 
 
 def main() -> None:
+    configure_logging()
+
     app = DemoTextUI()
     app.run(headless=True)
 

--- a/scripts/setup_memory.py
+++ b/scripts/setup_memory.py
@@ -15,6 +15,7 @@ from memory import (
     StoreConfig,
     load_memory_configuration,
 )
+from logging_config import configure_logging
 
 LOGGER = logging.getLogger("setup_memory")
 
@@ -363,6 +364,8 @@ def _iter_configs(config: StoreConfig, *, kind: str) -> Iterable[StoreConfig]:
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    configure_logging()
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", type=Path, help="Optional path to a memory config JSON override")
     parser.add_argument(

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import logging
+from logging import LogRecord
+
+import pytest
+
+from logging_config import configure_logging
+
+
+def _reset_root_logger() -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+        handler.close()
+    root.setLevel(logging.NOTSET)
+
+
+@pytest.fixture(autouse=True)
+def _reset_between_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_root_logger()
+    monkeypatch.delenv("AUTO_CODER_LOGGING_CONFIG", raising=False)
+    monkeypatch.delenv("AUTO_CODER_LOG_LEVEL", raising=False)
+    monkeypatch.delenv("AUTO_CODER_CONSOLE_LEVEL", raising=False)
+    monkeypatch.delenv("AUTO_CODER_FILE_LEVEL", raising=False)
+    monkeypatch.delenv("AUTO_CODER_LOG_FILE", raising=False)
+
+
+def test_configure_logging_installs_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTO_CODER_LOG_LEVEL", "WARNING")
+
+    configure_logging(force=True)
+
+    root = logging.getLogger()
+    assert root.level == logging.WARNING
+    assert len(root.handlers) == 1
+
+    handler = root.handlers[0]
+    assert isinstance(handler, logging.StreamHandler)
+    assert handler.level == logging.WARNING
+    formatter = handler.formatter
+    assert formatter is not None
+
+    record = LogRecord(
+        name="auto-coder.tests",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg="example",
+        args=(),
+        exc_info=None,
+    )
+    rendered = formatter.format(record)
+    assert "\"level\":\"WARNING\"" in rendered
+    assert "\"message\":\"example\"" in rendered
+
+
+def test_configure_logging_is_idempotent() -> None:
+    configure_logging(force=True)
+
+    root = logging.getLogger()
+    first_handlers = tuple(root.handlers)
+
+    configure_logging()
+
+    assert tuple(root.handlers) == first_handlers
+    for left, right in zip(root.handlers, first_handlers):
+        assert left is right
+
+
+def test_configure_logging_respects_json_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    override = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"simple": {"format": "%(message)s"}},
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "level": "ERROR",
+                "formatter": "simple",
+                "stream": "ext://sys.stdout",
+            }
+        },
+        "root": {"level": "ERROR", "handlers": ["console"]},
+    }
+    monkeypatch.setenv("AUTO_CODER_LOGGING_CONFIG", json.dumps(override))
+
+    configure_logging(force=True)
+
+    root = logging.getLogger()
+    assert root.level == logging.ERROR
+    assert len(root.handlers) == 1
+    handler = root.handlers[0]
+    assert isinstance(handler, logging.StreamHandler)
+    assert handler.level == logging.ERROR


### PR DESCRIPTION
## Summary
- add a reusable `configure_logging` helper that installs structured console/file handlers and supports JSON overrides
- initialize logging in the main TUI entrypoint and CLI scripts so they share the configured handlers
- add unit tests covering logger setup defaults, JSON overrides, and idempotent configuration

## Testing
- pytest tests/test_logging_config.py

------
https://chatgpt.com/codex/tasks/task_b_68ecab38e4dc832fb5e4b2f1dd2d65d4