### PR TITLE
Expose manager planning overrides via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,36 @@ python main.py --config path/to/config.json --repo-refresh-interval 120
 - **Tool Registration** – Attach your own toolsets with `AgentBuilder.with_tools()` or `register_default_toolset()`.
 - **Configuration** – Set environment variables referenced by `internal.RAG.WebRAG` or other modules to customise behaviour (proxies, anonymous browsing, etc.).
 
+### Customising manager planning
+
+Override the manager's planning behaviour by extending the `core.manager`
+section of your `config.json`. The example below increases plan retries, allows
+tasks to retry twice, and injects a bespoke documentation blueprint:
+
+```json
+{
+  "core": {
+    "manager": {
+      "plan_retries": 2,
+      "task_retry_limit": 2,
+      "specialist_blueprints": [
+        {
+          "name": "release-notes",
+          "kind": "documentation",
+          "agent": "documentation",
+          "keywords": ["release", "changelog"],
+          "budget": {"limit": 2, "unit": "rounds"},
+          "research": {"required": true, "audience": "docs"}
+        }
+      ]
+    }
+  }
+}
+```
+
+The override is optional—Auto-Coder keeps its default blueprint catalogue and
+single-attempt planning unless this section is provided.
+
 ### Running Tests
 
 ```bash

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -167,6 +167,7 @@ class ManagerAgent:
         plan_builder: Callable[[str], Sequence[Mapping[str, Any]]] | None = None,
         plan_retries: int = 1,
         task_retry_limit: int = 0,
+        specialist_blueprints: Sequence[Mapping[str, Any]] | None = None,
         repo_context: RepoContextAgent | None = None,
         test_critic: "TestCriticAgent" | None = None,
         research_agent: "ResearchAgent" | None = None,
@@ -193,6 +194,7 @@ class ManagerAgent:
         self._plan_builder = plan_builder or self._default_plan_builder
         self.plan_retries = max(0, plan_retries)
         self.task_retry_limit = max(0, task_retry_limit)
+        self._specialist_blueprints = self._resolve_specialist_blueprints(specialist_blueprints)
 
         self._active_plan: list[dict[str, Any]] = []
         self._budgets: dict[str, TaskBudget] = {}
@@ -794,6 +796,97 @@ class ManagerAgent:
         },
     )
 
+    @classmethod
+    def _resolve_specialist_blueprints(
+        cls, override: Sequence[Mapping[str, Any]] | None
+    ) -> tuple[Mapping[str, Any], ...]:
+        if override is None:
+            return tuple(cls._SPECIALIST_BLUEPRINTS)
+        resolved: list[Mapping[str, Any]] = []
+        for blueprint in override:
+            if not isinstance(blueprint, Mapping):
+                continue
+            resolved.append(cls._normalise_blueprint(blueprint))
+        return tuple(resolved) or tuple(cls._SPECIALIST_BLUEPRINTS)
+
+    @classmethod
+    def _normalise_blueprint(cls, blueprint: Mapping[str, Any]) -> Mapping[str, Any]:
+        payload = dict(blueprint)
+        name = str(payload.get("name") or payload.get("kind") or "task").strip()
+        kind = str(payload.get("kind") or "").strip()
+        agent = str(payload.get("agent") or kind or "session").strip()
+        if not name:
+            name = kind or "task"
+        if not agent:
+            agent = kind or "session"
+        description = str(payload.get("description") or "").strip()
+        keywords = cls._ensure_sequence(payload.get("keywords"))
+        budget = cls._normalise_blueprint_budget(payload.get("budget"))
+        research = cls._normalise_blueprint_research(payload.get("research"))
+        metadata = payload.get("metadata")
+        if isinstance(metadata, Mapping):
+            metadata_payload = dict(metadata)
+        else:
+            metadata_payload = None
+
+        normalised = dict(payload)
+        normalised.update({"name": name, "kind": kind, "agent": agent})
+        normalised["description"] = description
+        if keywords is not None:
+            normalised["keywords"] = keywords
+        if budget:
+            normalised["budget"] = budget
+        elif "budget" in normalised:
+            normalised["budget"] = {}
+        if research:
+            normalised["research"] = research
+        elif "research" in normalised:
+            normalised["research"] = {}
+        if metadata_payload is not None:
+            normalised["metadata"] = metadata_payload
+        elif "metadata" in normalised:
+            normalised.pop("metadata", None)
+        return normalised
+
+    @staticmethod
+    def _normalise_blueprint_budget(payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, Mapping):
+            return {}
+        budget: dict[str, Any] = {}
+        if "limit" in payload:
+            try:
+                limit_value = float(payload["limit"])
+            except (TypeError, ValueError):
+                limit_value = None
+            if limit_value is not None:
+                budget["limit"] = limit_value
+        if "unit" in payload and payload["unit"] is not None:
+            unit_value = str(payload["unit"]).strip()
+            if unit_value:
+                budget["unit"] = unit_value
+        return budget
+
+    @staticmethod
+    def _normalise_blueprint_research(payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, Mapping):
+            return {}
+        research: dict[str, Any] = {}
+        if "required" in payload:
+            required_flag = payload.get("required")
+            if isinstance(required_flag, bool):
+                research["required"] = required_flag
+            else:
+                text = str(required_flag).strip().lower()
+                if text in {"1", "true", "yes", "on"}:
+                    research["required"] = True
+                elif text in {"0", "false", "no", "off"}:
+                    research["required"] = False
+        if "audience" in payload and payload["audience"] is not None:
+            audience_value = str(payload["audience"]).strip()
+            if audience_value:
+                research["audience"] = audience_value
+        return research
+
     def _default_plan_builder(
         self,
         user_message: str,
@@ -814,7 +907,7 @@ class ManagerAgent:
                     return True
             return bool(requested)
 
-        for blueprint in self._SPECIALIST_BLUEPRINTS:
+        for blueprint in self._specialist_blueprints:
             if _matches(blueprint):
                 tasks.append(self._build_task_from_blueprint(blueprint, user_message))
 
@@ -841,20 +934,47 @@ class ManagerAgent:
         user_message: str,
     ) -> dict[str, Any]:
         name = str(blueprint.get("name") or blueprint.get("kind") or "task")
+        kind_value = str(blueprint.get("kind") or "").strip()
+        agent_value = str(blueprint.get("agent") or kind_value or "session").strip()
         budget_payload = dict(blueprint.get("budget", {}))
+        if "limit" in budget_payload:
+            try:
+                budget_payload["limit"] = float(budget_payload["limit"])
+            except (TypeError, ValueError):
+                budget_payload.pop("limit", None)
+        if "unit" in budget_payload and budget_payload["unit"] is not None:
+            budget_payload["unit"] = str(budget_payload["unit"]).strip()
+            if not budget_payload["unit"]:
+                budget_payload.pop("unit", None)
         research_payload = dict(blueprint.get("research", {}))
-        metadata_payload = {
-            "kind": blueprint.get("kind"),
-            "agent": blueprint.get("agent"),
-            "research": dict(research_payload) if research_payload else None,
-        }
-        if metadata_payload.get("research") is None:
-            metadata_payload.pop("research", None)
+        if "required" in research_payload:
+            flag = research_payload["required"]
+            if isinstance(flag, bool):
+                research_payload["required"] = flag
+            else:
+                text = str(flag).strip().lower()
+                if text in {"1", "true", "yes", "on"}:
+                    research_payload["required"] = True
+                elif text in {"0", "false", "no", "off"}:
+                    research_payload["required"] = False
+                else:
+                    research_payload.pop("required", None)
+        if "audience" in research_payload and research_payload["audience"] is not None:
+            research_payload["audience"] = str(research_payload["audience"]).strip()
+            if not research_payload["audience"]:
+                research_payload.pop("audience", None)
+        metadata_payload: dict[str, Any] = {}
+        if kind_value:
+            metadata_payload["kind"] = kind_value
+        if agent_value:
+            metadata_payload["agent"] = agent_value
+        if research_payload:
+            metadata_payload["research"] = dict(research_payload)
         return {
             "name": name,
             "description": blueprint.get("description", ""),
             "prompt": user_message,
-            "kind": blueprint.get("kind"),
+            "kind": kind_value or None,
             "budget": budget_payload,
             "metadata": metadata_payload,
             "research": research_payload,

--- a/core.py
+++ b/core.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import os
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Sequence
 
 from agents import AgentBuilder
 from agents.dependency import DependencyBuildAgent
@@ -116,6 +116,15 @@ class MCPSettings:
 
 
 @dataclass(slots=True)
+class ManagerSettings:
+    """Controls for the top-level manager agent."""
+
+    plan_retries: int = 1
+    task_retry_limit: int = 0
+    specialist_blueprints: tuple[Mapping[str, Any], ...] | None = None
+
+
+@dataclass(slots=True)
 class AutoCoderConfig:
     """Aggregate configuration consumed by :class:`AutoCoderCore`."""
 
@@ -125,6 +134,7 @@ class AutoCoderConfig:
     agents: AgentToggleSettings
     memory: MemorySettings
     mcp: MCPSettings
+    manager: ManagerSettings
 
 
 def _as_mapping(payload: Any | None) -> Mapping[str, Any]:
@@ -155,6 +165,18 @@ def _coerce_bool(value: Any | None) -> bool | None:
     if text in {"0", "false", "no", "off"}:
         return False
     return None
+
+
+def _coerce_int(value: Any | None, *, default: int = 0, minimum: int | None = None) -> int:
+    try:
+        if value is None:
+            raise ValueError
+        integer = int(value)
+    except (TypeError, ValueError):
+        integer = default
+    if minimum is not None and integer < minimum:
+        return minimum
+    return integer
 
 
 def _coerce_sequence(value: Any | None) -> tuple[str, ...] | None:
@@ -205,6 +227,111 @@ def _merge_sections(
     return merged
 
 
+def _normalise_blueprint_keywords(raw: Any) -> tuple[str, ...]:
+    if isinstance(raw, str):
+        return _coerce_sequence(raw) or ()
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        return _coerce_sequence(tuple(raw)) or ()
+    return ()
+
+
+def _normalise_blueprint_budget(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        return {}
+    payload: dict[str, Any] = {}
+    if "limit" in raw:
+        try:
+            limit_value = float(raw.get("limit")) if raw.get("limit") is not None else None
+        except (TypeError, ValueError):
+            limit_value = None
+        if limit_value is not None:
+            payload["limit"] = limit_value
+    if "unit" in raw and raw.get("unit") is not None:
+        unit_value = str(raw.get("unit")).strip()
+        if unit_value:
+            payload["unit"] = unit_value
+    for key in ("consumed", "remaining", "progress"):
+        if key in payload:
+            payload.pop(key, None)
+    return payload
+
+
+def _normalise_blueprint_research(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        return {}
+    payload: dict[str, Any] = {}
+    required_flag = _coerce_bool(raw.get("required"))
+    if required_flag is not None:
+        payload["required"] = required_flag
+    audience_value = raw.get("audience")
+    if audience_value is not None:
+        text = str(audience_value).strip()
+        if text:
+            payload["audience"] = text
+    return payload
+
+
+def _validate_specialist_blueprints(raw: Any) -> tuple[Mapping[str, Any], ...] | None:
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+        return None
+    validated: list[Mapping[str, Any]] = []
+    for index, blueprint in enumerate(raw):
+        if not isinstance(blueprint, Mapping):
+            LOGGER.warning("Skipping specialist blueprint %s: expected mapping, got %s", index, type(blueprint).__name__)
+            continue
+        name = str(blueprint.get("name") or blueprint.get("kind") or "").strip()
+        kind = str(blueprint.get("kind") or "").strip()
+        agent = str(blueprint.get("agent") or kind or "").strip()
+        if not name or not kind or not agent:
+            LOGGER.warning(
+                "Skipping specialist blueprint %s: missing required fields (name=%r, kind=%r, agent=%r)",
+                index,
+                blueprint.get("name"),
+                blueprint.get("kind"),
+                blueprint.get("agent"),
+            )
+            continue
+        description = str(blueprint.get("description") or "").strip()
+        keywords = _normalise_blueprint_keywords(blueprint.get("keywords"))
+        budget = _normalise_blueprint_budget(blueprint.get("budget"))
+        research = _normalise_blueprint_research(blueprint.get("research"))
+        metadata = blueprint.get("metadata")
+        if isinstance(metadata, Mapping):
+            metadata_payload = dict(metadata)
+        else:
+            metadata_payload = None
+        validated_blueprint = dict(blueprint)
+        validated_blueprint.update(
+            {
+                "name": name,
+                "kind": kind,
+                "agent": agent,
+            }
+        )
+        if description:
+            validated_blueprint["description"] = description
+        elif "description" in validated_blueprint:
+            validated_blueprint["description"] = description
+        if keywords:
+            validated_blueprint["keywords"] = keywords
+        elif "keywords" in validated_blueprint:
+            validated_blueprint["keywords"] = ()
+        if budget:
+            validated_blueprint["budget"] = budget
+        elif "budget" in validated_blueprint:
+            validated_blueprint["budget"] = {}
+        if research:
+            validated_blueprint["research"] = research
+        elif "research" in validated_blueprint:
+            validated_blueprint["research"] = {}
+        if metadata_payload is not None:
+            validated_blueprint["metadata"] = metadata_payload
+        elif "metadata" in validated_blueprint:
+            validated_blueprint.pop("metadata", None)
+        validated.append(validated_blueprint)
+    return tuple(validated) or None
+
+
 def load_core_configuration(
     config_path: Path | str | None = None,
     *,
@@ -228,6 +355,7 @@ def load_core_configuration(
     agent_config = _as_mapping(core_section.get("agents"))
     memory_config = _as_mapping(core_section.get("memory"))
     mcp_config = _as_mapping(core_section.get("mcp"))
+    manager_config = _as_mapping(core_section.get("manager"))
 
     repo_root = _coerce_path(
         _first_non_empty(
@@ -399,6 +527,15 @@ def load_core_configuration(
         auto_start=bool(auto_start_flag) if auto_start_flag is not None else False,
     )
 
+    plan_retries = _coerce_int(manager_config.get("plan_retries"), default=1, minimum=0)
+    task_retry_limit = _coerce_int(manager_config.get("task_retry_limit"), default=0, minimum=0)
+    blueprints = _validate_specialist_blueprints(manager_config.get("specialist_blueprints"))
+    manager = ManagerSettings(
+        plan_retries=plan_retries,
+        task_retry_limit=task_retry_limit,
+        specialist_blueprints=blueprints,
+    )
+
     return AutoCoderConfig(
         paths=paths,
         models=models,
@@ -406,6 +543,7 @@ def load_core_configuration(
         agents=agents,
         memory=memory,
         mcp=mcp,
+        manager=manager,
     )
 
 
@@ -674,6 +812,9 @@ class AutoCoderCore:
         manager = ManagerAgent(
             session=session,
             status_callback=status_callback,
+            plan_retries=self.config.manager.plan_retries,
+            task_retry_limit=self.config.manager.task_retry_limit,
+            specialist_blueprints=self.config.manager.specialist_blueprints,
             repo_context=repo_context,
             test_critic=test_critic,
             research_agent=research_agent,

--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -25,12 +25,47 @@ The configuration is broken down into a handful of nested sections:
 | `models` | Select default/reasoning/research models and browsing defaults. | `default_model`, `reasoning_model`, `research_model`, `allow_external_browsing` | `AUTO_CODER_MODEL`, `AUTO_CODER_REASONING_MODEL`, `AUTO_CODER_RESEARCH_MODEL`, `AUTO_CODER_ALLOW_BROWSING` |
 | `repo_context` | Control semantic indexing. | `include_exts`, `exclude_dirs`, `auto_refresh`, `refresh_interval` | `AUTO_CODER_REPO_INCLUDE_EXTS`, `AUTO_CODER_REPO_EXCLUDE_DIRS`, `AUTO_CODER_REPO_AUTO_REFRESH`, `AUTO_CODER_REPO_REFRESH_INTERVAL` |
 | `agents` | Enable/disable specialist helpers. | Flags for `repo_context`, `research`, `documentation`, `dependency`, `runner`, `db_migration`, `security`, `integrations`, `eval`, `test_critic` | `AUTO_CODER_ENABLE_<NAME>`, `AUTO_CODER_DISABLE_<NAME>` |
+| `manager` | Configure planning retries and specialist overrides. | `plan_retries`, `task_retry_limit`, `specialist_blueprints` | – |
 | `memory` | Configure vector-memory backends. | `config_path`, `default_scope`, `combined_scope`, `share_globally` | `AUTO_CODER_MEMORY_CONFIG`, `AUTO_CODER_MEMORY_DEFAULT_SCOPE`, `AUTO_CODER_MEMORY_COMBINED_SCOPE`, `AUTO_CODER_MEMORY_SHARE` |
 | `mcp` | Discover Model Context Protocol servers. | `config_path`, `servers`, `auto_start` | `AUTO_CODER_MCP_CONFIG`, `AUTO_CODER_MCP_AUTO_START` |
 
 Additional helper variables include `AUTO_CODER_CONFIG_PATH` (alternate core
 config file) and `AUTO_CODER_WORKSPACE_ROOT`/`AUTO_CODER_ARTIFACT_ROOT` when the
 workspace layout should deviate from the repository root.
+
+### Manager overrides
+
+The optional `core.manager` section controls the planning behaviour exposed by
+`AutoCoderCore.build_manager()`. Set `plan_retries` to retry plan generation in
+the DAG, `task_retry_limit` to cap how often individual tasks are retried, and
+`specialist_blueprints` to supply custom task templates that augment or replace
+the built-in specialist detection heuristics. Each blueprint is a mapping with
+`name`, `kind`, `agent`, optional `keywords`, and optional `budget`/`research`
+metadata:
+
+```json
+{
+  "core": {
+    "manager": {
+      "plan_retries": 3,
+      "task_retry_limit": 2,
+      "specialist_blueprints": [
+        {
+          "name": "release-notes",
+          "kind": "documentation",
+          "agent": "documentation",
+          "keywords": ["release", "changelog"],
+          "budget": {"limit": 2, "unit": "rounds"},
+          "research": {"required": true, "audience": "docs"}
+        }
+      ]
+    }
+  }
+}
+```
+
+When omitted, Auto-Coder falls back to the built-in blueprint catalogue and a
+single planning attempt per workflow.
 
 ## Orchestration pipeline
 

--- a/tests/test_core_runtime.py
+++ b/tests/test_core_runtime.py
@@ -260,3 +260,146 @@ def test_core_shutdown_tears_down(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     assert repo_context.stopped is True
     assert registry.shutdown_called is True
     assert get_shared_memory_facade() is not core.memory_facade
+
+
+def test_load_configuration_manager_settings(tmp_path: Path) -> None:
+    config = load_core_configuration(
+        overrides={
+            "paths": {"repo_root": str(tmp_path)},
+            "manager": {
+                "plan_retries": "3",
+                "task_retry_limit": 2,
+                "specialist_blueprints": [
+                    {
+                        "name": "custom-docs",
+                        "kind": "documentation",
+                        "agent": "docs",
+                        "keywords": "docs,readme",
+                        "budget": {"limit": "2", "unit": "rounds"},
+                        "research": {"required": "true", "audience": "writers"},
+                    }
+                ],
+            },
+        }
+    )
+
+    manager_settings = config.manager
+    assert manager_settings.plan_retries == 3
+    assert manager_settings.task_retry_limit == 2
+    assert manager_settings.specialist_blueprints is not None
+    assert len(manager_settings.specialist_blueprints) == 1
+    blueprint = manager_settings.specialist_blueprints[0]
+    assert blueprint["name"] == "custom-docs"
+    assert blueprint["agent"] == "docs"
+    assert blueprint["keywords"] == ("docs", "readme")
+    assert blueprint["budget"]["limit"] == pytest.approx(2.0)
+    assert blueprint["research"]["required"] is True
+    assert blueprint["research"]["audience"] == "writers"
+
+
+def test_core_manager_uses_configured_settings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class StubManager:
+        def __init__(
+            self,
+            *,
+            session,
+            plan_retries,
+            task_retry_limit,
+            specialist_blueprints=None,
+            repo_context=None,
+            test_critic=None,
+            research_agent=None,
+            dependency_agent=None,
+            db_migration_agent=None,
+            eval_agent=None,
+            security_agent=None,
+            doc_agent=None,
+            memory_router=None,
+            memory_facade=None,
+            mcp_registry=None,
+            status_callback=None,
+            **_: Any,
+        ) -> None:
+            captured.update(
+                {
+                    "plan_retries": plan_retries,
+                    "task_retry_limit": task_retry_limit,
+                    "specialist_blueprints": tuple(specialist_blueprints or ()),
+                    "status_callback": status_callback,
+                }
+            )
+            self.session = session
+            self.repo_context = repo_context
+            self.test_critic = test_critic
+            self.research_agent = research_agent
+            self._dependency_agent = dependency_agent
+            self._db_migration_agent = db_migration_agent
+            self.eval_agent = eval_agent
+            self._security_agent = security_agent
+            self._doc_agent = doc_agent
+            self._integrations_agent = None
+            self.memory_router = memory_router
+            self.memory_facade = memory_facade
+            self.mcp_registry = mcp_registry
+            self._attached = {
+                "research": None,
+                "repo": None,
+                "dependency": None,
+                "critic": None,
+                "eval": None,
+            }
+
+        def attach_research_agent(self, agent: Any) -> None:
+            self._attached["research"] = agent
+
+        def attach_repo_context(self, agent: Any) -> None:
+            self._attached["repo"] = agent
+
+        def attach_dependency_agent(self, agent: Any) -> None:
+            self._attached["dependency"] = agent
+
+        def attach_test_critic(self, agent: Any) -> None:
+            self._attached["critic"] = agent
+
+        def attach_eval_agent(self, agent: Any) -> None:
+            self._attached["eval"] = agent
+
+    monkeypatch.setattr("core.ManagerAgent", StubManager)
+
+    config = load_core_configuration(
+        overrides={
+            "paths": {"repo_root": str(tmp_path)},
+            "manager": {
+                "plan_retries": 4,
+                "task_retry_limit": "7",
+                "specialist_blueprints": [
+                    {
+                        "name": "regression-suite",
+                        "kind": "eval",
+                        "agent": "evaluation",
+                        "keywords": ["regression", "benchmark"],
+                        "budget": {"limit": 5, "unit": "rounds"},
+                    }
+                ],
+            },
+            "agents": {"eval": True},
+        }
+    )
+
+    core = AutoCoderCore(config=config)
+    manager = core.build_manager()
+
+    assert captured["plan_retries"] == 4
+    assert captured["task_retry_limit"] == 7
+    assert captured["specialist_blueprints"]
+    custom_blueprint = captured["specialist_blueprints"][0]
+    assert custom_blueprint["name"] == "regression-suite"
+    assert custom_blueprint["budget"]["limit"] == pytest.approx(5.0)
+    assert custom_blueprint["keywords"] == ("regression", "benchmark")
+    assert manager._attached["eval"] is core._eval_agent
+
+    core.shutdown()


### PR DESCRIPTION
## Summary
- add ManagerSettings to the core configuration loader with support for specialist blueprints
- thread manager retry and blueprint settings through AutoCoderCore into ManagerAgent
- document the new core.manager section and exercise it with dedicated tests

## Testing
- pytest tests/test_core_runtime.py

------
https://chatgpt.com/codex/tasks/task_b_68ecc37ae8a8832f9dbea8bf04aedc76