### PR TITLE
Add varied research agent modes and configuration support

### DIFF
--- a/agents/doc.py
+++ b/agents/doc.py
@@ -11,7 +11,7 @@ from typing import Any, Iterable, Mapping, MutableMapping, Sequence
 from internal.structures import StructuredResponse
 
 from .repo_context import DiffBundle, DiffFileStat, FileSummary, RepoContextAgent, RepoSearchResult
-from .research import ResearchAgent, ResearchResult, ResearchSnippet
+from .research import ResearchAgent, ResearchResult, ResearchSnippet, VariedResearchAgent
 
 __all__ = [
     "DocumentationSummary",
@@ -145,7 +145,7 @@ class DocAgent:
         self,
         repo_context: RepoContextAgent,
         *,
-        research_agent: ResearchAgent | None = None,
+        research_agent: ResearchAgent | VariedResearchAgent | None = None,
         artifact_dir: str | Path | None = None,
     ) -> None:
         self.repo_context = repo_context
@@ -156,7 +156,7 @@ class DocAgent:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def attach_research_agent(self, agent: ResearchAgent | None) -> None:
+    def attach_research_agent(self, agent: ResearchAgent | VariedResearchAgent | None) -> None:
         """Attach or detach the research agent used for evidence gathering."""
 
         self.research_agent = agent

--- a/agents/manager.py
+++ b/agents/manager.py
@@ -35,6 +35,7 @@ from .repo_context import (
     RepoSymbolResult,
 )
 from .security import SecurityAgent, SecurityScanResult
+from .research import VariedResearchAgent
 
 if TYPE_CHECKING:
     from mcp_tooling import MCPServerRegistry
@@ -170,7 +171,7 @@ class ManagerAgent:
         specialist_blueprints: Sequence[Mapping[str, Any]] | None = None,
         repo_context: RepoContextAgent | None = None,
         test_critic: "TestCriticAgent" | None = None,
-        research_agent: "ResearchAgent" | None = None,
+        research_agent: "ResearchAgent" | VariedResearchAgent | None = None,
         external_browsing_default: bool = False,
         dependency_agent: DependencyBuildAgent | None = None,
         db_migration_agent: DBMigrationAgent | None = None,
@@ -210,7 +211,7 @@ class ManagerAgent:
         self.test_critic: "TestCriticAgent" | None = None
         self._gate_report: "TestCriticReport" | None = None
         self._gate_blocked: bool = False
-        self.research_agent: "ResearchAgent" | None = research_agent
+        self.research_agent: "ResearchAgent" | VariedResearchAgent | None = research_agent
         self._external_browsing_default = bool(external_browsing_default)
         self._external_browsing_enabled = self._external_browsing_default
         self._shared_evidence: dict[str, list["ResearchSnippet"]] = {}
@@ -488,7 +489,7 @@ class ManagerAgent:
     # ------------------------------------------------------------------
     # Research helpers
     # ------------------------------------------------------------------
-    def attach_research_agent(self, agent: "ResearchAgent" | None) -> None:
+    def attach_research_agent(self, agent: "ResearchAgent" | VariedResearchAgent | None) -> None:
         """Attach or detach the research agent used for external browsing."""
 
         self.research_agent = agent
@@ -510,11 +511,14 @@ class ManagerAgent:
         self,
         query: str,
         *,
-        top_k: int = 5,
-        max_search_results: int = 20,
-        allow_rewrite: bool = True,
+        top_k: int | None = None,
+        max_search_results: int | None = None,
+        allow_rewrite: bool | None = None,
         audience: str | None = None,
         force_refresh: bool = False,
+        mode: str | None = None,
+        profile: str | Mapping[str, Any] | Sequence[str | Mapping[str, Any]] | None = None,
+        alpha: float | None = None,
     ) -> list[dict[str, Any]]:
         """Return structured snippets for ``query`` and cache the evidence."""
 
@@ -525,22 +529,61 @@ class ManagerAgent:
         if not self._external_browsing_enabled:
             raise RuntimeError("External browsing is disabled for this request")
 
-        try:
-            sanitized_top_k = int(top_k)
-        except (TypeError, ValueError):
-            sanitized_top_k = 5
-        if sanitized_top_k <= 0:
-            sanitized_top_k = 5
+        sanitized_top_k: int | None = None
+        if top_k is not None:
+            try:
+                sanitized_top_k = int(top_k)
+            except (TypeError, ValueError):
+                sanitized_top_k = 5
+            if sanitized_top_k <= 0:
+                sanitized_top_k = 5
+        sanitized_max_results: int | None = None
+        if max_search_results is not None:
+            try:
+                sanitized_max_results = int(max_search_results)
+            except (TypeError, ValueError):
+                sanitized_max_results = 20
+            if sanitized_max_results <= 0:
+                sanitized_max_results = 20
+        sanitized_allow_rewrite: bool | None = None
+        if allow_rewrite is not None:
+            sanitized_allow_rewrite = bool(allow_rewrite)
+        sanitized_alpha: float | None = None
+        if alpha is not None:
+            try:
+                sanitized_alpha = float(alpha)
+            except (TypeError, ValueError):
+                sanitized_alpha = None
+            else:
+                if sanitized_alpha < 0:
+                    sanitized_alpha = 0.0
+                elif sanitized_alpha > 1:
+                    sanitized_alpha = 1.0
         audience_value = None
         if audience is not None and str(audience).strip():
             audience_value = str(audience).strip()
