### PR TITLE
Add research configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,37 @@ python main.py --config path/to/config.json --repo-refresh-interval 120
 
 - **Repository Context** – Populate the `agents/repo_context.py` helpers with up-to-date repository information for best results.
 - **Tool Registration** – Attach your own toolsets with `AgentBuilder.with_tools()` or `register_default_toolset()`.
-- **Configuration** – Set environment variables referenced by `internal.RAG.WebRAG` or other modules to customise behaviour (proxies, anonymous browsing, etc.).
+- **Configuration** – Use the `core.research` section in `config.json` or the `AUTO_CODER_RESEARCH_*` environment variables to adjust WebRAG proxies, caching, and anonymous browsing defaults.
+
+### Customising research and browsing
+
+Override the defaults for the built-in research agent by extending the
+`core.research` section of your `config.json`. Cache-related knobs control how
+many queries and snippets remain in memory, while the nested `web` mapping is
+forwarded directly to the underlying web retriever:
+
+```json
+{
+  "core": {
+    "research": {
+      "cache_size": 16,
+      "cache_top_k": 12,
+      "max_quote_chars": 480,
+      "web": {
+        "proxy": "http://127.0.0.1:8080",
+        "user_agent_pool": ["Mozilla/5.0", "Brave/1.64"],
+        "incognito_contexts": true,
+        "anonymous_browsing": false
+      }
+    }
+  }
+}
+```
+
+Environment variables such as `AUTO_CODER_RESEARCH_USER_AGENT_POOL` (comma
+separated) or `AUTO_CODER_RESEARCH_PROXY` provide quick overrides without
+editing the file. If `anonymous_browsing` is omitted, Auto-Coder assumes the
+inverse of `core.models.allow_external_browsing`, matching previous releases.
 
 ### Customising manager planning
 

--- a/core.py
+++ b/core.py
@@ -71,6 +71,16 @@ class ModelSettings:
 
 
 @dataclass(slots=True)
+class ResearchSettings:
+    """Options controlling the behaviour of the :class:`ResearchAgent`."""
+
+    cache_size: int = 8
+    cache_top_k: int = 8
+    max_quote_chars: int = 320
+    web: Mapping[str, Any] | None = None
+
+
+@dataclass(slots=True)
 class RepoContextSettings:
     """Filters applied when building the repository semantic index."""
 
@@ -130,6 +140,7 @@ class AutoCoderConfig:
 
     paths: PathSettings
     models: ModelSettings
+    research: ResearchSettings
     repo_context: RepoContextSettings
     agents: AgentToggleSettings
     memory: MemorySettings
