### PR TITLE
Add CLI logging verbosity controls and propagate them to logging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ python main.py --config path/to/config.json --default-model anthropic/claude-3-s
 
 Run the command from the repository root to launch the Textual-powered interface. The entry point honours every shared flag defined in [`cli/overrides.py`](./cli/overrides.py), so you can pass model overrides, repository indexing preferences, memory settings, and MCP options directly on the command line. Existing automation that shells into `python TUI.py` continues to work and boots the same UI when you prefer the module-level target.
 
+### Logging controls
+
+Logging defaults to structured JSON at the `INFO` level. Use the new verbosity flags to adjust output without editing environment variables:
+
+- `--verbose` raises the root logger to `DEBUG`.
+- `--quiet` drops it to `WARNING`.
+- `--log-level LEVEL` accepts any standard logging level name (or numeric value) and takes precedence over the `AUTO_CODER_LOG_LEVEL` environment variable.
+
+Handler-specific environment overrides such as `AUTO_CODER_CONSOLE_LEVEL`, `AUTO_CODER_FILE_LEVEL`, and `AUTO_CODER_LOG_FILE` continue to work alongside the CLI flags, so you can still direct logs to files or adjust per-handler verbosity when required.
+
 ## Text UI
 
 ![Auto-Coder Text UI overview](docs/assets/text-ui-demo.png)

--- a/TUI.py
+++ b/TUI.py
@@ -518,10 +518,21 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def run_tui(argv: list[str] | None = None) -> int:
-    configure_logging()
-
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    raw_level = getattr(args, "log_level", None)
+    resolved_level: str | None
+    if isinstance(raw_level, str):
+        resolved_level = raw_level.strip() or None
+    else:
+        resolved_level = None
+
+    if resolved_level and not resolved_level.isdigit():
+        resolved_level = resolved_level.upper()
+
+    configure_logging(level=resolved_level)
+
     overrides = build_overrides(args)
 
     app = AutoCoderApp(config_path=args.config_path, overrides=overrides)

--- a/cli/overrides.py
+++ b/cli/overrides.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from typing import Any, Iterable
 
 from core import AgentToggleSettings
@@ -20,6 +21,29 @@ def _split_multi(values: Iterable[str] | None) -> list[str]:
         segments = [segment.strip() for segment in str(raw).split(",")]
         items.extend(segment for segment in segments if segment)
     return items
+
+
+def _parse_log_level(value: str) -> str:
+    """Validate and normalise a logging level supplied via the CLI."""
+
+    text = str(value).strip()
+    if not text:
+        raise argparse.ArgumentTypeError("Log level cannot be empty")
+    if text.isdigit():
+        return str(int(text))
+    try:
+        mapping = logging.getLevelNamesMapping()
+        valid = {name.upper() for name in mapping}
+    except AttributeError:  # pragma: no cover - Python < 3.11 fallback
+        valid = {
+            name.upper()
+            for name in logging._nameToLevel  # type: ignore[attr-defined]
+            if isinstance(name, str)
+        }
+    upper = text.upper()
+    if upper not in valid:
+        raise argparse.ArgumentTypeError(f"Unknown log level: {value}")
+    return upper
 
 
 def build_overrides(args: argparse.Namespace) -> dict[str, Any]:
@@ -194,4 +218,28 @@ def apply_common_flags(parser: argparse.ArgumentParser) -> None:
         help="Skip automatic MCP server startup",
     )
     parser.set_defaults(mcp_auto_start=None)
+
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        const="DEBUG",
+        help="Increase logging verbosity to DEBUG",
+    )
+    verbosity.add_argument(
+        "--quiet",
+        dest="log_level",
+        action="store_const",
+        const="WARNING",
+        help="Reduce logging verbosity to WARNING",
+    )
+    verbosity.add_argument(
+        "--log-level",
+        dest="log_level",
+        metavar="LEVEL",
+        type=_parse_log_level,
+        help="Explicit logging level (e.g. debug, info, warning)",
+    )
+    parser.set_defaults(log_level=None)
 

--- a/logging_config.py
+++ b/logging_config.py
@@ -45,10 +45,13 @@ def _coerce_level(default: str = "INFO") -> str:
     return str(level).upper()
 
 
-def _build_default_config() -> dict[str, Any]:
+def _build_default_config(level_override: str | None = None) -> dict[str, Any]:
     """Return the default logging configuration used across entrypoints."""
 
-    level = _coerce_level()
+    if level_override:
+        level = str(level_override).upper()
+    else:
+        level = _coerce_level()
     console_level = os.getenv("AUTO_CODER_CONSOLE_LEVEL", level)
     file_level = os.getenv("AUTO_CODER_FILE_LEVEL", level)
     log_file = os.getenv("AUTO_CODER_LOG_FILE")
@@ -118,6 +121,7 @@ def _resolve_configuration(
     config: Mapping[str, Any] | None,
     config_path: str | os.PathLike[str] | None,
     env_var: str,
+    level_override: str | None,
 ) -> Mapping[str, Any]:
     if config is not None:
         return config
