### PR TITLE
Add configurable corpus capture pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ python main.py --config path/to/config.json --default-model anthropic/claude-3-s
 
 Run the command from the repository root to launch the Textual-powered interface. The entry point honours every shared flag defined in [`cli/overrides.py`](./cli/overrides.py), so you can pass model overrides, repository indexing preferences, memory settings, and MCP options directly on the command line. Existing automation that shells into `python TUI.py` continues to work and boots the same UI when you prefer the module-level target.
 
+To capture structured corpus events during a session, enable the new corpus pipeline on the CLI:
+
+```bash
+python main.py --config path/to/config.json --enable-corpus --corpus-path ~/.autocoder/corpus/events.jsonl
+```
+
+Complementary flags let you disable capture (`--disable-corpus`), tune the similarity filter (`--corpus-dedup-threshold 0.7`), or override event categories (`--corpus-category web_search=research`).
+
 ### Logging controls
 
 Logging defaults to structured JSON at the `INFO` level. Use the new verbosity flags to adjust output without editing environment variables:
@@ -203,6 +211,28 @@ tasks to retry twice, and injects a bespoke documentation blueprint:
 
 The override is optional—Auto-Coder keeps its default blueprint catalogue and
 single-attempt planning unless this section is provided.
+
+### Capturing corpus events
+
+Corpus capture is disabled by default so development sessions remain ephemeral. Enable it by extending the `core.corpus` section of your configuration or by supplying the new CLI flags described earlier:
+
+```json
+{
+  "core": {
+    "corpus": {
+      "enabled": true,
+      "storage_path": "~/autocoder/corpus/events.jsonl",
+      "dedup_threshold": 0.7,
+      "default_categories": {
+        "web_search": "research",
+        "file_write": "repo_activity"
+      }
+    }
+  }
+}
+```
+
+Auto-Coder will instantiate a shared `CorpusManager`, persist events to long-term memory, and append JSONL entries to the configured `storage_path`. Environment variables (`AUTO_CODER_CORPUS_ENABLED`, `AUTO_CODER_CORPUS_PATH`, `AUTO_CODER_CORPUS_DEDUP_THRESHOLD`, `AUTO_CODER_CORPUS_DEFAULT_CATEGORIES`) provide zero-touch overrides. Adjust the deduplication threshold closer to `1.0` to suppress near-identical payloads, or omit it entirely to capture every event.
 
 ### Running Tests
 

--- a/cli/overrides.py
+++ b/cli/overrides.py
@@ -23,6 +23,24 @@ def _split_multi(values: Iterable[str] | None) -> list[str]:
     return items
 
 
+def _parse_key_value(values: Iterable[str] | None) -> dict[str, str]:
+    """Parse ``key=value`` pairs supplied via repeated CLI flags."""
+
+    mapping: dict[str, str] = {}
+    if not values:
+        return mapping
+    for raw in values:
+        text = str(raw).strip()
+        if not text or "=" not in text:
+            continue
+        key, value = text.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key:
+            mapping[key] = value
+    return mapping
+
+
 def _parse_log_level(value: str) -> str:
     """Validate and normalise a logging level supplied via the CLI."""
 
@@ -87,6 +105,16 @@ def build_overrides(args: argparse.Namespace) -> dict[str, Any]:
         section("memory")["config_path"] = args.memory_config_path
     if args.share_memory is not None:
         section("memory")["share_globally"] = bool(args.share_memory)
+
+    if getattr(args, "corpus_enabled", None) is not None:
+        section("corpus")["enabled"] = bool(args.corpus_enabled)
+    if getattr(args, "corpus_storage_path", None):
+        section("corpus")["storage_path"] = args.corpus_storage_path
+    if getattr(args, "corpus_dedup_threshold", None) is not None:
+        section("corpus")["dedup_threshold"] = float(args.corpus_dedup_threshold)
+    corpus_categories = _parse_key_value(getattr(args, "corpus_category", None))
+    if corpus_categories:
+        section("corpus")["default_categories"] = corpus_categories
 
     if args.mcp_config_path:
         section("mcp")["config_path"] = args.mcp_config_path