@@ -351,6 +362,7 @@ def load_core_configuration(
 
     paths_config = _as_mapping(core_section.get("paths"))
     models_config = _as_mapping(core_section.get("models"))
+    research_config = _as_mapping(core_section.get("research"))
     repo_config = _as_mapping(core_section.get("repo_context"))
     agent_config = _as_mapping(core_section.get("agents"))
     memory_config = _as_mapping(core_section.get("memory"))
@@ -387,6 +399,8 @@ def load_core_configuration(
         artifact_root=artifact_root,
     )
 
+    research_override = _as_mapping(override_section.get("research"))
+
     default_model = _first_non_empty(
         override_section.get("default_model"),
         env_map.get("AUTO_CODER_MODEL"),
@@ -413,6 +427,84 @@ def load_core_configuration(
         reasoning_model=str(reasoning_model) if reasoning_model is not None else None,
         research_model=str(research_model) if research_model is not None else None,
         allow_external_browsing=bool(allow_browsing_flag) if allow_browsing_flag is not None else False,
+    )
+
+    cache_size = _coerce_int(
+        _first_non_empty(
+            research_override.get("cache_size"),
+            env_map.get("AUTO_CODER_RESEARCH_CACHE_SIZE"),
+            research_config.get("cache_size"),
+        ),
+        default=8,
+        minimum=1,
+    )
+    cache_top_k = _coerce_int(
+        _first_non_empty(
+            research_override.get("cache_top_k"),
+            env_map.get("AUTO_CODER_RESEARCH_CACHE_TOP_K"),
+            research_config.get("cache_top_k"),
+        ),
+        default=8,
+        minimum=1,
+    )
+    max_quote_chars = _coerce_int(
+        _first_non_empty(
+            research_override.get("max_quote_chars"),
+            env_map.get("AUTO_CODER_RESEARCH_MAX_QUOTE_CHARS"),
+            research_config.get("max_quote_chars"),
+        ),
+        default=320,
+        minimum=80,
+    )
+
+    web_config = _as_mapping(research_config.get("web"))
+    web_override = _as_mapping(research_override.get("web"))
+
+    proxy_candidate = _first_non_empty(
+        web_override.get("proxy"),
+        env_map.get("AUTO_CODER_RESEARCH_PROXY"),
+        web_config.get("proxy"),
+    )
+    proxy_value = str(proxy_candidate).strip() if proxy_candidate is not None else None
+    if proxy_value == "":
+        proxy_value = None
+
+    user_agents_raw = _first_non_empty(
+        web_override.get("user_agent_pool"),
+        env_map.get("AUTO_CODER_RESEARCH_USER_AGENT_POOL"),
+        web_config.get("user_agent_pool"),
+    )
+    user_agent_pool = _coerce_sequence(user_agents_raw)
+
+    incognito_raw = _first_non_empty(
+        web_override.get("incognito_contexts"),
+        env_map.get("AUTO_CODER_RESEARCH_INCOGNITO_CONTEXTS"),
+        web_config.get("incognito_contexts"),
+    )
+    incognito_flag = _coerce_bool(incognito_raw)
+
+    anonymous_raw = _first_non_empty(
+        web_override.get("anonymous_browsing"),
+        env_map.get("AUTO_CODER_RESEARCH_ANONYMOUS_BROWSING"),
+        web_config.get("anonymous_browsing"),
+    )
+    anonymous_flag = _coerce_bool(anonymous_raw)
+
+    web_settings: dict[str, Any] = {}
+    if proxy_value:
+        web_settings["proxy"] = proxy_value
+    if user_agent_pool:
+        web_settings["user_agent_pool"] = tuple(user_agent_pool)
+    if incognito_flag is not None:
+        web_settings["incognito_contexts"] = bool(incognito_flag)
+    if anonymous_flag is not None:
+        web_settings["anonymous_browsing"] = bool(anonymous_flag)
+
+    research = ResearchSettings(
+        cache_size=cache_size,
+        cache_top_k=cache_top_k,
+        max_quote_chars=max_quote_chars,
+        web=web_settings or None,
     )
 
     include_exts = _coerce_sequence(
@@ -539,6 +631,7 @@ def load_core_configuration(
     return AutoCoderConfig(
         paths=paths,
         models=models,
+        research=research,
         repo_context=repo_context,
         agents=agents,
         memory=memory,
@@ -650,8 +743,19 @@ class AutoCoderCore:
             return None
         if self._research_agent is None:
             try:
+                settings = self.config.research
+                web_kwargs = dict(settings.web or {})
+                anonymous_override = web_kwargs.pop("anonymous_browsing", None)
+                if anonymous_override is None:
+                    anonymous_flag = not self.config.models.allow_external_browsing
+                else:
+                    anonymous_flag = bool(anonymous_override)
                 self._research_agent = ResearchAgent(
-                    anonymous_browsing=not self.config.models.allow_external_browsing,
+                    cache_size=settings.cache_size,
+                    cache_top_k=settings.cache_top_k,
+                    max_quote_chars=settings.max_quote_chars,
+                    anonymous_browsing=anonymous_flag,
+                    **web_kwargs,
                 )
             except Exception:  # pragma: no cover - safeguard
                 LOGGER.warning("Failed to initialise ResearchAgent; disabling research features", exc_info=True)

--- a/docs/autocoder/agents.md
+++ b/docs/autocoder/agents.md
@@ -74,6 +74,9 @@ collaborators.
   `internal.RAG.WebRAG`.
 - Delivers `ResearchSnippet` collections grouped into `ResearchResult`
   structures for evidence gathering.
+- Cache sizing, quote lengths, and browsing defaults are configurable via the
+  `core.research` section of `config.json` or the `AUTO_CODER_RESEARCH_*`
+  environment variables documented in the runtime guide.
 
 ## Runner (`agents/runner.py`)
 

--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -23,6 +23,7 @@ The configuration is broken down into a handful of nested sections:
 | --- | --- | --- | --- |
 | `paths` | Locate the repository and scratch space. | `repo_root`, `workspace_root`, `artifact_root` | `AUTO_CODER_REPO_ROOT`, `AUTO_CODER_WORKSPACE_ROOT`, `AUTO_CODER_ARTIFACT_ROOT` |
 | `models` | Select default/reasoning/research models and browsing defaults. | `default_model`, `reasoning_model`, `research_model`, `allow_external_browsing` | `AUTO_CODER_MODEL`, `AUTO_CODER_REASONING_MODEL`, `AUTO_CODER_RESEARCH_MODEL`, `AUTO_CODER_ALLOW_BROWSING` |
+| `research` | Tune caching and WebRAG networking defaults. | `cache_size`, `cache_top_k`, `max_quote_chars`, `web.proxy`, `web.user_agent_pool`, `web.incognito_contexts`, `web.anonymous_browsing` | `AUTO_CODER_RESEARCH_CACHE_SIZE`, `AUTO_CODER_RESEARCH_CACHE_TOP_K`, `AUTO_CODER_RESEARCH_MAX_QUOTE_CHARS`, `AUTO_CODER_RESEARCH_PROXY`, `AUTO_CODER_RESEARCH_USER_AGENT_POOL`, `AUTO_CODER_RESEARCH_INCOGNITO_CONTEXTS`, `AUTO_CODER_RESEARCH_ANONYMOUS_BROWSING` |
 | `repo_context` | Control semantic indexing. | `include_exts`, `exclude_dirs`, `auto_refresh`, `refresh_interval` | `AUTO_CODER_REPO_INCLUDE_EXTS`, `AUTO_CODER_REPO_EXCLUDE_DIRS`, `AUTO_CODER_REPO_AUTO_REFRESH`, `AUTO_CODER_REPO_REFRESH_INTERVAL` |
 | `agents` | Enable/disable specialist helpers. | Flags for `repo_context`, `research`, `documentation`, `dependency`, `runner`, `db_migration`, `security`, `integrations`, `eval`, `test_critic` | `AUTO_CODER_ENABLE_<NAME>`, `AUTO_CODER_DISABLE_<NAME>` |
 | `manager` | Configure planning retries and specialist overrides. | `plan_retries`, `task_retry_limit`, `specialist_blueprints` | – |
@@ -32,6 +33,39 @@ The configuration is broken down into a handful of nested sections:
 Additional helper variables include `AUTO_CODER_CONFIG_PATH` (alternate core
 config file) and `AUTO_CODER_WORKSPACE_ROOT`/`AUTO_CODER_ARTIFACT_ROOT` when the
 workspace layout should deviate from the repository root.
+
+### Research agent tuning
+
+Research-centric workflows can be customised through the `core.research`
+section. The numeric knobs control the cache eviction policy and the length of
+quotes that `ResearchAgent` keeps when summarising search results. The nested
+`web` mapping is passed directly to [`WebRAG`](../../internal/RAG.py)
+and accepts networking controls such as proxies, user-agent pools, and
+incognito defaults. Values originating from environment variables may be
+expressed as comma-separated lists (`AUTO_CODER_RESEARCH_USER_AGENT_POOL`) or
+common boolean aliases (`true`, `false`, `yes`, `no`).
+
+```json
+{
+  "core": {
+    "research": {
+      "cache_size": 32,
+      "cache_top_k": 12,
+      "max_quote_chars": 480,
+      "web": {
+        "proxy": "socks5h://127.0.0.1:9050",
+        "user_agent_pool": ["Mozilla/5.0", "curl/8.3.0"],
+        "incognito_contexts": true,
+        "anonymous_browsing": false
+      }
+    }
+  }
+}
+```
+
+If `anonymous_browsing` is omitted, the runtime falls back to the inverse of the
+`allow_external_browsing` flag in `core.models`, preserving the previous
+behaviour.
 
 ### Manager overrides
 

--- a/tests/test_core_runtime.py
+++ b/tests/test_core_runtime.py
@@ -166,6 +166,45 @@ def stub_agents(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("core.TestCriticAgent", StubTestCriticAgent)
 
 
+def test_research_agent_uses_research_settings(tmp_path: Path) -> None:
+    env = {
+        "AUTO_CODER_REPO_ROOT": str(tmp_path),
+        "AUTO_CODER_RESEARCH_CACHE_TOP_K": "13",
+        "AUTO_CODER_RESEARCH_USER_AGENT_POOL": "env-one, env-two",
+        "AUTO_CODER_RESEARCH_INCOGNITO_CONTEXTS": "true",
+    }
+
+    config = load_core_configuration(
+        env=env,
+        overrides={
+            "paths": {"repo_root": str(tmp_path)},
+            "models": {"allow_external_browsing": True},
+            "research": {
+                "cache_size": 21,
+                "max_quote_chars": 1024,
+                "web": {
+                    "proxy": "http://proxy.local",
+                    "anonymous_browsing": True,
+                },
+            },
+        },
+    )
+
+    core = AutoCoderCore(config=config)
+    agent = core._get_research_agent()
+
+    assert isinstance(agent, StubResearchAgent)
+    assert agent.kwargs["cache_size"] == 21
+    assert agent.kwargs["cache_top_k"] == 13
+    assert agent.kwargs["max_quote_chars"] == 1024
+    assert agent.kwargs["anonymous_browsing"] is True
+    assert agent.kwargs["proxy"] == "http://proxy.local"
+    assert agent.kwargs["user_agent_pool"] == ("env-one", "env-two")
+    assert agent.kwargs["incognito_contexts"] is True
+
+    core.shutdown()
+
+
 def test_core_builds_manager_with_specialists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     replaced_specs: list[Any] = []
 


### PR DESCRIPTION
## Summary
- add a ResearchSettings dataclass and extend the core configuration loader to hydrate research-specific options
- wire the new settings into AutoCoderCore so ResearchAgent receives cache sizing and WebRAG kwargs
- document the new `core.research` keys and cover them with runtime unit tests

## Testing
- pytest tests/test_core_runtime.py

------
https://chatgpt.com/codex/tasks/task_b_68eccb048d50832f82fdc1d4d37b7b35