### PR TITLE
Add similarity-based filtering for memory writes

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -10,6 +10,7 @@ without modifying code.
 from __future__ import annotations
 
 import asyncio
+from difflib import SequenceMatcher
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
@@ -3258,6 +3259,9 @@ def build_memory_router(config: Optional[MemoryConfiguration] = None) -> MemoryR
 class MemoryFacade:
     """High-level helper exposing convenience operations across memory scopes."""
 
+    _SIMILARITY_THRESHOLD: float = 0.65
+    _SIMILARITY_CANDIDATE_LIMIT: int = 5
+
     def __init__(
         self,
         router: MemoryRouter,
@@ -3497,6 +3501,16 @@ class MemoryFacade:
             embedding=list(embedding) if embedding is not None else None,
             score=self._coerce_float(score),
         )
+        should_skip, similarity_meta = self._evaluate_similarity(store, record)
+        if similarity_meta:
+            sanitized_meta = self._sanitize_value(similarity_meta)
+            attributes = dict(record.metadata.attributes)
+            attributes["similarity_check"] = sanitized_meta
+            metadata = replace(record.metadata, attributes=attributes)
+            metadata.touch()
+            record = replace(record, metadata=metadata)
+        if should_skip:
+            return record
         return store.add(record)
 
     def update(
@@ -3585,6 +3599,139 @@ class MemoryFacade:
     def _get_store(self, scope: str) -> MemoryStore:
         normalized = scope.lower().replace("-", "_")
         return self.router.get_store(normalized)
+
+    def _evaluate_similarity(
+        self,
+        store: MemoryStore,
+        candidate: MemoryRecord,
+    ) -> Tuple[bool, Mapping[str, Any]]:
+        attributes = candidate.metadata.attributes or {}
+        session_id = attributes.get("session_id") or attributes.get("session") or attributes.get("conversation_id")
+        category = attributes.get("category")
+
+        filters: Dict[str, Any] = {}
+        if session_id is not None:
+            filters["session_id"] = session_id
+        if category is not None:
+            filters["category"] = category
+
+        if not filters:
+            return False, {}
+
+        try:
+            recent = store.fetch(
+                MemoryQuery(limit=self._SIMILARITY_CANDIDATE_LIMIT, metadata_filters=filters)
+            )
+        except Exception:
+            LOGGER.debug("Similarity pre-check failed to query store; proceeding with write", exc_info=True)
+            return False, {}
+
+        if not recent:
+            return False, {}
+
+        embedder, _ = resolve_embedding_provider(None)
+        base_embedding = self._record_embedding_vector(candidate, embedder)
+
+        best_score = -1.0
+        best_strategy: Optional[str] = None
+        best_match: Optional[MemoryRecord] = None
+
+        for existing in recent:
+            if existing.record_id == candidate.record_id:
+                continue
+            score, strategy = self._compare_records(candidate, existing, base_embedding, embedder)
+            if score is None or strategy is None:
+                continue
+            if best_strategy is None or score > best_score:
+                best_score = score
+                best_strategy = strategy
+                best_match = existing
+
+        if best_strategy is None or best_score < 0:
+            return False, {}
+
+        decision = "rejected" if best_score >= self._SIMILARITY_THRESHOLD else "accepted"
+
+        similarity_meta: Dict[str, Any] = {
+            "decision": decision,
+            "score": float(best_score),
+            "threshold": self._SIMILARITY_THRESHOLD,
+            "strategy": best_strategy,
+        }
+        if best_match is not None:
+            similarity_meta["matched_record_id"] = best_match.record_id
+        if session_id is not None:
+            similarity_meta["session_id"] = session_id
+        if category is not None:
+            similarity_meta["category"] = category
+
+        log_context = (
+            session_id if session_id is not None else "<none>",
+            category if category is not None else "<none>",
+            best_score,
+            best_strategy,
+            self._SIMILARITY_THRESHOLD,
+            best_match.record_id if best_match is not None else "<unknown>",
+        )
+
+        if decision == "rejected":
+            LOGGER.debug(
+                "Similarity filter rejected memory for session '%s' category '%s': score %.3f via %s (threshold %.2f, match=%s)",
+                *log_context,
+            )
+            return True, similarity_meta
+
+        LOGGER.debug(
+            "Similarity filter accepted memory for session '%s' category '%s': score %.3f via %s (threshold %.2f)",
+            log_context[0],
+            log_context[1],
+            log_context[2],
+            log_context[3],
+            log_context[4],
+        )
+        return False, similarity_meta
+
+    def _record_embedding_vector(
+        self,
+        record: MemoryRecord,
+        embedder: Optional[EmbeddingFunction],
+    ) -> Sequence[float]:
+        embedding = _coerce_embedding_sequence(record.embedding)
+        if embedding:
+            return embedding
+        if embedder is None:
+            return []
+        content = (record.content or "").strip()
+        if not content:
+            return []
+        try:
+            generated = embedder(content)
+        except Exception:
+            LOGGER.debug("Embedding provider raised during similarity evaluation", exc_info=True)
+            return []
+        return _coerce_embedding_sequence(generated)
+
+    def _compare_records(
+        self,
+        candidate: MemoryRecord,
+        existing: MemoryRecord,
+        base_embedding: Sequence[float],
+        embedder: Optional[EmbeddingFunction],
+    ) -> Tuple[Optional[float], Optional[str]]:
+        if base_embedding:
+            existing_embedding = self._record_embedding_vector(existing, embedder)
+            if existing_embedding and len(existing_embedding) == len(base_embedding):
+                score = InMemoryMemoryStore._cosine_similarity(base_embedding, existing_embedding)
+                return score, "embedding"
+
+        candidate_text = (candidate.content or "").strip()
+        existing_text = (existing.content or "").strip()
+        if not candidate_text and not existing_text:
+            return 1.0, "fuzzy"
+        if not candidate_text or not existing_text:
+            return 0.0, "fuzzy"
+        score = SequenceMatcher(None, candidate_text, existing_text).ratio()
+        return score, "fuzzy"
 
     def _normalize_history_scopes(
         self, scope: str | Sequence[str] | None

--- a/tests/test_memory_backends.py
+++ b/tests/test_memory_backends.py
@@ -15,10 +15,12 @@ import pytest
 from memory import (
     CompositeMemoryStore,
     InMemoryMemoryStore,
+    MemoryFacade,
     MemoryConfiguration,
     MemoryMetadata,
     MemoryQuery,
     MemoryRecord,
+    MemoryRouter,
     MemoryStore,
     PostgresSettings,
     RedisSettings,
@@ -37,6 +39,66 @@ def _reset_embedding_cache() -> Iterator[None]:
     clear_embedding_providers()
     yield
     clear_embedding_providers()
+
+
+def _build_memory_facade() -> tuple[MemoryFacade, InMemoryMemoryStore]:
+    store = InMemoryMemoryStore()
+    router = MemoryRouter({MemoryRouter.SHORT_TERM: store})
+    facade = MemoryFacade(router, combined_scope=MemoryRouter.SHORT_TERM)
+    return facade, store
+
+
+def test_memory_facade_similarity_accepts_distinct_records() -> None:
+    facade, store = _build_memory_facade()
+
+    facade.add(
+        "First detail about topic",
+        attributes={"session_id": "accept-session", "category": "unit"},
+    )
+
+    stored = facade.add(
+        "A completely unrelated statement that should not be filtered",
+        attributes={"session_id": "accept-session", "category": "unit"},
+    )
+
+    similarity_meta = stored.metadata.attributes.get("similarity_check")
+    assert similarity_meta is not None
+    assert similarity_meta["decision"] == "accepted"
+    assert similarity_meta["score"] < 0.65
+    assert similarity_meta["strategy"] == "fuzzy"
+
+    results = store.fetch(
+        MemoryQuery(limit=10, metadata_filters={"session_id": "accept-session", "category": "unit"})
+    )
+    assert len(results) == 2
+
+
+def test_memory_facade_similarity_rejects_similar_records() -> None:
+    register_embedding_provider(lambda text: [1.0, 0.0] if "duplicate" in text else [0.0, 1.0])
+
+    facade, store = _build_memory_facade()
+
+    first = facade.add(
+        "duplicate content", attributes={"session_id": "reject-session", "category": "unit"}
+    )
+    assert store.get(first.record_id).content == "duplicate content"
+
+    second = facade.add(
+        "duplicate content", attributes={"session_id": "reject-session", "category": "unit"}
+    )
+
+    similarity_meta = second.metadata.attributes.get("similarity_check")
+    assert similarity_meta is not None
+    assert similarity_meta["decision"] == "rejected"
+    assert similarity_meta["score"] >= 0.65
+    assert similarity_meta["strategy"] == "embedding"
+    assert similarity_meta["matched_record_id"] == first.record_id
+
+    results = store.fetch(
+        MemoryQuery(limit=10, metadata_filters={"session_id": "reject-session", "category": "unit"})
+    )
+    assert len(results) == 1
+    assert results[0].record_id == first.record_id
 
 
 def test_build_memory_router_with_composite_combined_scope() -> None:


### PR DESCRIPTION
## Summary
- add a similarity filter to `MemoryFacade.add` that checks recent records for the same session/category
- compute cosine similarity with embeddings (falling back to fuzzy matching) and skip persisting near-duplicates while annotating metadata
- cover both the acceptance and rejection paths with new in-memory unit tests

## Testing
- pytest tests/test_memory_backends.py -q

------
https://chatgpt.com/codex/tasks/task_b_68ed1a5b0124832fb948c0f92a18a290