@@ -204,6 +232,38 @@ def apply_common_flags(parser: argparse.ArgumentParser) -> None:
         help="Avoid sharing the constructed memory facade globally",
     )
     parser.set_defaults(share_memory=None)
+
+    parser.add_argument(
+        "--enable-corpus",
+        dest="corpus_enabled",
+        action="store_true",
+        help="Enable structured corpus capture",
+    )
+    parser.add_argument(
+        "--disable-corpus",
+        dest="corpus_enabled",
+        action="store_false",
+        help="Disable structured corpus capture",
+    )
+    parser.set_defaults(corpus_enabled=None)
+    parser.add_argument(
+        "--corpus-path",
+        dest="corpus_storage_path",
+        help="Path to a JSONL file where corpus events should be written",
+    )
+    parser.add_argument(
+        "--corpus-dedup-threshold",
+        dest="corpus_dedup_threshold",
+        type=float,
+        help="Similarity threshold (0-1) used to deduplicate corpus events",
+    )
+    parser.add_argument(
+        "--corpus-category",
+        dest="corpus_category",
+        action="append",
+        metavar="EVENT=CATEGORY",
+        help="Override default category mapping for a corpus event type",
+    )
 
     parser.add_argument(
         "--mcp-auto-start",

--- a/core.py
+++ b/core.py
@@ -32,6 +32,7 @@ from memory import (
     load_memory_configuration,
     set_shared_memory_facade,
 )
+from corpus import CorpusManager, set_shared_corpus_manager
 from mcp_tooling import MCPServerRegistry, MCPConfigurationError, register_mcp_servers
 
 LOGGER = logging.getLogger(__name__)
@@ -122,6 +123,16 @@ class MemorySettings:
 
 
 @dataclass(slots=True)
+class CorpusSettings:
+    """Structured corpus capture configuration."""
+
+    enabled: bool = False
+    storage_path: Path | None = None
+    dedup_threshold: float | None = None
+    default_categories: Mapping[str, str] | None = None
+
+
+@dataclass(slots=True)
 class MCPSettings:
     """Configuration for MCP server discovery and lifecycle management."""
 
@@ -149,6 +160,7 @@ class AutoCoderConfig:
     repo_context: RepoContextSettings
     agents: AgentToggleSettings
     memory: MemorySettings
+    corpus: CorpusSettings
     mcp: MCPSettings
     manager: ManagerSettings
 
@@ -193,6 +205,26 @@ def _coerce_int(value: Any | None, *, default: int = 0, minimum: int | None = No
     if minimum is not None and integer < minimum:
         return minimum
     return integer
+
+
+def _coerce_float(
+    value: Any | None,
+    *,
+    default: float | None = None,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float | None:
+    if value is None:
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None and number < minimum:
+        number = minimum
+    if maximum is not None and number > maximum:
+        number = maximum
+    return number
 
 
 def _coerce_sequence(value: Any | None) -> tuple[str, ...] | None:
@@ -410,6 +442,7 @@ def load_core_configuration(
     repo_config = _as_mapping(core_section.get("repo_context"))
     agent_config = _as_mapping(core_section.get("agents"))
     memory_config = _as_mapping(core_section.get("memory"))
+    corpus_config = _as_mapping(core_section.get("corpus"))
     mcp_config = _as_mapping(core_section.get("mcp"))
     manager_config = _as_mapping(core_section.get("manager"))
 
@@ -444,6 +477,7 @@ def load_core_configuration(
     )
 
     research_override = _as_mapping(override_section.get("research"))
+    corpus_override = _as_mapping(override_section.get("corpus"))
 
     default_model = _first_non_empty(
         override_section.get("default_model"),
@@ -682,6 +716,48 @@ def load_core_configuration(
         share_globally=True if share_globally is None else bool(share_globally),
     )
 
+    corpus_enabled_raw = _first_non_empty(
+        corpus_override.get("enabled"),
+        env_map.get("AUTO_CODER_CORPUS_ENABLED"),
+        corpus_config.get("enabled"),
+    )
+    corpus_enabled_flag = _coerce_bool(corpus_enabled_raw)
+    corpus_path = _coerce_path(
+        _first_non_empty(
+            corpus_override.get("storage_path"),
+            env_map.get("AUTO_CODER_CORPUS_PATH"),
+            corpus_config.get("storage_path"),
+        )
+    )
+    dedup_value = _coerce_float(
+        _first_non_empty(
+            corpus_override.get("dedup_threshold"),
+            env_map.get("AUTO_CODER_CORPUS_DEDUP_THRESHOLD"),
+            corpus_config.get("dedup_threshold"),
+        ),
+        minimum=0.0,
+        maximum=1.0,
+    )
+    categories_raw = _coerce_mapping_payload(
+        _first_non_empty(
+            corpus_override.get("default_categories"),
+            env_map.get("AUTO_CODER_CORPUS_DEFAULT_CATEGORIES"),
+            corpus_config.get("default_categories"),
+        ),
+        context="corpus.default_categories",
+    )
+    default_categories = (
+        {str(key): str(value) for key, value in categories_raw.items()}
+        if categories_raw
+        else None
+    )
+    corpus = CorpusSettings(
+        enabled=bool(corpus_enabled_flag) if corpus_enabled_flag is not None else False,
+        storage_path=corpus_path,
+        dedup_threshold=dedup_value,
+        default_categories=default_categories,
+    )
+
     mcp_path = _coerce_path(
         _first_non_empty(
             mcp_config.get("config_path"),
@@ -717,6 +793,7 @@ def load_core_configuration(
         repo_context=repo_context,
         agents=agents,
         memory=memory,
+        corpus=corpus,
         mcp=mcp,
         manager=manager,
     )
@@ -751,9 +828,13 @@ class AutoCoderCore:
             set_shared_memory_facade(self.memory_facade)
             self._shared_memory_installed = True
 
+        self._corpus_manager: CorpusManager | None = None
+        self._corpus_shared_installed = False
+
         self._mcp_registry: MCPServerRegistry | None = None
         self._mcp_specs: tuple[Any, ...] = ()
         self._setup_mcp_registry()
+        self._setup_corpus_manager()
 
         self._repo_context_agent: RepoContextAgent | None = None
         self._research_agent: ResearchAgent | VariedResearchAgent | None = None
@@ -796,9 +877,37 @@ class AutoCoderCore:
             self._mcp_registry = None
             self._mcp_specs = ()
 
+    def _setup_corpus_manager(self) -> None:
+        settings = self.config.corpus
+        if not settings.enabled:
+            set_shared_corpus_manager(None)
+            self._corpus_manager = None
+            self._corpus_shared_installed = False
+            return
+
+        category_map = (
+            {str(key): str(value) for key, value in settings.default_categories.items()}
+            if settings.default_categories
+            else None
+        )
+        manager = CorpusManager(
+            self.memory_facade,
+            scope=self.config.memory.combined_scope,
+            category_map=category_map,
+            enabled=True,
+            storage_path=settings.storage_path,
+            dedup_threshold=settings.dedup_threshold,
+        )
+        set_shared_corpus_manager(manager)
+        self._corpus_manager = manager
+        self._corpus_shared_installed = True
+
     # ------------------------------------------------------------------
     # Agent factories
     # ------------------------------------------------------------------
+    def _get_corpus_manager(self) -> CorpusManager | None:
+        return self._corpus_manager
+
     def _get_repo_context(self) -> RepoContextAgent | None:
         if not self.config.agents.repo_context:
             return None
@@ -1032,6 +1141,7 @@ class AutoCoderCore:
             memory_router=self.memory_router,
             memory_facade=self.memory_facade,
             mcp_registry=self._mcp_registry,
+            corpus_manager=self._get_corpus_manager(),
         )
 
         if integrations_agent is not None:
@@ -1068,6 +1178,10 @@ class AutoCoderCore:
         if self._shared_memory_installed:
             set_shared_memory_facade(None)
             self._shared_memory_installed = False
+        if self._corpus_shared_installed:
+            set_shared_corpus_manager(None)
+            self._corpus_shared_installed = False
+            self._corpus_manager = None
 
     def __enter__(self) -> "AutoCoderCore":
         return self

--- a/corpus/manager.py
+++ b/corpus/manager.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import deque
 from dataclasses import dataclass, field
+from difflib import SequenceMatcher
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
 
 from memory import MemoryFacade, MemoryRecord, MemoryRouter
@@ -65,6 +68,8 @@ class CorpusManager:
         scope: str | None = None,
         category_map: Mapping[str, str] | None = None,
         enabled: bool = True,
+        storage_path: str | Path | None = None,
+        dedup_threshold: float | None = None,
     ) -> None:
         self._facade = facade
         self._scope = scope or MemoryRouter.LONG_TERM
@@ -74,13 +79,27 @@ class CorpusManager:
         self._category_map = merged
         self._enabled = bool(enabled)
         self._modifiers: list[Callable[[CorpusEvent], None]] = []
+        self._storage_path = self._normalise_path(storage_path)
+        self._dedup_threshold = self._normalise_threshold(dedup_threshold)
+        self._dedup_cache: dict[tuple[str | None, str | None, str | None], deque[str]] = {}
+        self._dedup_cache_limit = 32
 
     @property
     def enabled(self) -> bool:
-        return self._enabled and self._facade is not None
+        if not self._enabled:
+            return False
+        return self._facade is not None or self._storage_path is not None
 
     def set_enabled(self, enabled: bool) -> None:
         self._enabled = bool(enabled)
+
+    @property
+    def storage_path(self) -> Path | None:
+        return self._storage_path
+
+    @property
+    def dedup_threshold(self) -> float | None:
+        return self._dedup_threshold
 
     def register_modifier(self, modifier: Callable[[CorpusEvent], None]) -> None:
         """Install a callback that can adjust events before persistence."""
@@ -132,6 +151,15 @@ class CorpusManager:
         if event.category:
             event.enrich_tags((event.category,))
         event.enrich_tags((event.source,))
+        payload_text = self._stringify_payload(event.payload)
+        if self._dedup_threshold is not None and self._is_duplicate(event, payload_text):
+            LOGGER.debug(
+                "Skipping corpus event from %s (%s) due to deduplication threshold %.2f",
+                event.source,
+                event.event_type,
+                self._dedup_threshold,
+            )
+            return None
         for modifier in list(self._modifiers):
             try:
                 modifier(event)
@@ -147,20 +175,24 @@ class CorpusManager:
         attributes["payload"] = event.payload
         attributes["recorded_at"] = datetime.now(timezone.utc).isoformat()
 
-        content = self._stringify_payload(event.payload)
+        record: MemoryRecord | None = None
         try:
-            return self._facade.add(
-                content,
-                scope=self._scope,
-                tags=event.tags,
-                attributes=attributes,
-                source="corpus",
-                session_id=event.session_id,
-                agent_id=event.agent_id,
-            )
+            if self._facade is not None:
+                record = self._facade.add(
+                    payload_text,
+                    scope=self._scope,
+                    tags=event.tags,
+                    attributes=attributes,
+                    source="corpus",
+                    session_id=event.session_id,
+                    agent_id=event.agent_id,
+                )
         except Exception:
             LOGGER.exception("Failed to persist corpus event from %s", event.source)
-            return None
+
+        self._remember_event(event, payload_text)
+        self._write_to_storage(event, attributes, record)
+        return record
 
     @staticmethod
     def _stringify_payload(payload: Any) -> str:
@@ -172,6 +204,84 @@ class CorpusManager:
             return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
         except Exception:
             return str(payload)
+
+    @staticmethod
+    def _normalise_path(path: str | Path | None) -> Path | None:
+        if path is None:
+            return None
+        resolved = Path(path).expanduser().resolve()
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        return resolved
+
+    @staticmethod
+    def _normalise_threshold(value: float | None) -> float | None:
+        if value is None:
+            return None
+        try:
+            threshold = float(value)
+        except (TypeError, ValueError):
+            return None
+        if threshold <= 0:
+            return None
+        if threshold > 1:
+            threshold = 1.0
+        return threshold
+
+    def _dedup_key(self, event: CorpusEvent) -> tuple[str | None, str | None, str | None]:
+        return event.category, event.event_type, event.session_id
+
+    def _is_duplicate(self, event: CorpusEvent, content: str) -> bool:
+        key = self._dedup_key(event)
+        bucket = self._dedup_cache.get(key)
+        if not bucket:
+            return False
+        for existing in bucket:
+            if not existing:
+                continue
+            score = SequenceMatcher(None, existing, content).ratio()
+            if score >= (self._dedup_threshold or 1.0):
+                return True
+        return False
+
+    def _remember_event(self, event: CorpusEvent, content: str) -> None:
+        if self._dedup_threshold is None:
+            return
+        key = self._dedup_key(event)
+        bucket = self._dedup_cache.setdefault(key, deque(maxlen=self._dedup_cache_limit))
+        bucket.append(content)
+
+    def _write_to_storage(
+        self,
+        event: CorpusEvent,
+        attributes: Mapping[str, Any],
+        record: MemoryRecord | None,
+    ) -> None:
+        if self._storage_path is None:
+            return
+
+        payload: dict[str, Any] = {
+            "recorded_at": attributes.get("recorded_at"),
+            "source": event.source,
+            "event_type": event.event_type,
+            "category": event.category,
+            "tags": list(event.tags),
+            "metadata": dict(event.metadata),
+            "payload": event.payload,
+            "session_id": event.session_id,
+            "agent_id": event.agent_id,
+        }
+        if record is not None:
+            payload["memory_record_id"] = record.record_id
+
+        try:
+            with self._storage_path.open("a", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, default=str)
+                handle.write("\n")
+        except Exception:
+            LOGGER.debug(
+                "Failed to persist corpus event to %s", self._storage_path,
+                exc_info=True,
+            )
 
 
 _SHARED_CORPUS_MANAGER: CorpusManager | None = None

--- a/docs/autocoder/codebase-reference.md
+++ b/docs/autocoder/codebase-reference.md
@@ -119,6 +119,8 @@ Core runtime orchestration utilities for Auto-Coder.
     Enable/disable specialist agents without code changes.
 - **MemorySettings**
     Overrides controlling memory configuration resolution.
+- **CorpusSettings**
+    Structured corpus capture configuration (enabled flag, storage path, deduplication threshold, default categories).
 - **MCPSettings**
     Configuration for MCP server discovery and lifecycle management.
 - **ManagerSettings**

--- a/docs/autocoder/runtime.md
+++ b/docs/autocoder/runtime.md
@@ -28,6 +28,7 @@ The configuration is broken down into a handful of nested sections:
 | `agents` | Enable/disable specialist helpers. | Flags for `repo_context`, `research`, `documentation`, `dependency`, `runner`, `db_migration`, `security`, `integrations`, `eval`, `test_critic` | `AUTO_CODER_ENABLE_<NAME>`, `AUTO_CODER_DISABLE_<NAME>` |
 | `manager` | Configure planning retries and specialist overrides. | `plan_retries`, `task_retry_limit`, `specialist_blueprints` | – |
 | `memory` | Configure vector-memory backends. | `config_path`, `default_scope`, `combined_scope`, `share_globally` | `AUTO_CODER_MEMORY_CONFIG`, `AUTO_CODER_MEMORY_DEFAULT_SCOPE`, `AUTO_CODER_MEMORY_COMBINED_SCOPE`, `AUTO_CODER_MEMORY_SHARE` |
+| `corpus` | Control structured corpus capture. | `enabled`, `storage_path`, `dedup_threshold`, `default_categories` | `AUTO_CODER_CORPUS_ENABLED`, `AUTO_CODER_CORPUS_PATH`, `AUTO_CODER_CORPUS_DEDUP_THRESHOLD`, `AUTO_CODER_CORPUS_DEFAULT_CATEGORIES` |
 | `mcp` | Discover Model Context Protocol servers. | `config_path`, `servers`, `auto_start` | `AUTO_CODER_MCP_CONFIG`, `AUTO_CODER_MCP_AUTO_START` |
 
 Additional helper variables include `AUTO_CODER_CONFIG_PATH` (alternate core
@@ -100,6 +101,10 @@ metadata:
 
 When omitted, Auto-Coder falls back to the built-in blueprint catalogue and a
 single planning attempt per workflow.
+
+### Corpus capture
+
+The optional `core.corpus` section toggles structured corpus logging. Capture is disabled by default, keeping local runs ephemeral. Setting `enabled` to `true` instantiates a shared [`CorpusManager`](../../corpus/manager.py) that persists events to long-term memory and, when `storage_path` is provided, appends JSONL records to that path. Use `dedup_threshold` to suppress near-duplicate payloads (values close to `1.0` keep only unique events) and `default_categories` to override the built-in event-type category map. All values can be overridden via the CLI flags (`--enable-corpus`, `--corpus-path`, `--corpus-dedup-threshold`, `--corpus-category`) or the corresponding environment variables listed above.
 
 ## Orchestration pipeline
 

--- a/tests/test_cli_overrides.py
+++ b/tests/test_cli_overrides.py
@@ -69,6 +69,15 @@ def test_build_overrides_constructs_expected_structure(overrides_module):
             "--memory-config",
             "/tmp/memory.json",
             "--no-shared-memory",
+            "--enable-corpus",
+            "--corpus-path",
+            "/tmp/corpus.jsonl",
+            "--corpus-dedup-threshold",
+            "0.7",
+            "--corpus-category",
+            "web_search=discovery",
+            "--corpus-category",
+            "file_write=repo_activity",
             "--mcp-auto-start",
         ],
     )
@@ -96,6 +105,15 @@ def test_build_overrides_constructs_expected_structure(overrides_module):
             "config_path": "/tmp/memory.json",
             "share_globally": False,
         },
+        "corpus": {
+            "enabled": True,
+            "storage_path": "/tmp/corpus.jsonl",
+            "dedup_threshold": 0.7,
+            "default_categories": {
+                "web_search": "discovery",
+                "file_write": "repo_activity",
+            },
+        },
         "mcp": {
             "config_path": "/tmp/mcp.json",
             "auto_start": True,
@@ -117,6 +135,10 @@ def test_build_overrides_ignores_missing_values(overrides_module):
         disable_agent=None,
         memory_config_path=None,
         share_memory=None,
+        corpus_enabled=None,
+        corpus_storage_path=None,
+        corpus_dedup_threshold=None,
+        corpus_category=None,
         mcp_config_path=None,
         mcp_auto_start=None,
     )
@@ -132,6 +154,7 @@ def test_apply_common_flags_supports_tristate_toggles(overrides_module):
     assert defaults.allow_browsing is None
     assert defaults.repo_auto_refresh is None
     assert defaults.share_memory is None
+    assert defaults.corpus_enabled is None
     assert defaults.mcp_auto_start is None
     assert defaults.log_level is None
 
@@ -143,6 +166,9 @@ def test_apply_common_flags_supports_tristate_toggles(overrides_module):
 
     assert parser.parse_args(["--shared-memory"]).share_memory is True
     assert parser.parse_args(["--no-shared-memory"]).share_memory is False
+
+    assert parser.parse_args(["--enable-corpus"]).corpus_enabled is True
+    assert parser.parse_args(["--disable-corpus"]).corpus_enabled is False
 
     assert parser.parse_args(["--mcp-auto-start"]).mcp_auto_start is True
     assert parser.parse_args(["--no-mcp-auto-start"]).mcp_auto_start is False

--- a/tests/test_core_runtime.py
+++ b/tests/test_core_runtime.py
@@ -223,6 +223,14 @@ def test_research_agent_uses_research_settings(tmp_path: Path) -> None:
     core.shutdown()
 
 
+def test_corpus_disabled_by_default(tmp_path: Path) -> None:
+    config = load_core_configuration(overrides={"paths": {"repo_root": str(tmp_path)}})
+
+    assert not config.corpus.enabled
+    assert config.corpus.storage_path is None
+    assert config.corpus.dedup_threshold is None
+
+
 def test_varied_research_agent_enabled(tmp_path: Path) -> None:
     env = {"AUTO_CODER_REPO_ROOT": str(tmp_path)}
 
@@ -407,6 +415,7 @@ def test_core_manager_uses_configured_settings(
             memory_facade=None,
             mcp_registry=None,
             status_callback=None,
+            corpus_manager=None,
             **_: Any,
         ) -> None:
             captured.update(
@@ -415,6 +424,7 @@ def test_core_manager_uses_configured_settings(
                     "task_retry_limit": task_retry_limit,
                     "specialist_blueprints": tuple(specialist_blueprints or ()),
                     "status_callback": status_callback,
+                    "corpus_manager": corpus_manager,
                 }
             )
             self.session = session
@@ -486,5 +496,41 @@ def test_core_manager_uses_configured_settings(
     assert custom_blueprint["budget"]["limit"] == pytest.approx(5.0)
     assert custom_blueprint["keywords"] == ("regression", "benchmark")
     assert manager._attached["eval"] is core._eval_agent
+    assert captured["corpus_manager"] is None
 
     core.shutdown()
+
+
+def test_core_enables_corpus_when_configured(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class StubManager:
+        def __init__(self, *, corpus_manager=None, **_: Any) -> None:
+            captured["corpus_manager"] = corpus_manager
+
+    monkeypatch.setattr("core.ManagerAgent", StubManager)
+
+    overrides = {
+        "paths": {"repo_root": str(tmp_path)},
+        "corpus": {
+            "enabled": True,
+            "storage_path": str(tmp_path / "events.jsonl"),
+            "dedup_threshold": 0.75,
+            "default_categories": {"custom_event": "custom"},
+        },
+    }
+
+    core = AutoCoderCore(overrides=overrides)
+    try:
+        core.build_manager()
+    finally:
+        core.shutdown()
+
+    corpus_manager = captured.get("corpus_manager")
+    assert corpus_manager is not None
+    assert corpus_manager.enabled
+    assert corpus_manager.storage_path == (tmp_path / "events.jsonl").resolve()
+    assert corpus_manager.dedup_threshold == pytest.approx(0.75)
+    assert corpus_manager.infer_category("custom_event") == "custom"

--- a/tests/test_corpus_logging.py
+++ b/tests/test_corpus_logging.py
@@ -1,9 +1,8 @@
+import json
 import os
 import sys
 import types
-import os
-import sys
-import types
+from pathlib import Path
 from dataclasses import dataclass
 from typing import Any, Mapping
 
@@ -160,6 +159,59 @@ def test_file_write_logs_corpus_event(corpus_environment):
     finally:
         if os.path.exists(target):
             os.remove(target)
+
+
+def test_corpus_manager_applies_deduplication(tmp_path: Path) -> None:
+    short_store = InMemoryMemoryStore()
+    router = MemoryRouter(
+        {
+            MemoryRouter.SHORT_TERM: short_store,
+            MemoryRouter.LONG_TERM: short_store,
+            MemoryRouter.COMBINED: short_store,
+        }
+    )
+    facade = MemoryFacade(router)
+    manager = CorpusManager(facade, dedup_threshold=0.9)
+
+    manager.record_event(
+        source="tester",
+        payload={"message": "repeat me"},
+        event_type="custom_event",
+        session_id="session-1",
+    )
+    skipped = manager.record_event(
+        source="tester",
+        payload={"message": "repeat me"},
+        event_type="custom_event",
+        session_id="session-1",
+    )
+
+    records = router.long_term.fetch(MemoryQuery(limit=10))
+    assert len(records) == 1
+    assert skipped is None
+
+
+def test_corpus_manager_writes_to_storage(tmp_path: Path) -> None:
+    storage = tmp_path / "events.jsonl"
+    manager = CorpusManager(
+        None,
+        enabled=True,
+        storage_path=storage,
+    )
+
+    result = manager.record_event(
+        source="tester",
+        payload={"value": 42},
+        event_type="metric",
+        session_id="session-2",
+    )
+
+    assert result is None  # No facade was configured
+    contents = storage.read_text(encoding="utf-8").strip().splitlines()
+    assert contents, "expected corpus manager to write JSONL entries"
+    record = json.loads(contents[-1])
+    assert record["event_type"] == "metric"
+    assert record["payload"]["value"] == 42
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add a `core.corpus` configuration section and plumb it through AutoCoderCore
- enhance CorpusManager with optional deduplication and JSONL storage
- expose CLI/environment toggles for corpus capture and update docs/tests

## Testing
- pytest *(fails: requires numpy and rich test dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68ed1cf665c8832f94511acef97bcf20