### PR TITLE
Add corpus event logging infrastructure

### DIFF
--- a/agents/manager.py
+++ b/agents/manager.py
@@ -22,6 +22,11 @@ from memory import (
     get_shared_memory_router,
     set_shared_memory_facade,
 )
+from corpus import (
+    CorpusManager,
+    get_shared_corpus_manager,
+    set_shared_corpus_manager,
+)
 
 from .dependency import DependencyBuildAgent
 from .doc import DocAgent
@@ -182,6 +187,7 @@ class ManagerAgent:
         memory_facade: MemoryFacade | None = None,
         session_id: str | None = None,
         mcp_registry: "MCPServerRegistry" | None = None,
+        corpus_manager: CorpusManager | None = None,
     ) -> None:
         if session is None:
             if session_factory is None:
@@ -256,6 +262,13 @@ class ManagerAgent:
                 agent_label="manager",
             )
             self._seed_conversation_history_from_memory()
+
+        resolved_corpus = corpus_manager or get_shared_corpus_manager()
+        if resolved_corpus is None and self.memory_facade is not None:
+            resolved_corpus = CorpusManager(self.memory_facade)
+        if resolved_corpus is not None:
+            set_shared_corpus_manager(resolved_corpus)
+        self._corpus_manager = resolved_corpus
         if test_critic is not None:
             self.attach_test_critic(test_critic)
         if eval_agent is not None:
@@ -323,6 +336,20 @@ class ManagerAgent:
             response_text = self._last_response_text
             structured_response = self._last_structured
             self._publish_status("Workflow completed", kind="success")
+
+        status = "blocked" if self._gate_blocked else "completed"
+        self._record_corpus_event(
+            "assistant_reply",
+            {
+                "status": status,
+                "response_text": response_text,
+                "structured": self._serialize_structured(structured_response),
+                "budgets": {name: budget.as_dict() for name, budget in self._budgets.items()},
+                "status_updates": [update.as_dict() for update in self._status_log],
+            },
+            source="manager.workflow",
+            tags=("manager", status),
+        )
 
         new_rounds = self.session.rounds[self._initial_round_index :]
         return ManagerResult(
@@ -507,6 +534,40 @@ class ManagerAgent:
 
         self._external_browsing_enabled = bool(enabled)
 
+    def _record_corpus_event(
+        self,
+        event_type: str,
+        payload: Mapping[str, Any],
+        *,
+        source: str,
+        tags: Sequence[str] | None = None,
+    ) -> None:
+        manager = self._corpus_manager
+        if manager is None:
+            return
+        try:
+            manager.record_event(
+                source=source,
+                payload=dict(payload),
+                event_type=event_type,
+                tags=tags,
+                session_id=self.session_id,
+                agent_id="manager",
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.debug("Failed to record corpus event '%s'", event_type, exc_info=True)
+
+    @staticmethod
+    def _serialize_structured(result: StructuredResponse | None) -> Mapping[str, Any] | None:
+        if result is None:
+            return None
+        return {
+            "content": result.content,
+            "parsed": result.parsed,
+            "structured": result.structured,
+            "schema": result.schema,
+        }
+
     def request_research(
         self,
         query: str,
@@ -586,6 +647,18 @@ class ManagerAgent:
             **search_kwargs,
         )
         self._record_research_evidence(audience_value, result)
+        self._record_corpus_event(
+            "web_search",
+            {
+                "query": query,
+                "sanitized_query": cleaned_query,
+                "audience": audience_value,
+                "parameters": search_kwargs,
+                "snippets": [snippet.to_dict() for snippet in result.snippets],
+            },
+            source="manager.research",
+            tags=("research",),
+        )
         return [snippet.to_dict() for snippet in result.snippets]
 
     def get_research_evidence(self, audience: str | None = None) -> list[dict[str, Any]]:

--- a/agents/repo_context.py
+++ b/agents/repo_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import ast
+import logging
 import os
 import re
 import subprocess
@@ -14,6 +15,7 @@ from typing import Any, Iterable, Iterator, Mapping, MutableMapping, Sequence
 
 from internal.RAG import CodebaseRAG
 from internal.tools import git as git_tools
+from corpus import CorpusManager, get_shared_corpus_manager
 
 __all__ = [
     "RepoSearchResult",
@@ -23,6 +25,9 @@ __all__ = [
     "DiffBundle",
     "RepoContextAgent",
 ]
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -141,6 +146,7 @@ class RepoContextAgent:
         exclude_dirs: Sequence[str] | None = None,
         auto_refresh: bool = True,
         refresh_interval: float = 900.0,
+        corpus_manager: CorpusManager | None = None,
     ) -> None:
         self.repo_root = os.path.abspath(repo_root)
         self._include_exts = tuple(include_exts) if include_exts is not None else None
@@ -159,6 +165,7 @@ class RepoContextAgent:
         self._last_refresh: float = 0.0
         self._last_refresh_count: int = 0
         self._last_refresh_error: Exception | None = None
+        self._corpus_manager = corpus_manager or get_shared_corpus_manager()
         # Build index synchronously for the initial snapshot
         self.refresh_index(blocking=True)
         if auto_refresh:
@@ -255,6 +262,16 @@ class RepoContextAgent:
                     provenance=provenance,
                 )
             )
+        self._record_corpus_event(
+            "repo_search",
+            {
+                "query": query,
+                "top_k": top_k,
+                "results": [result.to_dict() for result in results],
+            },
+            source="repo_context.search",
+            tags=("repo_context",),
+        )
         return results
 
     def symbol_search(self, symbol: str, *, top_k: int = 5) -> list[RepoSymbolResult]:
@@ -286,6 +303,16 @@ class RepoContextAgent:
             )
             if len(matches) >= top_k:
                 break
+        self._record_corpus_event(
+            "repo_symbol_search",
+            {
+                "symbol": symbol,
+                "top_k": top_k,
+                "results": [match.to_dict() for match in matches],
+            },
+            source="repo_context.symbol_search",
+            tags=("repo_context", "symbol"),
+        )
         return matches
 
     # ------------------------------------------------------------------