-        result = self.research_agent.search(
+        agent = self.research_agent
+        assert agent is not None  # For type checkers; guarded above.
+        search_kwargs: dict[str, Any] = {
+            "audience": audience_value,
+            "force_refresh": force_refresh,
+        }
+        if sanitized_top_k is not None:
+            search_kwargs["top_k"] = sanitized_top_k
+        if sanitized_max_results is not None:
+            search_kwargs["max_search_results"] = sanitized_max_results
+        if sanitized_allow_rewrite is not None:
+            search_kwargs["allow_rewrite"] = sanitized_allow_rewrite
+        if sanitized_alpha is not None:
+            search_kwargs["alpha"] = sanitized_alpha
+        if isinstance(agent, VariedResearchAgent):
+            if mode is not None:
+                search_kwargs["mode"] = mode
+            if profile is not None:
+                search_kwargs["profile"] = profile
+        result = agent.search(
             query,
-            top_k=sanitized_top_k,
-            max_search_results=max_search_results,
-            allow_rewrite=allow_rewrite,
-            audience=audience_value,
-            force_refresh=force_refresh,
+            **search_kwargs,
         )
         self._record_research_evidence(audience_value, result)
         return [snippet.to_dict() for snippet in result.snippets]
@@ -777,6 +820,39 @@ class ManagerAgent:
             "research": {"required": True, "audience": "docs"},
         },
         {
+            "name": "research-discovery",
+            "kind": "research_discovery",
+            "agent": "research",
+            "description": "Explore external sources using tuned research depth modes",
+            "keywords": ("research", "discover", "investigate", "analysis", "insight"),
+            "budget": {"limit": 1.5, "unit": "rounds"},
+            "research": {
+                "required": True,
+                "mode": "balanced",
+                "profiles": (
+                    "skim",
+                    "survey",
+                    "balanced",
+                    "insight",
+                    "investigative",
+                    "deep_dive",
+                    "forensic",
+                ),
+            },
+            "metadata": {
+                "research_modes": ("light", "balanced", "deep"),
+                "research_profiles": (
+                    "skim",
+                    "survey",
+                    "balanced",
+                    "insight",
+                    "investigative",
+                    "deep_dive",
+                    "forensic",
+                ),
+            },
+        },
+        {
             "name": "ci-integration",
             "kind": "integrations",
             "agent": "integrations",
@@ -885,6 +961,24 @@ class ManagerAgent:
             audience_value = str(payload["audience"]).strip()
             if audience_value:
                 research["audience"] = audience_value
+        if "mode" in payload and payload["mode"] is not None:
+            mode_value = str(payload["mode"]).strip()
+            if mode_value:
+                research["mode"] = mode_value
+        if "profile" in payload and payload["profile"] is not None:
+            research["profile"] = payload["profile"]
+        if "profiles" in payload and payload["profiles"] is not None:
+            profiles_value = payload["profiles"]
+            if isinstance(profiles_value, (list, tuple, set)):
+                normalised = tuple(
+                    str(item).strip() for item in profiles_value if isinstance(item, (str, bytes)) and str(item).strip()
+                )
+            elif isinstance(profiles_value, str):
+                normalised = tuple(part.strip() for part in profiles_value.split(",") if part.strip())
+            else:
+                normalised = ()
+            if normalised:
+                research["profiles"] = normalised
         return research
 
     def _default_plan_builder(
@@ -970,6 +1064,9 @@ class ManagerAgent:
             metadata_payload["agent"] = agent_value
         if research_payload:
             metadata_payload["research"] = dict(research_payload)
+        extra_metadata = blueprint.get("metadata")
+        if isinstance(extra_metadata, Mapping):
+            metadata_payload.update(extra_metadata)
         return {
             "name": name,
             "description": blueprint.get("description", ""),
@@ -1110,37 +1207,78 @@ class ManagerAgent:
         research_spec = task.get("research")
         if not isinstance(research_spec, Mapping):
             research_spec = metadata.get("research") if isinstance(metadata, Mapping) else None
+
         audience_hint = None
         raw_queries: Any = None
+        mode_hint: Any | None = None
+        profile_hint: Any | None = None
+        alpha_hint: Any | None = None
+        max_results_hint: Any | None = None
+        top_k_hint: Any | None = None
+        allow_rewrite_hint: Any | None = None
+
         if isinstance(research_spec, Mapping):
             raw_queries = research_spec.get("queries")
             if raw_queries is None and research_spec.get("query") is not None:
                 raw_queries = research_spec.get("query")
             audience_hint = research_spec.get("audience")
             required_research = bool(research_spec.get("required"))
+            mode_hint = research_spec.get("mode")
+            profile_hint = research_spec.get("profile")
+            alpha_hint = research_spec.get("alpha")
+            max_results_hint = research_spec.get("max_search_results")
+            top_k_hint = research_spec.get("top_k")
+            allow_rewrite_hint = research_spec.get("allow_rewrite")
         else:
             raw_queries = task.get("research_queries")
             audience_hint = task.get("research_audience")
             required_research = False
+            mode_hint = task.get("research_mode")
+            profile_hint = task.get("research_profile")
+            alpha_hint = task.get("research_alpha")
+            max_results_hint = task.get("research_max_results")
+            top_k_hint = task.get("research_top_k")
+            allow_rewrite_hint = task.get("research_allow_rewrite")
         queries = self._coerce_queries(raw_queries)
         if required_research and not queries and prompt.strip():
             queries = [prompt.strip()]
         audience_value = str(audience_hint).strip() if audience_hint is not None else None
         if queries:
-            try:
-                top_k_raw = task.get("research_top_k", 5)
-                top_k = int(top_k_raw)
-            except (TypeError, ValueError):
-                top_k = 5
-            if top_k <= 0:
-                top_k = 5
+            top_k = None
+            if top_k_hint is not None:
+                try:
+                    top_k = int(top_k_hint)
+                except (TypeError, ValueError):
+                    top_k = None
+            elif task.get("research_top_k") is not None:
+                try:
+                    top_k = int(task.get("research_top_k"))
+                except (TypeError, ValueError):
+                    top_k = None
+            if isinstance(top_k, int) and top_k <= 0:
+                top_k = None
+            if max_results_hint is None and task.get("research_max_results") is not None:
+                max_results_hint = task.get("research_max_results")
+            if allow_rewrite_hint is None and task.get("research_allow_rewrite") is not None:
+                allow_rewrite_hint = task.get("research_allow_rewrite")
+            if mode_hint is None and task.get("research_mode") is not None:
+                mode_hint = task.get("research_mode")
+            if profile_hint is None and task.get("research_profile") is not None:
+                profile_hint = task.get("research_profile")
+            if alpha_hint is None and task.get("research_alpha") is not None:
+                alpha_hint = task.get("research_alpha")
             metadata["requested_research"] = list(queries)
             for query_text in queries:
                 try:
                     self.request_research(
                         query_text,
                         top_k=top_k,
+                        max_search_results=max_results_hint,
+                        allow_rewrite=allow_rewrite_hint,
                         audience=audience_value,
+                        mode=mode_hint,
+                        profile=profile_hint,
+                        alpha=alpha_hint,
                     )
                 except Exception as exc:
                     self._publish_status(

--- a/agents/research.py
+++ b/agents/research.py
@@ -15,6 +15,7 @@ __all__ = [
     "ResearchSnippet",
     "ResearchResult",
     "ResearchAgent",
+    "VariedResearchAgent",
 ]
 
 
@@ -195,6 +196,230 @@ class ResearchAgent:
             while len(self._cache) > self._cache_size:
                 self._cache.popitem(last=False)
         return result.limit(top_k)
+
+
+class VariedResearchAgent:
+    """Compose :class:`ResearchAgent` with profile-based search presets."""
+
+    _DEFAULT_PROFILES: Mapping[str, Mapping[str, Any]] = {
+        "skim": {"top_k": 2, "max_search_results": 6, "allow_rewrite": False, "alpha": 0.3},
+        "survey": {"top_k": 4, "max_search_results": 12, "allow_rewrite": False, "alpha": 0.45},
+        "balanced": {"top_k": 6, "max_search_results": 18, "allow_rewrite": True, "alpha": 0.55},
+        "insight": {"top_k": 8, "max_search_results": 24, "allow_rewrite": True, "alpha": 0.65},
+        "investigative": {"top_k": 10, "max_search_results": 32, "allow_rewrite": True, "alpha": 0.7},
+        "deep_dive": {"top_k": 12, "max_search_results": 40, "allow_rewrite": True, "alpha": 0.8},
+        "forensic": {"top_k": 16, "max_search_results": 60, "allow_rewrite": True, "alpha": 0.85},
+    }
+
+    _DEFAULT_MODES: Mapping[str, Mapping[str, Any]] = {
+        "light": {"profile": "survey"},
+        "balanced": {"profile": "balanced"},
+        "deep": {"profile": "deep_dive"},
+    }
+
+    def __init__(
+        self,
+        base_agent: ResearchAgent,
+        *,
+        profiles: Mapping[str, Mapping[str, Any]] | None = None,
+        mode_defaults: Mapping[str, Mapping[str, Any]] | None = None,
+        default_mode: str = "balanced",
+    ) -> None:
+        self._base_agent = base_agent
+        self._profiles = self._build_profiles(profiles)
+        self._mode_defaults = self._build_mode_defaults(mode_defaults)
+        self._default_mode = self._normalise_mode(default_mode)
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    @property
+    def base_agent(self) -> ResearchAgent:
+        return self._base_agent
+
+    @property
+    def profiles(self) -> Mapping[str, Mapping[str, Any]]:
+        return self._profiles
+
+    @property
+    def modes(self) -> Mapping[str, Mapping[str, Any]]:
+        return self._mode_defaults
+
+    def search(
+        self,
+        query: str,
+        *,
+        mode: str | None = None,
+        profile: str
+        | Mapping[str, Any]
+        | Sequence[str | Mapping[str, Any]]
+        | None = None,
+        top_k: int | None = None,
+        max_search_results: int | None = None,
+        allow_rewrite: bool | None = None,
+        alpha: float | None = None,
+        audience: str | None = None,
+        force_refresh: bool = False,
+    ) -> ResearchResult:
+        resolved_mode = self._resolve_mode(mode)
+        parameters = dict(self._mode_defaults[resolved_mode])
+
+        profile_overrides = self._resolve_profile_overrides(parameters.pop("profile", None))
+        parameters.update(profile_overrides)
+
+        if profile is not None:
+            parameters.update(self._resolve_profile_overrides(profile))
+
+        if top_k is not None:
+            parameters["top_k"] = self._coerce_positive_int(top_k, fallback=parameters.get("top_k", 5))
+        if max_search_results is not None:
+            parameters["max_search_results"] = self._coerce_positive_int(
+                max_search_results,
+                fallback=parameters.get("max_search_results", 20),
+            )
+        if allow_rewrite is not None:
+            parameters["allow_rewrite"] = bool(allow_rewrite)
+        if alpha is not None:
+            parameters["alpha"] = self._coerce_alpha(alpha, fallback=parameters.get("alpha", 0.6))
+
+        # Ensure "top_k" does not exceed "max_search_results" to avoid invalid calls.
+        max_results = parameters.get("max_search_results")
+        top_results = parameters.get("top_k")
+        if isinstance(max_results, int) and isinstance(top_results, int) and top_results > max_results:
+            parameters["top_k"] = max_results
+
+        return self._base_agent.search(
+            query,
+            top_k=int(parameters.get("top_k", 5)),
+            max_search_results=int(parameters.get("max_search_results", 20)),
+            allow_rewrite=bool(parameters.get("allow_rewrite", True)),
+            audience=audience,
+            force_refresh=force_refresh,
+            alpha=float(parameters.get("alpha", 0.6)),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _build_profiles(
+        self, overrides: Mapping[str, Mapping[str, Any]] | None
+    ) -> dict[str, Mapping[str, Any]]:
+        profiles: dict[str, Mapping[str, Any]] = {}
+        merged = dict(self._DEFAULT_PROFILES)
+        if overrides:
+            for name, payload in overrides.items():
+                if not isinstance(payload, Mapping):
+                    continue
+                merged[str(name).strip().lower()] = dict(payload)
+        for name, payload in merged.items():
+            normalised = self._normalise_parameters(payload)
+            if normalised:
+                profiles[name.lower()] = normalised
+        return profiles
+
+    def _build_mode_defaults(
+        self, overrides: Mapping[str, Mapping[str, Any]] | None
+    ) -> dict[str, Mapping[str, Any]]:
+        modes: dict[str, Mapping[str, Any]] = {}
+        merged = dict(self._DEFAULT_MODES)
+        if overrides:
+            for name, payload in overrides.items():
+                if not isinstance(payload, Mapping):
+                    continue
+                merged[str(name).strip().lower()] = dict(payload)
+        for name, payload in merged.items():
+            normalised = dict(self._normalise_parameters(payload))
+            profile_name = payload.get("profile")
+            if isinstance(profile_name, str) and profile_name.strip():
+                normalised["profile"] = profile_name.strip().lower()
+            if normalised:
+                modes[name.lower()] = normalised
+        if not modes:
+            modes["balanced"] = dict(self._normalise_parameters({"profile": "balanced"}))
+        return modes
+
+    def _normalise_mode(self, mode: str) -> str:
+        candidate = str(mode or "balanced").strip().lower()
+        if candidate in self._mode_defaults:
+            return candidate
+        return "balanced" if "balanced" in self._mode_defaults else next(iter(self._mode_defaults))
+
+    def _resolve_mode(self, mode: str | None) -> str:
+        if mode is None:
+            return self._default_mode
+        candidate = str(mode).strip().lower()
+        if candidate in self._mode_defaults:
+            return candidate
+        return self._default_mode
+
+    def _resolve_profile_overrides(
+        self,
+        profile: str | Mapping[str, Any] | Sequence[str | Mapping[str, Any]] | None,
+    ) -> dict[str, Any]:
+        if profile is None:
+            return {}
+        payloads: list[Mapping[str, Any]] = []
+        if isinstance(profile, str):
+            lookup = self._profiles.get(profile.strip().lower())
+            if lookup:
+                payloads.append(lookup)
+        elif isinstance(profile, Mapping):
+            payloads.append(profile)
+        else:
+            for item in profile:
+                if isinstance(item, str):
+                    lookup = self._profiles.get(item.strip().lower())
+                    if lookup:
+                        payloads.append(lookup)
+                elif isinstance(item, Mapping):
+                    payloads.append(item)
+        merged: dict[str, Any] = {}
+        for payload in payloads:
+            merged.update(self._normalise_parameters(payload))
+        return merged
+
+    @staticmethod
+    def _coerce_positive_int(value: Any, *, fallback: int) -> int:
+        try:
+            integer = int(value)
+        except (TypeError, ValueError):
+            return fallback
+        if integer <= 0:
+            return fallback
+        return integer
+
+    @staticmethod
+    def _coerce_alpha(value: Any, *, fallback: float) -> float:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return fallback
+        if number < 0:
+            return fallback
+        if number > 1:
+            return 1.0
+        return number
+
+    def _normalise_parameters(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if "top_k" in payload:
+            params["top_k"] = self._coerce_positive_int(payload.get("top_k"), fallback=5)
+        if "max_search_results" in payload:
+            params["max_search_results"] = self._coerce_positive_int(
+                payload.get("max_search_results"),
+                fallback=max(params.get("top_k", 5), 20),
+            )
+        if "allow_rewrite" in payload:
+            params["allow_rewrite"] = bool(payload.get("allow_rewrite"))
+        if "alpha" in payload:
+            params["alpha"] = self._coerce_alpha(payload.get("alpha"), fallback=0.6)
+        for key in ("top_k", "max_search_results"):
+            if key not in params and key in payload:
+                params[key] = payload[key]
+        for key, value in payload.items():
+            if key not in params and key != "profile":
+                params[key] = value
+        return params
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/core.py
+++ b/core.py
@@ -8,6 +8,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
+import json
 
 from agents import AgentBuilder
 from agents.dependency import DependencyBuildAgent
@@ -17,7 +18,7 @@ from agents.eval import EvalAgent
 from agents.integrations import IntegrationsAgent
 from agents.manager import ManagerAgent
 from agents.repo_context import RepoContextAgent
-from agents.research import ResearchAgent
+from agents.research import ResearchAgent, VariedResearchAgent
 from agents.runner import RunnerAgent
 from agents.security import SecurityAgent
 from agents.tester import TestCriticAgent
@@ -78,6 +79,10 @@ class ResearchSettings:
     cache_top_k: int = 8
     max_quote_chars: int = 320
     web: Mapping[str, Any] | None = None
+    enable_varied_agent: bool = False
+    default_mode: str = "balanced"
+    mode_defaults: Mapping[str, Mapping[str, Any]] | None = None
+    profiles: Mapping[str, Mapping[str, Any]] | None = None
 
 
 @dataclass(slots=True)
@@ -199,6 +204,45 @@ def _coerce_sequence(value: Any | None) -> tuple[str, ...] | None:
         parts = [segment.strip() for segment in value.split(",")]
         return tuple(part for part in parts if part) or None
     return None
+
+
+def _coerce_mapping_payload(value: Any | None, *, context: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return {str(key): val for key, val in value.items()}
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            LOGGER.warning("Failed to parse %s as mapping", context, exc_info=True)
+            return None
+        if isinstance(parsed, Mapping):
+            return {str(key): val for key, val in parsed.items()}
+        LOGGER.warning("Expected mapping for %s but received %s", context, type(parsed).__name__)
+    return None
+
+
+def _coerce_mapping_tree(value: Any | None, *, context: str) -> dict[str, Mapping[str, Any]] | None:
+    root = _coerce_mapping_payload(value, context=context)
+    if not root:
+        return None
+    normalised: dict[str, Mapping[str, Any]] = {}
+    for key, candidate in root.items():
+        name = str(key).strip().lower()
+        if not name:
+            continue
+        if isinstance(candidate, Mapping):
+            normalised[name] = dict(candidate)
+            continue
+        if isinstance(candidate, str):
+            nested = _coerce_mapping_payload(candidate, context=f"{context}.{name}")
+            if nested is not None:
+                normalised[name] = nested
+    return normalised or None
 
 
 def _first_non_empty(*candidates: Any | None) -> Any | None:
@@ -500,11 +544,49 @@ def load_core_configuration(
     if anonymous_flag is not None:
         web_settings["anonymous_browsing"] = bool(anonymous_flag)
 
+    varied_raw = _first_non_empty(
+        research_override.get("enable_varied_agent"),
+        env_map.get("AUTO_CODER_RESEARCH_ENABLE_VARIED_AGENT"),
+        research_config.get("enable_varied_agent"),
+    )
+    varied_flag = _coerce_bool(varied_raw)
+    enable_varied_agent = bool(varied_flag) if varied_flag is not None else False
+
+    default_mode_raw = _first_non_empty(
+        research_override.get("default_mode"),
+        env_map.get("AUTO_CODER_RESEARCH_DEFAULT_MODE"),
+        research_config.get("default_mode"),
+    )
+    default_mode = str(default_mode_raw).strip().lower() if default_mode_raw is not None else "balanced"
+    if not default_mode:
+        default_mode = "balanced"
+
+    mode_defaults = _coerce_mapping_tree(
+        _first_non_empty(
+            research_override.get("mode_defaults"),
+            env_map.get("AUTO_CODER_RESEARCH_MODE_DEFAULTS"),
+            research_config.get("mode_defaults"),
+        ),
+        context="research.mode_defaults",
+    )
+    profiles = _coerce_mapping_tree(
+        _first_non_empty(
+            research_override.get("profiles"),
+            env_map.get("AUTO_CODER_RESEARCH_PROFILES"),
+            research_config.get("profiles"),
+        ),
+        context="research.profiles",
+    )
+
     research = ResearchSettings(
         cache_size=cache_size,
         cache_top_k=cache_top_k,
         max_quote_chars=max_quote_chars,
         web=web_settings or None,
+        enable_varied_agent=enable_varied_agent,
+        default_mode=default_mode,
+        mode_defaults=mode_defaults,
+        profiles=profiles,
     )
 
     include_exts = _coerce_sequence(
@@ -674,7 +756,7 @@ class AutoCoderCore:
         self._setup_mcp_registry()
 
         self._repo_context_agent: RepoContextAgent | None = None
-        self._research_agent: ResearchAgent | None = None
+        self._research_agent: ResearchAgent | VariedResearchAgent | None = None
         self._doc_agent: DocAgent | None = None
         self._runner_agent: RunnerAgent | None = None
         self._dependency_agent: DependencyBuildAgent | None = None
@@ -738,7 +820,7 @@ class AutoCoderCore:
                 self._repo_context_agent = None
         return self._repo_context_agent
 
-    def _get_research_agent(self) -> ResearchAgent | None:
+    def _get_research_agent(self) -> ResearchAgent | VariedResearchAgent | None:
         if not self.config.agents.research:
             return None
         if self._research_agent is None:
@@ -750,13 +832,32 @@ class AutoCoderCore:
                     anonymous_flag = not self.config.models.allow_external_browsing
                 else:
                     anonymous_flag = bool(anonymous_override)
-                self._research_agent = ResearchAgent(
+                base_agent = ResearchAgent(
                     cache_size=settings.cache_size,
                     cache_top_k=settings.cache_top_k,
                     max_quote_chars=settings.max_quote_chars,
                     anonymous_browsing=anonymous_flag,
                     **web_kwargs,
                 )
+                if settings.enable_varied_agent:
+                    mode_defaults = (
+                        {name: dict(payload) for name, payload in settings.mode_defaults.items()}
+                        if settings.mode_defaults
+                        else None
+                    )
+                    profiles = (
+                        {name: dict(payload) for name, payload in settings.profiles.items()}
+                        if settings.profiles
+                        else None
+                    )
+                    self._research_agent = VariedResearchAgent(
+                        base_agent,
+                        mode_defaults=mode_defaults,
+                        profiles=profiles,
+                        default_mode=settings.default_mode,
+                    )
+                else:
+                    self._research_agent = base_agent
             except Exception:  # pragma: no cover - safeguard
                 LOGGER.warning("Failed to initialise ResearchAgent; disabling research features", exc_info=True)
                 self._research_agent = None

--- a/docs/autocoder/agents.md
+++ b/docs/autocoder/agents.md
@@ -77,6 +77,17 @@ collaborators.
 - Cache sizing, quote lengths, and browsing defaults are configurable via the
   `core.research` section of `config.json` or the `AUTO_CODER_RESEARCH_*`
   environment variables documented in the runtime guide.
+- The optional `VariedResearchAgent` composes the base research helper with
+  `mode` (`light`, `balanced`, `deep`) and `profile` presets spanning at least
+  five depth options (`skim`, `survey`, `balanced`, `insight`, `investigative`,
+  `deep_dive`, `forensic`). Enable it with
+  `core.research.enable_varied_agent` (or the
+  `AUTO_CODER_RESEARCH_ENABLE_VARIED_AGENT` environment variable) and adjust the
+  per-mode thresholds via the `mode_defaults` and `profiles` mappings in
+  configuration or JSON-formatted environment overrides
+  (`AUTO_CODER_RESEARCH_MODE_DEFAULTS`, `AUTO_CODER_RESEARCH_PROFILES`). The
+  runtime exposes the same combined agent to the manager and documentation
+  helpers so evidence tracking continues to function unchanged.
 
 ## Runner (`agents/runner.py`)
 

--- a/tests/test_core_runtime.py
+++ b/tests/test_core_runtime.py
@@ -98,6 +98,23 @@ class StubResearchAgent:
         self.kwargs = kwargs
 
 
+class StubVariedResearchAgent:
+    def __init__(
+        self,
+        base_agent: Any,
+        *,
+        mode_defaults: Mapping[str, Any] | None = None,
+        profiles: Mapping[str, Any] | None = None,
+        default_mode: str = "balanced",
+    ) -> None:
+        self.base_agent = base_agent
+        self.kwargs = {
+            "mode_defaults": mode_defaults,
+            "profiles": profiles,
+            "default_mode": default_mode,
+        }
+
+
 class StubRunnerAgent:
     def __init__(self, *, repo_root: str | Path | None = None, **kwargs: Any) -> None:
         self.repo_root = Path(repo_root) if repo_root else None
@@ -156,6 +173,7 @@ class StubTestCriticAgent:
 def stub_agents(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("core.RepoContextAgent", StubRepoContext)
     monkeypatch.setattr("core.ResearchAgent", StubResearchAgent)
+    monkeypatch.setattr("core.VariedResearchAgent", StubVariedResearchAgent)
     monkeypatch.setattr("core.RunnerAgent", StubRunnerAgent)
     monkeypatch.setattr("core.DependencyBuildAgent", StubDependencyAgent)
     monkeypatch.setattr("core.DocAgent", StubDocAgent)
@@ -201,6 +219,34 @@ def test_research_agent_uses_research_settings(tmp_path: Path) -> None:
     assert agent.kwargs["proxy"] == "http://proxy.local"
     assert agent.kwargs["user_agent_pool"] == ("env-one", "env-two")
     assert agent.kwargs["incognito_contexts"] is True
+
+    core.shutdown()
+
+
+def test_varied_research_agent_enabled(tmp_path: Path) -> None:
+    env = {"AUTO_CODER_REPO_ROOT": str(tmp_path)}
+
+    config = load_core_configuration(
+        env=env,
+        overrides={
+            "paths": {"repo_root": str(tmp_path)},
+            "research": {
+                "enable_varied_agent": True,
+                "default_mode": "deep",
+                "mode_defaults": {"deep": {"top_k": 15}},
+                "profiles": {"custom": {"top_k": 9, "max_search_results": 30}},
+            },
+        },
+    )
+
+    core = AutoCoderCore(config=config)
+    agent = core._get_research_agent()
+
+    assert isinstance(agent, StubVariedResearchAgent)
+    assert isinstance(agent.base_agent, StubResearchAgent)
+    assert agent.kwargs["default_mode"] == "deep"
+    assert agent.kwargs["mode_defaults"]["deep"]["top_k"] == 15
+    assert "custom" in agent.kwargs["profiles"]
 
     core.shutdown()
 

--- a/tests/test_manager_research.py
+++ b/tests/test_manager_research.py
@@ -4,8 +4,68 @@ from typing import Any, Mapping
 
 import pytest
 
+import sys
+import types
+from typing import Any, Mapping
+
+class _StubModel:
+    def respond(self, *_, **__):
+        return {"choices": [{"message": {"content": "stub"}}]}
+
+    def respond_stream(self, *_, **__):
+        yield {"choices": [{"delta": {"content": "stub"}}]}
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None) -> None:
+        self.messages: list[Mapping[str, Any]] = []
+        if system_prompt is not None:
+            self.messages.append({"role": "system", "content": system_prompt})
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":
+        instance = cls()
+        if isinstance(history, Mapping):
+            instance.messages = list(history.get("messages", []))
+        elif isinstance(history, str):
+            instance.messages = [{"role": "user", "content": history}]
+        return instance
+
+    def add_user_message(self, content: str) -> None:
+        self.messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        self.messages.append({"role": "assistant", "content": content})
+
+
+class _ToolFunctionDef:
+    def __init__(
+        self,
+        name: str,
+        description: str | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        implementation: Any = None,
+        **_: Any,
+    ) -> None:
+        self.name = name
+        self.description = description or ""
+        self.parameters = dict(parameters or {})
+        self.implementation = implementation
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *_, **__: _StubModel(),
+        Chat=_StubChat,
+        ToolFunctionDef=_ToolFunctionDef,
+    ),
+)
+
+sys.modules.setdefault("psutil", types.SimpleNamespace(Process=lambda pid=None: types.SimpleNamespace(pid=pid)))
+
 from agents.manager import ManagerAgent
-from agents.research import ResearchResult, ResearchSnippet
+from agents.research import ResearchResult, ResearchSnippet, VariedResearchAgent
 from internal.structures import StructuredResponse
 from session import AgentRound
 
@@ -66,7 +126,7 @@ class DummySession:
 
 class StubResearchAgent:
     def __init__(self) -> None:
-        self.queries: list[tuple[str, int, str | None]] = []
+        self.queries: list[dict[str, Any]] = []
         snippet = ResearchSnippet(
             url="https://example.com/doc",
             title="Example",
@@ -86,7 +146,16 @@ class StubResearchAgent:
         force_refresh: bool = False,
         alpha: float = 0.6,
     ) -> ResearchResult:
-        self.queries.append((query, top_k, audience))
+        self.queries.append(
+            {
+                "query": query,
+                "top_k": top_k,
+                "max_search_results": max_search_results,
+                "allow_rewrite": allow_rewrite,
+                "audience": audience,
+                "alpha": alpha,
+            }
+        )
         return ResearchResult(query=query, snippets=self._result.snippets)
 
 
@@ -112,7 +181,7 @@ def test_manager_routes_research_into_metadata() -> None:
 
     result = manager.run("do work", metadata={"external_browsing": True})
 
-    assert research.queries[0][0] == "python testing"
+    assert research.queries[0]["query"] == "python testing"
     assert "external_evidence" in session.last_metadata
     evidence = session.last_metadata["external_evidence"]
     assert evidence["coder"][0]["url"] == "https://example.com/doc"
@@ -130,3 +199,17 @@ def test_manager_respects_external_browsing_toggle() -> None:
     manager.run("task", metadata={"external_browsing": False})
     with pytest.raises(RuntimeError):
         manager.request_research("second")
+
+
+def test_manager_varied_modes_adjust_parameters() -> None:
+    session = DummySession()
+    base_agent = StubResearchAgent()
+    varied = VariedResearchAgent(base_agent)
+    manager = ManagerAgent(session=session, research_agent=varied, external_browsing_default=True)
+
+    manager.request_research("topic", mode="light")
+    manager.request_research("topic", mode="deep")
+
+    assert base_agent.queries[0]["top_k"] < base_agent.queries[1]["top_k"]
+    assert base_agent.queries[0]["allow_rewrite"] is False
+    assert base_agent.queries[1]["allow_rewrite"] is True

--- a/tests/test_varied_research_agent.py
+++ b/tests/test_varied_research_agent.py
@@ -1,0 +1,181 @@
+import sys
+import types
+from typing import Any, Mapping
+
+import pytest
+
+class _StubModel:
+    def respond(self, *_, **__):
+        return {"choices": [{"message": {"content": "stub"}}]}
+
+    def respond_stream(self, *_, **__):
+        yield {"choices": [{"delta": {"content": "stub"}}]}
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None) -> None:
+        self.messages: list[Mapping[str, Any]] = []
+        if system_prompt is not None:
+            self.messages.append({"role": "system", "content": system_prompt})
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":
+        instance = cls()
+        if isinstance(history, Mapping):
+            instance.messages = list(history.get("messages", []))
+        elif isinstance(history, str):
+            instance.messages = [{"role": "user", "content": history}]
+        return instance
+
+    def add_user_message(self, content: str) -> None:
+        self.messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        self.messages.append({"role": "assistant", "content": content})
+
+
+class _ToolFunctionDef:
+    def __init__(
+        self,
+        name: str,
+        description: str | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        implementation: Any = None,
+        **_: Any,
+    ) -> None:
+        self.name = name
+        self.description = description or ""
+        self.parameters = dict(parameters or {})
+        self.implementation = implementation
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *_, **__: _StubModel(),
+        Chat=_StubChat,
+        ToolFunctionDef=_ToolFunctionDef,
+    ),
+)
+
+sys.modules.setdefault("psutil", types.SimpleNamespace(Process=lambda pid=None: types.SimpleNamespace(pid=pid)))
+
+from agents.research import ResearchResult, VariedResearchAgent
+
+
+class RecordingResearchAgent:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        max_search_results: int = 20,
+        allow_rewrite: bool = True,
+        audience: str | None = None,
+        force_refresh: bool = False,
+        alpha: float = 0.6,
+    ) -> ResearchResult:
+        self.calls.append(
+            {
+                "query": query,
+                "top_k": top_k,
+                "max_search_results": max_search_results,
+                "allow_rewrite": allow_rewrite,
+                "alpha": alpha,
+                "audience": audience,
+            }
+        )
+        return ResearchResult(query=query, snippets=())
+
+
+@pytest.mark.parametrize(
+    "mode, expected",
+    [
+        ("light", {"top_k": 4, "max_search_results": 12, "allow_rewrite": False, "alpha": pytest.approx(0.45)}),
+        ("balanced", {"top_k": 6, "max_search_results": 18, "allow_rewrite": True, "alpha": pytest.approx(0.55)}),
+        ("deep", {"top_k": 12, "max_search_results": 40, "allow_rewrite": True, "alpha": pytest.approx(0.8)}),
+    ],
+)
+def test_varied_agent_modes_apply_defaults(mode: str, expected: dict[str, object]) -> None:
+    base = RecordingResearchAgent()
+    agent = VariedResearchAgent(base)
+
+    agent.search("topic", mode=mode)
+
+    call = base.calls[-1]
+    assert call["top_k"] == expected["top_k"]
+    assert call["max_search_results"] == expected["max_search_results"]
+    assert call["allow_rewrite"] is expected["allow_rewrite"]
+    assert call["alpha"] == expected["alpha"]
+
+
+def test_varied_agent_supports_custom_mode_overrides() -> None:
+    base = RecordingResearchAgent()
+    agent = VariedResearchAgent(
+        base,
+        mode_defaults={"deep": {"top_k": 20, "max_search_results": 50, "allow_rewrite": False, "alpha": 0.9}},
+    )
+
+    agent.search("topic", mode="deep")
+
+    call = base.calls[-1]
+    assert call["top_k"] == 20
+    assert call["max_search_results"] == 50
+    assert call["allow_rewrite"] is False
+    assert call["alpha"] == pytest.approx(0.9)
+
+
+def test_varied_agent_profile_chain_merges_overrides() -> None:
+    base = RecordingResearchAgent()
+    agent = VariedResearchAgent(base)
+
+    agent.search(
+        "topic",
+        mode="balanced",
+        profile=["investigative", {"max_search_results": 70, "alpha": 0.5}],
+    )
+
+    call = base.calls[-1]
+    assert call["top_k"] == 10  # investigative profile
+    assert call["max_search_results"] == 70
+    assert call["allow_rewrite"] is True
+    assert call["alpha"] == pytest.approx(0.5)
+
+
+def test_varied_agent_caps_top_k_to_max_results() -> None:
+    base = RecordingResearchAgent()
+    agent = VariedResearchAgent(base)
+
+    agent.search(
+        "topic",
+        mode="light",
+        profile={"top_k": 25, "max_search_results": 9},
+    )
+
+    call = base.calls[-1]
+    assert call["top_k"] == 9
+    assert call["max_search_results"] == 9
+
+
+def test_varied_agent_falls_back_to_default_mode() -> None:
+    base = RecordingResearchAgent()
+    agent = VariedResearchAgent(base, default_mode="deep")
+
+    agent.search("topic", mode="unknown")
+
+    call = base.calls[-1]
+    assert call["top_k"] == 12
+    assert call["max_search_results"] == 40
+    assert call["allow_rewrite"] is True
+
+
+def test_varied_agent_exposes_multiple_profiles() -> None:
+    base = RecordingResearchAgent()
+    agent = VariedResearchAgent(base)
+
+    assert len(agent.profiles) >= 5
+    for key in ("skim", "survey", "balanced", "insight", "deep_dive"):
+        assert key in agent.profiles


### PR DESCRIPTION
## Summary
- introduce a VariedResearchAgent wrapper that offers light/balanced/deep presets with extensible profiles and integrates with the manager's research-discovery blueprint
- extend runtime configuration and documentation so the varied research agent and its mode/profile defaults can be toggled via config or environment variables
- add targeted unit tests covering varied agent behaviour and manager integration

## Testing
- pytest tests/test_varied_research_agent.py tests/test_manager_research.py tests/test_core_runtime.py

------
https://chatgpt.com/codex/tasks/task_b_68ecdaf3311c832fb7877932d4e53e54