@@ -126,7 +130,7 @@ def _resolve_configuration(
     env_override = os.getenv(env_var)
     if env_override:
         return _load_config_from_payload(env_override)
-    return _build_default_config()
+    return _build_default_config(level_override)
 
 
 def configure_logging(
@@ -135,6 +139,7 @@ def configure_logging(
     config_path: str | os.PathLike[str] | None = None,
     env_var: str = _DEFAULT_ENV_VAR,
     force: bool = False,
+    level: str | None = None,
 ) -> None:
     """Install the Auto-Coder logging configuration.
 
@@ -151,11 +156,14 @@ def configure_logging(
     force:
         When ``True`` the configuration is always applied, even if it matches the
         previous invocation.
+    level:
+        Optional logging level applied to the default configuration. Command-line
+        flags take precedence over environment defaults when supplied.
     """
 
     global _LAST_FINGERPRINT
 
-    resolved = _resolve_configuration(config, config_path, env_var)
+    resolved = _resolve_configuration(config, config_path, env_var, level)
     fingerprint = _fingerprint(resolved)
 
     if not force and _LAST_FINGERPRINT == fingerprint:

--- a/main.py
+++ b/main.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import sys
 
 from TUI import run_tui
-from logging_config import configure_logging
 
 
 def main(argv: list[str] | None = None) -> int:
     """Launch the Textual TUI entrypoint."""
 
-    configure_logging()
     return run_tui(argv)
 
 

--- a/tests/test_cli_overrides.py
+++ b/tests/test_cli_overrides.py
@@ -133,6 +133,7 @@ def test_apply_common_flags_supports_tristate_toggles(overrides_module):
     assert defaults.repo_auto_refresh is None
     assert defaults.share_memory is None
     assert defaults.mcp_auto_start is None
+    assert defaults.log_level is None
 
     assert parser.parse_args(["--allow-browsing"]).allow_browsing is True
     assert parser.parse_args(["--disable-browsing"]).allow_browsing is False
@@ -145,3 +146,16 @@ def test_apply_common_flags_supports_tristate_toggles(overrides_module):
 
     assert parser.parse_args(["--mcp-auto-start"]).mcp_auto_start is True
     assert parser.parse_args(["--no-mcp-auto-start"]).mcp_auto_start is False
+
+
+def test_apply_common_flags_handles_logging_levels(overrides_module):
+    parser = argparse.ArgumentParser(prog="auto-coder")
+    overrides_module.apply_common_flags(parser)
+
+    assert parser.parse_args(["--verbose"]).log_level == "DEBUG"
+    assert parser.parse_args(["--quiet"]).log_level == "WARNING"
+    assert parser.parse_args(["--log-level", "info"]).log_level == "INFO"
+    assert parser.parse_args(["--log-level", "10"]).log_level == "10"
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--log-level", "invalid"])

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -69,6 +69,17 @@ def test_configure_logging_is_idempotent() -> None:
         assert left is right
 
 
+def test_configure_logging_prefers_explicit_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTO_CODER_LOG_LEVEL", "ERROR")
+
+    configure_logging(force=True, level="debug")
+
+    root = logging.getLogger()
+    assert root.level == logging.DEBUG
+    handler = root.handlers[0]
+    assert handler.level == logging.DEBUG
+
+
 def test_configure_logging_respects_json_override(monkeypatch: pytest.MonkeyPatch) -> None:
     override = {
         "version": 1,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -149,6 +149,7 @@ from TUI import (  # noqa: E402  # pylint: disable=wrong-import-position
     PlanTrackerWidget,
     TranscriptWidget,
     _build_parser,
+    run_tui,
 )
 
 
@@ -325,3 +326,28 @@ def test_cli_help_output(capsys: pytest.CaptureFixture[str]) -> None:
     help_output = capsys.readouterr().out
     assert "Launch the Auto-Coder Textual UI" in help_output
     assert "--config" in help_output
+
+
+def test_run_tui_configures_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_configure_logging(*, level: str | None = None, **_: Any) -> None:
+        captured["level"] = level
+
+    class DummyApp:
+        def __init__(self, *, config_path: str | None, overrides: Mapping[str, Any]) -> None:
+            captured["config_path"] = config_path
+            captured["overrides"] = dict(overrides)
+
+        def run(self) -> int:
+            return 0
+
+    monkeypatch.setattr("TUI.configure_logging", fake_configure_logging)
+    monkeypatch.setattr("TUI.AutoCoderApp", DummyApp)
+
+    exit_code = run_tui(["--log-level", "warning"])
+
+    assert exit_code == 0
+    assert captured["level"] == "WARNING"
+    assert captured["config_path"] is None
+    assert captured["overrides"] == {}


### PR DESCRIPTION
## Summary
- add validated logging verbosity flags to the shared CLI overrides and expose the parsed level
- allow `configure_logging` to take an explicit level override and have the TUI entrypoint forward CLI choices while keeping `main.py` minimal
- document the new behaviour and extend the test suite to cover the CLI mappings, logging overrides, and TUI integration

## Testing
- pytest tests/test_cli_overrides.py tests/test_logging_config.py tests/test_tui_app.py tests/test_main_cli.py

------
https://chatgpt.com/codex/tasks/task_b_68ecb2ab81a4832f939e81805fc1bee2