@@ -309,7 +336,7 @@ class RepoContextAgent:
             "line_count": len(lines),
             "captured": len(trimmed),
         }
-        return FileSummary(
+        summary_obj = FileSummary(
             path=self._rel_path(abs_path),
             summary=summary,
             language=language,
@@ -318,6 +345,18 @@ class RepoContextAgent:
             metadata=metadata,
             provenance=provenance,
         )
+        self._record_corpus_event(
+            "repo_summary",
+            {
+                "path": summary_obj.path,
+                "language": summary_obj.language,
+                "line_count": summary_obj.line_count,
+                "size": summary_obj.size,
+            },
+            source="repo_context.summarize_file",
+            tags=("repo_context", "summary"),
+        )
+        return summary_obj
 
     def summarize_ast(self, path: str) -> FileSummary:
         """Produce a structure-oriented summary leveraging Python's AST when applicable."""
@@ -400,7 +439,7 @@ class RepoContextAgent:
             "line_count": len(lines),
             "node_count": len(module.body),
         }
-        return FileSummary(
+        summary_obj = FileSummary(
             path=rel_path,
             summary=summary,
             language=language,
@@ -409,6 +448,17 @@ class RepoContextAgent:
             metadata=metadata,
             provenance=provenance,
         )
+        self._record_corpus_event(
+            "repo_summary",
+            {
+                "path": summary_obj.path,
+                "language": summary_obj.language,
+                "node_count": len(metadata["functions"]) + len(metadata["classes"]),
+            },
+            source="repo_context.summarize_ast",
+            tags=("repo_context", "summary", "ast"),
+        )
+        return summary_obj
 
     # ------------------------------------------------------------------
     # Git helpers
@@ -484,13 +534,25 @@ class RepoContextAgent:
             "staged": staged,
             "include_untracked": include_untracked,
         }
-        return DiffBundle(
+        bundle = DiffBundle(
             patch=patch_text,
             stats=tuple(stats),
             staged=staged,
             include_untracked=include_untracked,
             provenance=provenance,
         )
+        self._record_corpus_event(
+            "repo_diff",
+            {
+                "staged": staged,
+                "include_untracked": include_untracked,
+                "patch_length": len(bundle.patch),
+                "files": [stat.to_dict() for stat in bundle.stats],
+            },
+            source="repo_context.diff_bundle",
+            tags=("repo_context", "diff"),
+        )
+        return bundle
 
     # ------------------------------------------------------------------
     # Focus helpers for manager/agents
@@ -535,9 +597,26 @@ class RepoContextAgent:
         abs_path = self._abs_path(path)
         try:
             with open(abs_path, "r", encoding=encoding) as handle:
-                return handle.read()
+                content = handle.read()
         except FileNotFoundError:
+            self._record_corpus_event(
+                "repo_read",
+                {"path": self._rel_path(abs_path), "status": "missing"},
+                source="repo_context.read_file",
+                tags=("repo_context", "read"),
+            )
             return None
+        self._record_corpus_event(
+            "repo_read",
+            {
+                "path": self._rel_path(abs_path),
+                "status": "ok",
+                "size": len(content),
+            },
+            source="repo_context.read_file",
+            tags=("repo_context", "read"),
+        )
+        return content
 
     def update_file_if_changed(
         self,
@@ -552,14 +631,56 @@ class RepoContextAgent:
         os.makedirs(os.path.dirname(abs_path), exist_ok=True)
         current = self.read_file(path, encoding=encoding)
         if current == content:
+            self._record_corpus_event(
+                "repo_update",
+                {
+                    "path": self._rel_path(abs_path),
+                    "status": "unchanged",
+                    "size": len(content),
+                },
+                source="repo_context.update_file",
+                tags=("repo_context", "write"),
+            )
             return False
         with open(abs_path, "w", encoding=encoding) as handle:
             handle.write(content)
+        self._record_corpus_event(
+            "repo_update",
+            {
+                "path": self._rel_path(abs_path),
+                "status": "written",
+                "size": len(content),
+            },
+            source="repo_context.update_file",
+            tags=("repo_context", "write"),
+        )
         return True
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+    def _record_corpus_event(
+        self,
+        event_type: str,
+        payload: Mapping[str, Any],
+        *,
+        source: str,
+        tags: Sequence[str] | None = None,
+    ) -> None:
+        manager = self._corpus_manager
+        if manager is None:
+            return
+        try:
+            manager.record_event(
+                source=source,
+                payload=dict(payload),
+                event_type=event_type,
+                tags=tags,
+                agent_id="repo_context",
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.debug("Failed to record repo corpus event '%s'", event_type, exc_info=True)
+
     def _rel_path(self, path: str) -> str:
         return os.path.relpath(os.path.abspath(path), start=self.repo_root).replace("\\", "/")
 

--- a/agents/research.py
+++ b/agents/research.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from dataclasses import dataclass, field
+import logging
 import re
 import threading
 import urllib.parse
 from typing import Any, Callable, Mapping, MutableMapping, Sequence
 
+from corpus import CorpusManager, get_shared_corpus_manager
 from internal.RAG import WebRAG
 
 __all__ = [
@@ -17,6 +19,9 @@ __all__ = [
     "ResearchAgent",
     "VariedResearchAgent",
 ]
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
@@ -84,6 +89,7 @@ class ResearchAgent:
         cache_top_k: int = 8,
         max_quote_chars: int = 320,
         anonymous_browsing: bool | None = None,
+        corpus_manager: CorpusManager | None = None,
         **rag_kwargs: Any,
     ) -> None:
         self._rag_factory = rag_factory or WebRAG
@@ -97,10 +103,18 @@ class ResearchAgent:
         self._cache: "OrderedDict[str, ResearchResult]" = OrderedDict()
         self._lock = threading.Lock()
         self._url_cache: dict[str, MutableMapping[str, Any]] = {}
+        self._corpus_manager: CorpusManager | None = corpus_manager or get_shared_corpus_manager()
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+    @property
+    def corpus_manager(self) -> CorpusManager | None:
+        return self._corpus_manager
+
+    def attach_corpus_manager(self, manager: CorpusManager | None) -> None:
+        self._corpus_manager = manager
+
     def clear_cache(self) -> None:
         """Invalidate cached query and source lookups."""
 
@@ -195,7 +209,125 @@ class ResearchAgent:
             self._cache.move_to_end(cache_key)
             while len(self._cache) > self._cache_size:
                 self._cache.popitem(last=False)
-        return result.limit(top_k)
+        limited = result.limit(top_k)
+        self._record_corpus_event(
+            "web_search",
+            {
+                "query": query,
+                "sanitized_query": cleaned_query,
+                "top_k": top_k,
+                "max_search_results": max_search_results,
+                "snippets": [snippet.to_dict() for snippet in limited.snippets],
+            },
+        )
+        return limited
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_rag(self) -> WebRAG:
+        if self._rag is None:
+            self._rag = self._rag_factory(**self._rag_kwargs)
+        return self._rag
+
+    def _normalise_query(self, query: str) -> str:
+        return _WHITESPACE_RE.sub(" ", query.strip())
+
+    def _normalise_url(self, url: str) -> str:
+        parsed = urllib.parse.urlsplit(url)
+        path = parsed.path.rstrip("/")
+        normalised = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, ""))
+        return normalised or url
+
+    def _collect_source_metadata(
+        self,
+        rag: WebRAG,
+        query: str,
+        max_results: int,
+    ) -> dict[str, Mapping[str, str]]:
+        meta: dict[str, Mapping[str, str]] = {}
+        results: Sequence[Mapping[str, str]] = []
+        client = getattr(rag, "_playwright_client", None)
+        if client is not None and callable(getattr(client, "is_available", None)):
+            try:
+                if client.is_available():
+                    results = client.collect_search_results(query, max_results=max_results)  # type: ignore[attr-defined]
+            except Exception:
+                results = []
+        if not results:
+            try:
+                results = rag._search_ddg(query, max_results=max_results)
+            except Exception:
+                results = []
+
+        for entry in results:
+            url = str(entry.get("url") or entry.get("href") or "").strip()
+            if not url:
+                continue
+            normalised = self._normalise_url(url)
+            if normalised in meta:
+                continue
+            title = entry.get("title") or entry.get("body") or ""
+            snippet = entry.get("snippet") or entry.get("body") or ""
+            meta[normalised] = {
+                "title": self._sanitize(title, max_chars=160) or self._derive_title(url),
+                "snippet": self._sanitize(snippet, max_chars=self._max_quote_chars),
+            }
+        return meta
+
+    def _record_corpus_event(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        manager = self._corpus_manager
+        if manager is None:
+            return
+        try:
+            manager.record_event(
+                source="research.agent",
+                payload=dict(payload),
+                event_type=event_type,
+                tags=("research",),
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.debug("Failed to record research corpus event '%s'", event_type, exc_info=True)
+
+    def _resolve_source_details(
+        self,
+        url: str,
+        meta: Mapping[str, Mapping[str, str]],
+    ) -> tuple[str, str]:
+        normalised = self._normalise_url(url)
+        if normalised in meta:
+            entry = meta[normalised]
+            return entry.get("title", self._derive_title(url)), entry.get("snippet", "")
+        return self._derive_title(url), ""
+
+    def _derive_title(self, url: str) -> str:
+        parsed = urllib.parse.urlsplit(url)
+        host = parsed.netloc or parsed.path or url
+        host = host.split("@")[-1]
+        if parsed.path and parsed.path not in {"", "/"}:
+            parts = [segment for segment in parsed.path.split("/") if segment]
+            if parts:
+                return self._sanitize(parts[-1], max_chars=80)
+        return self._sanitize(host, max_chars=80)
+
+    def _build_quote(self, text: str, fallback: str) -> str:
+        primary = self._sanitize(text, max_chars=self._max_quote_chars)
+        if primary:
+            return primary
+        return self._sanitize(fallback, max_chars=self._max_quote_chars)
+
+    def _sanitize(self, text: str, *, max_chars: int) -> str:
+        cleaned = _CONTROL_RE.sub("", str(text))
+        cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
+        if not cleaned:
+            return ""
+        if len(cleaned) > max_chars:
+            truncated = cleaned[: max_chars - 1].rstrip(" ,;:\n")
+            return f"{truncated}…"
+        return cleaned
+
+    def _format_citation(self, index: int, url: str) -> str:
+        return f"[{index}]({url})"
 
 
 class VariedResearchAgent:
@@ -224,11 +356,16 @@ class VariedResearchAgent:
         profiles: Mapping[str, Mapping[str, Any]] | None = None,
         mode_defaults: Mapping[str, Mapping[str, Any]] | None = None,
         default_mode: str = "balanced",
+        corpus_manager: CorpusManager | None = None,
     ) -> None:
         self._base_agent = base_agent
         self._profiles = self._build_profiles(profiles)
         self._mode_defaults = self._build_mode_defaults(mode_defaults)
         self._default_mode = self._normalise_mode(default_mode)
+        candidate_manager = corpus_manager or getattr(base_agent, "corpus_manager", None) or get_shared_corpus_manager()
+        if hasattr(base_agent, "attach_corpus_manager"):
+            base_agent.attach_corpus_manager(candidate_manager)
+        self._corpus_manager: CorpusManager | None = candidate_manager
 
     # ------------------------------------------------------------------
     # Public helpers
@@ -244,6 +381,15 @@ class VariedResearchAgent:
     @property
     def modes(self) -> Mapping[str, Mapping[str, Any]]:
         return self._mode_defaults
+
+    @property
+    def corpus_manager(self) -> CorpusManager | None:
+        return self._corpus_manager
+
+    def attach_corpus_manager(self, manager: CorpusManager | None) -> None:
+        self._corpus_manager = manager
+        if hasattr(self._base_agent, "attach_corpus_manager"):
+            self._base_agent.attach_corpus_manager(manager)
 
     def search(
         self,
@@ -288,7 +434,7 @@ class VariedResearchAgent:
         if isinstance(max_results, int) and isinstance(top_results, int) and top_results > max_results:
             parameters["top_k"] = max_results
 
-        return self._base_agent.search(
+        result = self._base_agent.search(
             query,
             top_k=int(parameters.get("top_k", 5)),
             max_search_results=int(parameters.get("max_search_results", 20)),
@@ -297,6 +443,18 @@ class VariedResearchAgent:
             force_refresh=force_refresh,
             alpha=float(parameters.get("alpha", 0.6)),
         )
+        self._record_corpus_event(
+            "web_search",
+            {
+                "query": query,
+                "mode": resolved_mode,
+                "profile": profile,
+                "parameters": parameters,
+                "audience": audience,
+                "result": result.to_dict() if hasattr(result, "to_dict") else None,
+            },
+        )
+        return result
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -330,10 +488,10 @@ class VariedResearchAgent:
         for name, payload in merged.items():
             normalised = dict(self._normalise_parameters(payload))
             profile_name = payload.get("profile")
-            if isinstance(profile_name, str) and profile_name.strip():
-                normalised["profile"] = profile_name.strip().lower()
-            if normalised:
-                modes[name.lower()] = normalised
+        if isinstance(profile_name, str) and profile_name.strip():
+            normalised["profile"] = profile_name.strip().lower()
+        if normalised:
+            modes[name.lower()] = normalised
         if not modes:
             modes["balanced"] = dict(self._normalise_parameters({"profile": "balanced"}))
         return modes
@@ -343,6 +501,20 @@ class VariedResearchAgent:
         if candidate in self._mode_defaults:
             return candidate
         return "balanced" if "balanced" in self._mode_defaults else next(iter(self._mode_defaults))
+
+    def _record_corpus_event(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        manager = self._corpus_manager
+        if manager is None:
+            return
+        try:
+            manager.record_event(
+                source="research.varied",
+                payload=dict(payload),
+                event_type=event_type,
+                tags=("research", "varied"),
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.debug("Failed to record varied research corpus event '%s'", event_type, exc_info=True)
 
     def _resolve_mode(self, mode: str | None) -> str:
         if mode is None:
@@ -421,96 +593,4 @@ class VariedResearchAgent:
                 params[key] = value
         return params
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-    def _ensure_rag(self) -> WebRAG:
-        if self._rag is None:
-            self._rag = self._rag_factory(**self._rag_kwargs)
-        return self._rag
-
-    def _normalise_query(self, query: str) -> str:
-        return _WHITESPACE_RE.sub(" ", query.strip())
-
-    def _normalise_url(self, url: str) -> str:
-        parsed = urllib.parse.urlsplit(url)
-        path = parsed.path.rstrip("/")
-        normalised = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, ""))
-        return normalised or url
-
-    def _collect_source_metadata(
-        self,
-        rag: WebRAG,
-        query: str,
-        max_results: int,
-    ) -> dict[str, Mapping[str, str]]:
-        meta: dict[str, Mapping[str, str]] = {}
-        results: Sequence[Mapping[str, str]] = []
-        client = getattr(rag, "_playwright_client", None)
-        if client is not None and callable(getattr(client, "is_available", None)):
-            try:
-                if client.is_available():
-                    results = client.collect_search_results(query, max_results=max_results)  # type: ignore[attr-defined]
-            except Exception:
-                results = []
-        if not results:
-            try:
-                results = rag._search_ddg(query, max_results=max_results)
-            except Exception:
-                results = []
-
-        for entry in results:
-            url = str(entry.get("url") or entry.get("href") or "").strip()
-            if not url:
-                continue
-            normalised = self._normalise_url(url)
-            if normalised in meta:
-                continue
-            title = entry.get("title") or entry.get("body") or ""
-            snippet = entry.get("snippet") or entry.get("body") or ""
-            meta[normalised] = {
-                "title": self._sanitize(title, max_chars=160) or self._derive_title(url),
-                "snippet": self._sanitize(snippet, max_chars=self._max_quote_chars),
-            }
-        return meta
-
-    def _resolve_source_details(
-        self,
-        url: str,
-        meta: Mapping[str, Mapping[str, str]],
-    ) -> tuple[str, str]:
-        normalised = self._normalise_url(url)
-        if normalised in meta:
-            entry = meta[normalised]
-            return entry.get("title", self._derive_title(url)), entry.get("snippet", "")
-        return self._derive_title(url), ""
-
-    def _derive_title(self, url: str) -> str:
-        parsed = urllib.parse.urlsplit(url)
-        host = parsed.netloc or parsed.path or url
-        host = host.split("@")[-1]
-        if parsed.path and parsed.path not in {"", "/"}:
-            parts = [segment for segment in parsed.path.split("/") if segment]
-            if parts:
-                return self._sanitize(parts[-1], max_chars=80)
-        return self._sanitize(host, max_chars=80)
-
-    def _build_quote(self, text: str, fallback: str) -> str:
-        primary = self._sanitize(text, max_chars=self._max_quote_chars)
-        if primary:
-            return primary
-        return self._sanitize(fallback, max_chars=self._max_quote_chars)
-
-    def _sanitize(self, text: str, *, max_chars: int) -> str:
-        cleaned = _CONTROL_RE.sub("", str(text))
-        cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
-        if not cleaned:
-            return ""
-        if len(cleaned) > max_chars:
-            truncated = cleaned[: max_chars - 1].rstrip(" ,;:\n")
-            return f"{truncated}…"
-        return cleaned
-
-    def _format_citation(self, index: int, url: str) -> str:
-        return f"[{index}]({url})"
 

--- a/corpus/__init__.py
+++ b/corpus/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for recording interaction events into the shared corpus."""
+
+from .manager import (
+    CorpusEvent,
+    CorpusManager,
+    get_shared_corpus_manager,
+    record_event,
+    set_shared_corpus_manager,
+)
+
+__all__ = [
+    "CorpusEvent",
+    "CorpusManager",
+    "get_shared_corpus_manager",
+    "record_event",
+    "set_shared_corpus_manager",
+]

--- a/corpus/manager.py
+++ b/corpus/manager.py
@@ -1,0 +1,212 @@
+"""Structured corpus event logging backed by the shared memory facade."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+from memory import MemoryFacade, MemoryRecord, MemoryRouter
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CorpusEvent:
+    """Normalized representation of an interaction captured for the corpus."""
+
+    source: str
+    payload: Any
+    event_type: str | None = None
+    category: str | None = None
+    tags: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    session_id: str | None = None
+    agent_id: str | None = None
+
+    def enrich_tags(self, extra: Iterable[str]) -> None:
+        merged = list(self.tags)
+        merged.extend(str(tag) for tag in extra if tag)
+        self.tags = tuple(dict.fromkeys(merged))  # Preserve order without duplicates
+
+
+_DEFAULT_CATEGORY_MAP: Mapping[str, str] = {
+    "web_search": "research",
+    "web_result": "research",
+    "research_snippet": "research",
+    "repo_search": "repo_context",
+    "repo_symbol_search": "repo_context",
+    "repo_summary": "repo_context",
+    "repo_read": "repo_context",
+    "repo_update": "repo_context",
+    "file_read": "repo_context",
+    "file_write": "repo_context",
+    "file_patch": "repo_context",
+    "repo_diff": "repo_context",
+    "command_execution": "runtime",
+    "process_run": "runtime",
+    "code_generation": "assistant_output",
+    "assistant_reply": "assistant_output",
+    "tool_result": "runtime",
+    "test_execution": "qa",
+    "security_report": "security",
+}
+
+
+class CorpusManager:
+    """Persist structured event payloads into memory-backed corpus storage."""
+
+    def __init__(
+        self,
+        facade: MemoryFacade | None,
+        *,
+        scope: str | None = None,
+        category_map: Mapping[str, str] | None = None,
+        enabled: bool = True,
+    ) -> None:
+        self._facade = facade
+        self._scope = scope or MemoryRouter.LONG_TERM
+        merged = dict(_DEFAULT_CATEGORY_MAP)
+        if category_map:
+            merged.update({str(key): str(value) for key, value in category_map.items()})
+        self._category_map = merged
+        self._enabled = bool(enabled)
+        self._modifiers: list[Callable[[CorpusEvent], None]] = []
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled and self._facade is not None
+
+    def set_enabled(self, enabled: bool) -> None:
+        self._enabled = bool(enabled)
+
+    def register_modifier(self, modifier: Callable[[CorpusEvent], None]) -> None:
+        """Install a callback that can adjust events before persistence."""
+
+        if modifier not in self._modifiers:
+            self._modifiers.append(modifier)
+
+    def infer_category(self, event_type: str | None, default: str = "general") -> str:
+        if not event_type:
+            return default
+        normalized = str(event_type).strip().lower()
+        if normalized in self._category_map:
+            return self._category_map[normalized]
+        head, _, tail = normalized.partition(":")
+        if head and head in self._category_map:
+            return self._category_map[head]
+        if tail and tail in self._category_map:
+            return self._category_map[tail]
+        return default
+
+    def record_event(
+        self,
+        *,
+        source: str,
+        payload: Any,
+        event_type: str | None = None,
+        category: str | None = None,
+        tags: Sequence[str] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        session_id: str | None = None,
+        agent_id: str | None = None,
+    ) -> MemoryRecord | None:
+        """Persist an event into the configured corpus scope."""
+
+        if not self.enabled:
+            return None
+        event = CorpusEvent(
+            source=str(source),
+            payload=payload,
+            event_type=event_type,
+            category=category,
+            tags=tuple(str(tag) for tag in (tags or ())),
+            metadata=dict(metadata or {}),
+            session_id=session_id,
+            agent_id=agent_id,
+        )
+        if not event.category:
+            event.category = self.infer_category(event.event_type)
+        if event.category:
+            event.enrich_tags((event.category,))
+        event.enrich_tags((event.source,))
+        for modifier in list(self._modifiers):
+            try:
+                modifier(event)
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.debug("Corpus modifier %s raised", modifier, exc_info=True)
+
+        attributes: MutableMapping[str, Any] = {
+            "source": event.source,
+            "event_type": event.event_type,
+            "category": event.category,
+        }
+        attributes.update({str(key): value for key, value in event.metadata.items()})
+        attributes["payload"] = event.payload
+        attributes["recorded_at"] = datetime.now(timezone.utc).isoformat()
+
+        content = self._stringify_payload(event.payload)
+        try:
+            return self._facade.add(
+                content,
+                scope=self._scope,
+                tags=event.tags,
+                attributes=attributes,
+                source="corpus",
+                session_id=event.session_id,
+                agent_id=event.agent_id,
+            )
+        except Exception:
+            LOGGER.exception("Failed to persist corpus event from %s", event.source)
+            return None
+
+    @staticmethod
+    def _stringify_payload(payload: Any) -> str:
+        if isinstance(payload, str):
+            return payload
+        if isinstance(payload, (bytes, bytearray)):
+            return payload.decode("utf-8", errors="replace")
+        try:
+            return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+        except Exception:
+            return str(payload)
+
+
+_SHARED_CORPUS_MANAGER: CorpusManager | None = None
+
+
+def set_shared_corpus_manager(manager: CorpusManager | None) -> None:
+    global _SHARED_CORPUS_MANAGER
+    _SHARED_CORPUS_MANAGER = manager
+
+
+def get_shared_corpus_manager() -> CorpusManager | None:
+    return _SHARED_CORPUS_MANAGER
+
+
+def record_event(
+    source: str,
+    payload: Any,
+    *,
+    event_type: str | None = None,
+    category: str | None = None,
+    tags: Sequence[str] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    session_id: str | None = None,
+    agent_id: str | None = None,
+) -> MemoryRecord | None:
+    manager = get_shared_corpus_manager()
+    if manager is None:
+        return None
+    return manager.record_event(
+        source=source,
+        payload=payload,
+        event_type=event_type,
+        category=category,
+        tags=tags,
+        metadata=metadata,
+        session_id=session_id,
+        agent_id=agent_id,
+    )

--- a/internal/tools/file.py
+++ b/internal/tools/file.py
@@ -11,8 +11,23 @@ import base64
 import zipfile
 import tempfile
 from collections import deque
-from typing import Optional, List
+from typing import Any, Dict, Optional, List
+
 from lmstudio import ToolFunctionDef
+
+from corpus import record_event as record_corpus_event
+
+
+def _record_file_event(event_type: str, path: str, payload: Dict[str, Any]) -> None:
+    try:
+        record_corpus_event(
+            source="tool.file",
+            payload=payload,
+            event_type=event_type,
+            tags=("tool", "file"),
+        )
+    except Exception:
+        pass
 
 
 def create_file(path: str, content: str = ""):
@@ -23,8 +38,18 @@ def create_file(path: str, content: str = ""):
             os.makedirs(parent, exist_ok=True)
         with open(path, 'w', encoding='utf-8') as f:
             f.write(content)
+        _record_file_event(
+            "file_write",
+            path,
+            {"status": "created", "size": len(content)},
+        )
         return {"status": "success", "message": f"File created at {path}"}
     except Exception as e:
+        _record_file_event(
+            "file_write",
+            path,
+            {"status": "error", "message": str(e)},
+        )
         return {"status": "error", "message": str(e)}
 
 
@@ -32,8 +57,18 @@ def read_file(path: str):
     try:
         with open(path, 'r', encoding='utf-8') as f:
             content = f.read()
+        _record_file_event(
+            "file_read",
+            path,
+            {"status": "success", "size": len(content)},
+        )
         return {"status": "success", "content": content}
     except Exception as e:
+        _record_file_event(
+            "file_read",
+            path,
+            {"status": "error", "message": str(e)},
+        )
         return {"status": "error", "message": str(e)}
 
 
@@ -41,8 +76,18 @@ def write_file(path: str, content: str):
     try:
         with open(path, 'w', encoding='utf-8') as f:
             f.write(content)
+        _record_file_event(
+            "file_write",
+            path,
+            {"status": "written", "size": len(content)},
+        )
         return {"status": "success", "message": f"Content written to {path}"}
     except Exception as e:
+        _record_file_event(
+            "file_write",
+            path,
+            {"status": "error", "message": str(e)},
+        )
         return {"status": "error", "message": str(e)}
 
 
@@ -50,8 +95,18 @@ def append_to_file(path: str, content: str):
     try:
         with open(path, 'a', encoding='utf-8') as f:
             f.write(content)
+        _record_file_event(
+            "file_write",
+            path,
+            {"status": "appended", "size": len(content)},
+        )
         return {"status": "success", "message": f"Content appended to {path}"}
     except Exception as e:
+        _record_file_event(
+            "file_write",
+            path,
+            {"status": "error", "message": str(e)},
+        )
         return {"status": "error", "message": str(e)}
 
 
@@ -121,8 +176,22 @@ def patch_file(path: str, patch_type: str, **kwargs):
             f.writelines(modified_lines)
 
         diff = list(difflib.unified_diff(original_lines, modified_lines, fromfile="original", tofile="modified"))
+        _record_file_event(
+            "file_patch",
+            path,
+            {
+                "status": "success",
+                "patch_type": patch_type,
+                "lines_changed": len(diff),
+            },
+        )
         return {"status": "success", "message": f"File patched using {patch_type} method", "patch_info": patch_info, "diff": diff}
     except Exception as e:
+        _record_file_event(
+            "file_patch",
+            path,
+            {"status": "error", "patch_type": patch_type, "message": str(e)},
+        )
         return {"status": "error", "message": str(e)}
 
 

--- a/internal/tools/shell.py
+++ b/internal/tools/shell.py
@@ -1,9 +1,21 @@
 import os
+import os
 import platform
 import shutil
 import subprocess
-from typing import List, Optional, Union, Dict
+from typing import Any, Dict, List, Optional, Union
+
 from lmstudio import ToolFunctionDef
+
+from corpus import record_event as record_corpus_event
+
+
+def _truncate(value: Any, limit: int = 2048) -> Any:
+    if not isinstance(value, str):
+        return value
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3] + "..."
 
 
 def shell(
@@ -29,16 +41,48 @@ def shell(
     - `workdir`, `timeout_ms`: optional.
     - `with_escalated_permissions`: acknowledged but not supported.
     """
+    rt = (runtime or "native").lower()
+    command_repr = command if isinstance(command, str) else " ".join(map(str, command))
+
+    def _finalize(result: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            payload: Dict[str, Any] = {
+                "command": command_repr,
+                "runtime": result.get("runtime", rt),
+                "workdir": workdir,
+                "status": result.get("status"),
+                "code": result.get("code"),
+            }
+            if "stdout" in result and result.get("stdout") is not None:
+                payload["stdout"] = _truncate(result["stdout"])
+            if "stderr" in result and result.get("stderr") is not None:
+                payload["stderr"] = _truncate(result["stderr"])
+            if "output" in result and result.get("output") is not None:
+                payload["output"] = _truncate(result["output"])
+            if "message" in result and result.get("message") is not None:
+                payload["message"] = _truncate(result["message"])
+            record_corpus_event(
+                source="tool.shell",
+                payload=payload,
+                event_type="command_execution",
+                tags=("tool", "shell"),
+            )
+        except Exception:
+            pass
+        return result
+
     try:
         if with_escalated_permissions:
-            return {
-                "status": "error",
-                "message": "Escalated permissions are not supported in this environment.",
-            }
+            return _finalize(
+                {
+                    "status": "error",
+                    "message": "Escalated permissions are not supported in this environment.",
+                    "runtime": rt,
+                }
+            )
 
         sysname = platform.system()
         timeout = (timeout_ms / 1000.0) if timeout_ms else None
-        rt = (runtime or "native").lower()
 
         def run_direct(argv: List[str]):
             return subprocess.run(
@@ -75,14 +119,16 @@ def shell(
             if fail_on_stderr and result.stderr:
                 ok = False
             out = result.stdout if not combine_output else (result.stdout or "") + (result.stderr or "")
-            return {
-                "status": "success" if ok else "error",
-                "code": result.returncode,
-                "stdout": None if combine_output else result.stdout,
-                "stderr": None if combine_output else result.stderr,
-                "output": out if combine_output else None,
-                "runtime": rt,
-            }
+            return _finalize(
+                {
+                    "status": "success" if ok else "error",
+                    "code": result.returncode,
+                    "stdout": None if combine_output else result.stdout,
+                    "stderr": None if combine_output else result.stderr,
+                    "output": out if combine_output else None,
+                    "runtime": rt,
+                }
+            )
 
         # Windows-specific runtimes
         if sysname == "Windows" and rt in ("cmd", "powershell", "pwsh", "wsl"):
@@ -105,14 +151,16 @@ def shell(
             if fail_on_stderr and result.stderr:
                 ok = False
             out = result.stdout if not combine_output else (result.stdout or "") + (result.stderr or "")
-            return {
-                "status": "success" if ok else "error",
-                "code": result.returncode,
-                "stdout": None if combine_output else result.stdout,
-                "stderr": None if combine_output else result.stderr,
-                "output": out if combine_output else None,
-                "runtime": rt,
-            }
+            return _finalize(
+                {
+                    "status": "success" if ok else "error",
+                    "code": result.returncode,
+                    "stdout": None if combine_output else result.stdout,
+                    "stderr": None if combine_output else result.stderr,
+                    "output": out if combine_output else None,
+                    "runtime": rt,
+                }
+            )
 
         # POSIX shells
         if rt in ("sh", "bash"):
@@ -126,37 +174,43 @@ def shell(
             if fail_on_stderr and result.stderr:
                 ok = False
             out = result.stdout if not combine_output else (result.stdout or "") + (result.stderr or "")
-            return {
-                "status": "success" if ok else "error",
-                "code": result.returncode,
-                "stdout": None if combine_output else result.stdout,
-                "stderr": None if combine_output else result.stderr,
-                "output": out if combine_output else None,
-                "runtime": rt,
-            }
+            return _finalize(
+                {
+                    "status": "success" if ok else "error",
+                    "code": result.returncode,
+                    "stdout": None if combine_output else result.stdout,
+                    "stderr": None if combine_output else result.stderr,
+                    "output": out if combine_output else None,
+                    "runtime": rt,
+                }
+            )
 
         # Fallback: treat as native
         if isinstance(command, list):
             result = run_direct(command)
         else:
             result = run_shell_str(command)
-        return {
-            "status": "success" if result.returncode == 0 else "error",
-            "code": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-            "runtime": rt,
-        }
+        return _finalize(
+            {
+                "status": "success" if result.returncode == 0 else "error",
+                "code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "runtime": rt,
+            }
+        )
     except subprocess.TimeoutExpired as e:
-        return {
-            "status": "error",
-            "message": f"Command timed out after {timeout_ms} ms" if timeout_ms else "Command timed out",
-            "partial_stdout": e.stdout,
-            "partial_stderr": e.stderr,
-            "runtime": runtime or "native",
-        }
+        return _finalize(
+            {
+                "status": "error",
+                "message": f"Command timed out after {timeout_ms} ms" if timeout_ms else "Command timed out",
+                "partial_stdout": e.stdout,
+                "partial_stderr": e.stderr,
+                "runtime": runtime or "native",
+            }
+        )
     except Exception as e:
-        return {"status": "error", "message": str(e), "runtime": runtime or "native"}
+        return _finalize({"status": "error", "message": str(e), "runtime": runtime or "native"})
 
 
 shell_tool = ToolFunctionDef(

--- a/tests/test_corpus_logging.py
+++ b/tests/test_corpus_logging.py
@@ -1,0 +1,247 @@
+import os
+import sys
+import types
+import os
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class _StubModel:
+    def respond(self, *_, **__):
+        return {"choices": [{"message": {"content": "stub"}}]}
+
+
+class _StubChat:
+    def __init__(self, system_prompt: str | None = None) -> None:
+        self.messages: list[Mapping[str, Any]] = []
+        if system_prompt is not None:
+            self.messages.append({"role": "system", "content": system_prompt})
+
+    @classmethod
+    def from_history(cls, history: Any) -> "_StubChat":
+        instance = cls()
+        if isinstance(history, Mapping):
+            messages = history.get("messages", [])
+            if isinstance(messages, list):
+                instance.messages = list(messages)
+        elif isinstance(history, str):
+            instance.messages = [{"role": "user", "content": history}]
+        return instance
+
+    def add_user_message(self, content: str) -> None:
+        self.messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        self.messages.append({"role": "assistant", "content": content})
+
+
+class _StubToolFunctionDef:
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters: Mapping[str, Any] | None = None,
+        implementation: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.parameters = dict(parameters or {})
+        self.implementation = implementation
+        self.extra = dict(kwargs)
+
+
+sys.modules.setdefault(
+    "lmstudio",
+    types.SimpleNamespace(
+        llm=lambda *_, **__: _StubModel(),
+        Chat=_StubChat,
+        ToolFunctionDef=_StubToolFunctionDef,
+    ),
+)
+
+_psutil_stub = types.ModuleType("psutil")
+_psutil_stub.Process = lambda pid=None: types.SimpleNamespace(pid=pid or 0)
+sys.modules.setdefault("psutil", _psutil_stub)
+
+import pytest
+
+from agents.manager import ManagerAgent
+from agents.research import ResearchAgent
+from corpus import CorpusManager, set_shared_corpus_manager
+from internal.structures import StructuredResponse
+from internal.tools import file as file_tools
+from memory import InMemoryMemoryStore, MemoryFacade, MemoryQuery, MemoryRouter
+
+
+@pytest.fixture()
+def corpus_environment(tmp_path):
+    short_store = InMemoryMemoryStore()
+    long_store = InMemoryMemoryStore()
+    router = MemoryRouter(
+        {
+            MemoryRouter.SHORT_TERM: short_store,
+            MemoryRouter.LONG_TERM: long_store,
+            MemoryRouter.COMBINED: short_store,
+        }
+    )
+    facade = MemoryFacade(router, combined_scope=MemoryRouter.SHORT_TERM)
+    corpus_manager = CorpusManager(facade)
+    set_shared_corpus_manager(corpus_manager)
+    yield corpus_manager, router, facade, long_store
+    set_shared_corpus_manager(None)
+
+
+class DummyRag:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Mapping[str, Any]]] = []
+
+    def search(self, query: str, **kwargs: Any) -> list[Mapping[str, Any]]:
+        self.calls.append((query, kwargs))
+        return [
+            {
+                "path": "https://example.com/article",
+                "text": "Example body of text",
+                "score": 0.9,
+                "offset": 0,
+            }
+        ]
+
+    def _search_ddg(self, *_: Any, **__: Any) -> list[Mapping[str, Any]]:
+        return []
+
+
+def test_research_agent_logs_corpus_event(corpus_environment):
+    corpus_manager, router, facade, long_store = corpus_environment
+    agent = ResearchAgent(
+        rag_factory=lambda **_: DummyRag(),
+        cache_size=2,
+        cache_top_k=2,
+        max_quote_chars=120,
+        corpus_manager=corpus_manager,
+    )
+
+    assert hasattr(agent, "_normalise_query"), f"ResearchAgent came from {agent.__class__.__module__}"
+
+    result = agent.search("Example query", top_k=1)
+    assert result.snippets
+
+    records = router.long_term.fetch(MemoryQuery(limit=10))
+    event_records = [
+        record
+        for record in records
+        if record.metadata.attributes.get("event_type") == "web_search"
+    ]
+    assert event_records, "expected web_search event to be recorded"
+    event = event_records[-1]
+    assert event.metadata.attributes.get("category") == "research"
+    payload = event.metadata.attributes.get("payload", {})
+    assert payload.get("query") == "Example query"
+
+
+def test_file_write_logs_corpus_event(corpus_environment):
+    corpus_manager, router, facade, long_store = corpus_environment
+    target = os.path.join(os.getcwd(), "test_generated.txt")
+    try:
+        file_tools.write_file(target, "hello world")
+        records = router.long_term.fetch(MemoryQuery(limit=10))
+        file_events = [
+            record
+            for record in records
+            if record.metadata.attributes.get("event_type") == "file_write"
+        ]
+        assert file_events, "expected file_write event"
+        payload = file_events[-1].metadata.attributes.get("payload", {})
+        assert payload.get("status") == "written"
+        assert payload.get("size") == len("hello world")
+    finally:
+        if os.path.exists(target):
+            os.remove(target)
+
+
+@dataclass
+class DummyRound:
+    index: int
+    user_message: str | None
+    response_text: str
+    result: StructuredResponse
+    transcript: list[Any]
+    messages: list[Any]
+    tool_history: dict[str, list[Any]]
+    metadata: dict[str, Any] | None = None
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            "index": self.index,
+            "user_message": self.user_message,
+            "response_text": self.response_text,
+            "result": self.result,
+            "transcript": list(self.transcript),
+            "messages": list(self.messages),
+            "tool_history": {key: list(values) for key, values in self.tool_history.items()},
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.rounds: list[DummyRound] = []
+        self._round_start_hooks: list[Any] = []
+        self._round_end_hooks: list[Any] = []
+        self.next_response_text = "done"
+
+    def add_round_hooks(self, *, on_round_start=None, on_round_end=None) -> None:
+        if on_round_start is not None:
+            self._round_start_hooks.append(on_round_start)
+        if on_round_end is not None:
+            self._round_end_hooks.append(on_round_end)
+
+    def act(self, user_message: str | None = None, *, metadata: Mapping[str, Any] | None = None, **_: Any):
+        index = len(self.rounds)
+        for hook in list(self._round_start_hooks):
+            hook({"index": index, "user_message": user_message, "session": self, "metadata": dict(metadata or {})})
+        structured = StructuredResponse(
+            raw_response={"choices": [{"message": {"content": self.next_response_text}}]},
+            content=self.next_response_text,
+            parsed={"ok": True},
+            schema=None,
+            structured=False,
+        )
+        round_record = DummyRound(
+            index=index,
+            user_message=user_message,
+            response_text=self.next_response_text,
+            result=structured,
+            transcript=[],
+            messages=[],
+            tool_history={"calls": [], "results": []},
+            metadata=dict(metadata or {}),
+        )
+        self.rounds.append(round_record)
+        for hook in list(self._round_end_hooks):
+            hook(round_record)
+        return self.next_response_text, structured
+
+
+def test_manager_run_records_assistant_reply(corpus_environment):
+    corpus_manager, router, facade, long_store = corpus_environment
+    session = DummySession()
+    manager = ManagerAgent(session=session, memory_facade=facade, corpus_manager=corpus_manager)
+
+    manager.run("summarise this")
+
+    records = router.long_term.fetch(MemoryQuery(limit=20))
+    reply_events = [
+        record
+        for record in records
+        if record.metadata.attributes.get("event_type") == "assistant_reply"
+    ]
+    assert reply_events, "expected assistant_reply event recorded"
+    reply = reply_events[-1]
+    assert reply.metadata.attributes.get("category") == "assistant_output"
+    payload = reply.metadata.attributes.get("payload", {})
+    assert payload.get("status") == "completed"
+    assert "response_text" in payload


### PR DESCRIPTION
## Summary
- add a corpus manager backed by the shared memory facade to record structured events with inferred categories
- instrument manager, repo context, research agents, and shell/file tool wrappers to emit corpus events for key interactions
- add regression tests validating research queries, file writes, and manager replies are captured when the corpus manager is enabled

## Testing
- pytest tests/test_corpus_logging.py -q

------
https://chatgpt.com/codex/tasks/task_b_68ed135c15b4832fb727ffe1dfb408ae