### PR TITLE
docs: expand python chat and namespace references

### DIFF
--- a/docs/LMStudio/developer/python/api-reference/chat.md
+++ b/docs/LMStudio/developer/python/api-reference/chat.md
@@ -5,4 +5,169 @@ description: "`Chat` - API reference for representing a chat conversation with a
 index: 5
 ---
 
-...
+`Chat` is a mutable container that tracks the ordered messages shared between the user, the
+assistant, the system, and tool executions. It is the preferred structure for providing context to
+[`LLM.respond()`](./respond.md) and agent workflows such as
+[`LLM.act()`](../../agent/act.md), and it is accepted anywhere the SDK expects a chat history (for
+example [`LLM.apply_prompt_template()`](./llm-namespace.md#preview-a-prompt-template)).
+
+Import the class from the top-level SDK namespace:
+
+```python
+from lmstudio import Chat
+```
+
+## Creating a chat history
+
+### Start from scratch
+
+```python
+chat = Chat()
+```
+
+Create an empty conversation. You can optionally seed the conversation with a system prompt:
+
+```python
+chat = Chat(initial_prompt="You are a concise assistant.")
+```
+
+Passing `initial_prompt` is equivalent to calling [`add_system_prompt`](#add_system_prompt) after
+construction.
+
+### Clone or restore an existing history
+
+Use `Chat.from_history()` when you already have serialized messages:
+
+```python
+saved_history = {
+    "messages": [
+        {"role": "system", "content": [{"text": "Stay upbeat."}]},
+        {"role": "user", "content": [{"text": "Tell me a joke."}]},
+    ]
+}
+
+chat = Chat.from_history(saved_history)
+```
+
+`from_history()` accepts:
+
+- Another `Chat` instance (creates a deep copy)
+- A `ChatHistoryData` struct or its plain-`dict` form
+- A single `str`, which becomes a one-line user message
+
+## Mutating the conversation
+
+The public helpers on `Chat` correspond to the roles that can appear in prediction transcripts.
+They accept flexible input types that are validated by the SDK before they are serialized for the
+server. The most common helpers are summarised below.
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| [`add_system_prompt`](#add_system_prompt) | `add_system_prompt(prompt)` | Add a system message that sets behaviour for future turns. |
+| [`add_user_message`](#add_user_message) | `add_user_message(content, *, images=())` | Append user text and optional files or images. |
+| [`add_assistant_response`](#add_assistant_response) | `add_assistant_response(response, tool_call_requests=())` | Record an assistant reply and any tool call requests returned by the model. |
+| [`add_tool_results`](#add_tool_results) | `add_tool_results(results)` | Append tool outputs returned to the assistant. |
+| [`append`](#append) | `append(message)` | Copy an already-formatted message (dict or struct) into the chat. |
+| [`copy`](#copy) | `copy()` | Produce a deep copy of the chat. |
+
+### `add_system_prompt`
+
+```python
+chat.add_system_prompt("Answer in fewer than 20 words.")
+```
+
+Accepts either a string, a `TextData` instance, or a dictionary containing a `text` field.
+Consecutive system prompts are rejected to prevent
+accidental duplication.
+
+### `add_user_message`
+
+```python
+from lmstudio import prepare_image
+
+handle = prepare_image("diagram.png")
+chat.add_user_message(
+    "Summarize the attachment",
+    images=[handle],
+)
+```
+
+`content` may be a string, a `TextData` object, a `FileHandle`, or an iterable combining those
+values. Additional file handles can be supplied through the `images` keyword (other file types will
+become available as the server adds support). When multiple user calls occur back to back the SDK
+merges them into a single multi-part message so the serialized transcript always alternates roles.
+
+### `add_assistant_response`
+
+```python
+response = chat.add_assistant_response("Here is what I found:")
+chat.add_assistant_response(
+    {"text": "Calling the lookup tool."},
+    tool_call_requests=[{"type": "toolCallRequest", "toolCallId": "lookup"}],
+)
+```
+
+`response` accepts the same shapes as user content (string, `TextData`, or `FileHandle`). Tool call
+requests are optional; when provided they can be dictionaries with `toolCallId`/`content` fields or
+`ToolCallRequest` structs. The helper ensures two assistant messages never appear consecutively in
+the history.
+
+### `add_tool_results` and `add_tool_result`
+
+Record the results of a tool invocation so the model can read them on the next prediction round:
+
+```python
+chat.add_tool_results([
+    {
+        "toolCallId": "lookup",
+        "content": [{"text": "Temperature is 21°C."}],
+    }
+])
+```
+
+For a single result you can call `add_tool_result(result)` instead of wrapping it in a list. Both
+helpers accept dictionaries that match the wire schema or pre-built `ToolCallResultData` structs.
+
+### `add_entry` and `append`
+
+`add_entry(role, content)` routes to the specialised helpers above based on the role string, while
+`append(message)` copies an already-normalized message object (`AnyChatMessage` or `dict`). These
+are convenient when you receive structured events from streaming APIs like
+[`PredictionStream`](./llm-namespace.md#streaming-predictions).
+
+### `copy`
+
+`chat.copy()` (and the equivalent `copy.copy(chat)` or `copy.deepcopy(chat)`) returns a fully
+independent conversation that can be mutated without affecting the original object. This is useful
+when branching conversations or retrying with a different prediction configuration.
+
+## Using `Chat` with predictions
+
+```python
+import lmstudio as lms
+
+chat = Chat(initial_prompt="You are a travel assistant.")
+chat.add_user_message("Plan a 3 day trip to Tokyo")
+
+with lms.Client() as client:
+    model = client.llm.model("lmstudio-community/llama-3.2-3b-instruct")
+    result = model.respond(chat)
+    chat.append(result.message)  # Keep the assistant turn in the transcript
+```
+
+`Chat` instances can be reused for subsequent turns, or copied before modifying them to preserve the
+previous state. When passing `Chat` to [`LLM.respond()`](./respond.md) or
+[`LLM.act()`](../../agent/act.md), the SDK automatically serializes the messages into the format
+expected by the LM Studio server. You can also hand the same object to
+[`LLM.apply_prompt_template()`](./llm-namespace.md#preview-a-prompt-template) to preview how the
+conversation will be rendered prior to sending a prediction.
+
+## See also
+
+- [`LLM.respond()`](./respond.md) – generate chat completions from an LLM handle.
+- [Chat completion guide](../../llm-prediction/chat-completion.md) – end-to-end walkthrough of
+  multi-turn interactions.
+- [`PredictionStream`](./llm-namespace.md#streaming-predictions) – consume streaming events while
+  updating a `Chat` incrementally.
+- [Prompt template helpers](../../more/apply-prompt-template.md) – format conversations outside of a
+  prediction call.

--- a/docs/LMStudio/developer/python/api-reference/llm-namespace.md
+++ b/docs/LMStudio/developer/python/api-reference/llm-namespace.md
@@ -5,4 +5,184 @@ description: "`client.llm` - API reference for the llm namespace in an `LMStudio
 index: 6
 ---
 
-...
+The `llm` namespace exposes operations for discovering, loading, and interacting with large language
+models hosted by LM Studio. It is available on both the synchronous [`Client`](./lmstudioclient.md)
+and asynchronous `AsyncClient` classes as the `client.llm` property. The same helpers are also
+re-exported as top-level convenience functions such as `lmstudio.llm()`.
+
+```python
+import lmstudio as lms
+
+with lms.Client() as client:
+    llama = client.llm.model("lmstudio-community/llama-3.2-3b-instruct")
+    print(llama.respond("Hello there!"))
+```
+
+All interactions ultimately yield an [`LLM` handle](./model.md) whose methods perform predictions
+(`.respond()`, `.complete()`, `.act()`, `.tokenize()`, ...). This page focuses on the namespace-level
+helpers that orchestrate model lifecycle.
+
+## Core operations
+
+| Method | Description |
+| --- | --- |
+| [`model(model_key=None, *, ttl=..., config=None, on_load_progress=None)`](#retrieve-a-handle) | Return a handle to an already loaded model or trigger a just-in-time load. |
+| [`load_new_instance(model_key, instance_identifier=None, *, ttl=..., config=None, on_load_progress=None)`](#load-additional-model-instances) | Force a fresh copy of the model into memory even when one is already resident. |
+| [`list_loaded()`](#inspect-loaded-models) | Enumerate every LLM currently in memory. |
+| [`list_downloaded()`](#discover-downloaded-models) | Return downloaded models that can be loaded without contacting the repository. |
+| [`get_model_info(model_specifier)`](#inspect-loaded-models) | Fetch metadata (identifier, context length, etc.) about an in-memory model. |
+| [`unload(model_identifier)`](#unload-a-model) | Proactively free GPU/CPU memory for a loaded instance. |
+| [`connect()` / `disconnect()`](#manual-session-control) | Manually manage the underlying websocket session (rarely required). |
+
+Every method above is available in synchronous form (`client.llm`) and as `await`-able counterparts on
+`AsyncClient.llm`. Keyword parameters are the same across both APIs.
+
+### Retrieve a handle
+
+```python
+model = client.llm.model()
+```
+
+- Without arguments the first loaded model is returned; an error is raised if none are loaded.
+- Provide `model_key` to specify which model should be returned or loaded. The key matches the
+  identifiers shown in LM Studio (for example `"lmstudio-community/phi-3.5-mini-instruct"`).
+- `config` and `ttl` mirror the parameters described in
+  [load-time configuration](../../llm-prediction/parameters.md#load-parameters). They are applied only
+  if the model needs to be loaded during the call. See [`model()`](./model.md) for full details.
+- `on_load_progress` receives streaming progress events while the server loads the model. The callback
+  signature is documented in [Download progress callbacks](../model-management/download-models.md#track-download-progress).
+
+To obtain a handle outside of a scoped `Client`, call the top-level convenience wrapper:
+
+```python
+llm = lms.llm("llama-3.2-1b-instruct")
+print(llm.complete("One-sentence summary of LM Studio"))
+```
+
+### Load additional model instances
+
+```python
+fresh = client.llm.load_new_instance(
+    "lmstudio-community/llama-3.2-3b-instruct",
+    instance_identifier="analysis",
+    ttl=15 * 60,
+    config={"contextLength": 8192},
+)
+```
+
+`load_new_instance()` always creates a new runtime instance, allowing you to run multiple copies of
+the same base model simultaneously (for example, one dedicated to low-latency streaming responses and
+another to long-form analysis). Use [`list_loaded()`](#inspect-loaded-models) to view the identifiers
+you can pass to [`unload()`](#unload-a-model) later.
+
+### Inspect loaded models
+
+```python
+for handle in client.llm.list_loaded():
+    info = client.llm.get_model_info(handle.identifier)
+    print(info.display_name, info.context_length)
+```
+
+`list_loaded()` returns `LLM` handles representing each in-memory model. `get_model_info()` accepts a
+model identifier string or any other [model specifier](../../model-info/get-model-info.md#parameters)
+and yields a `ModelInstanceInfo` struct.
+
+### Discover downloaded models
+
+```python
+for downloaded in client.llm.list_downloaded():
+    print(downloaded.display_name, downloaded.path)
+```
+
+The return value is a sequence of `DownloadedLlm` wrappers. Each wrapper exposes:
+
+- `model_key`, `display_name`, `architecture`, and other metadata through the `info` property
+- `.model(...)` – a shortcut to `client.llm.model(model_key, ...)`
+- `.load_new_instance(...)` – identical to calling the namespace method directly
+
+To search the online model repository instead, use [`client.repository`](../model-management/download-models.md).
+
+### Unload a model
+
+```python
+client.llm.unload("analysis")
+```
+
+Pass the instance identifier returned by [`list_loaded()`](#inspect-loaded-models). Unloading frees
+resources immediately instead of waiting for the [idle TTL](../../app/api/ttl-and-auto-evict.md) to
+expire.
+
+### Preview a prompt template
+
+```python
+rendered = llama.apply_prompt_template(chat, opts={"preset": "instruct"})
+print(rendered)
+```
+
+The handle method `LLM.apply_prompt_template()` accepts any chat history supported by
+[`LLM.respond()`](./respond.md) and returns the formatted prompt string without performing a
+prediction. This is handy for debugging how a conversation will be rendered before streaming tokens.
+For higher-level guidance see
+[Apply prompt templates](../../more/apply-prompt-template.md).
+
+### Streaming predictions
+
+Use the `*_stream()` helpers on an `LLM` handle to receive partial outputs while a prediction is in
+progress.
+
+```python
+stream = llama.respond_stream("Explain speculative decoding")
+for fragment in stream:
+    print(fragment.content, end="")
+```
+
+- [`LLM.respond_stream()`](./respond.md#streaming) accepts either a `Chat` instance or anything that
+  [`Chat.from_history()`](./chat.md#clone-or-restore-an-existing-history) can understand.
+- [`LLM.complete_stream()`](./complete.md#streaming) exposes the same pattern for single-turn prompts.
+- In the asynchronous API these helpers return an `AsyncPredictionStream` that you iterate with
+  `async for`.
+
+Consult [Chat completions](../../llm-prediction/chat-completion.md#streaming) for a full walkthrough,
+including how to merge streamed events back into a [`Chat`](./chat.md).
+
+### Manual session control
+
+The namespace automatically opens and closes its websocket connection as needed. In advanced
+integrations you can explicitly control the lifecycle:
+
+```python
+session = client.llm.connect()
+try:
+    ...  # Issue multiple remote_call(...) invocations
+finally:
+    client.llm.disconnect()
+```
+
+Maintaining a persistent connection can reduce latency when issuing a large batch of predictions or
+invoking lower-level RPCs through `client.llm.remote_call(endpoint, params)`.
+
+## Asynchronous usage
+
+The asynchronous API mirrors the synchronous surface area:
+
+```python
+import lmstudio as lms
+
+async with lms.AsyncClient() as client:
+    model = await client.llm.model("qwen2.5-7b-instruct")
+    stream = await model.respond_stream("Hi there")
+    async for fragment in stream:
+        print(fragment.content, end="")
+```
+
+Async methods return awaitables (`await client.llm.list_loaded()`, `await client.llm.unload(...)`,
+etc.) and the streaming helpers yield `AsyncPredictionStream` instances. The semantics of `config`,
+`ttl`, and callbacks remain identical to their synchronous counterparts.
+
+## See also
+
+- [`client.system`](./system-namespace.md) for accessing the shared catalogue of downloaded models.
+- [Load models into memory](../model-management/loading.md) for higher-level lifecycle patterns.
+- [Chat completion guide](../../llm-prediction/chat-completion.md) and
+  [text completion guide](../../llm-prediction/completion.md) for prediction workflows once you have
+  an `LLM` handle.

--- a/docs/LMStudio/developer/python/api-reference/system-namespace.md
+++ b/docs/LMStudio/developer/python/api-reference/system-namespace.md
@@ -5,4 +5,65 @@ description: "`client.system` - API reference for the system namespace in an `LM
 index: 6
 ---
 
-...
+The `system` namespace exposes LM Studio server-level utilities that apply across all model types.
+When you need a catalogue of every model the host has already downloaded—regardless of whether it is
+an LLM or embedding model—start here.
+
+```python
+import lmstudio as lms
+
+with lms.Client() as client:
+    downloaded = client.system.list_downloaded_models()
+    for model in downloaded:
+        print(model.model_key, model.type, model.path)
+```
+
+Returned objects are wrappers around the JSON payloads sent by LM Studio, providing strongly-typed
+helpers to load models directly from the result set.
+
+## `list_downloaded_models()`
+
+```python
+models = client.system.list_downloaded_models()
+```
+
+- Returns a list of `DownloadedLlm` and `DownloadedEmbeddingModel` instances (alias `AnyDownloadedModel`).
+- Each wrapper exposes:
+  - `model_key`, `display_name`, `architecture`, `vision`, and related metadata through the `.info`
+    property.
+  - `.model(...)` – equivalent to calling [`client.llm.model()`](./llm-namespace.md#retrieve-a-handle)
+    or [`client.embedding.model()`](../embedding/index.md) depending on the model type.
+  - `.load_new_instance(...)` – identical to the respective namespace’s
+    [`load_new_instance()`](./llm-namespace.md#load-additional-model-instances) helper.
+  - `.path` – absolute filesystem path of the downloaded weights, useful for troubleshooting.
+- The ordering matches the server response: newly downloaded models appear last.
+
+Use these helpers to build dashboards or reconcile on-disk models with what is currently loaded into
+memory. When combined with [`client.llm.list_loaded()`](./llm-namespace.md#inspect-loaded-models) you
+can easily detect which downloads are idle.
+
+## Typical workflow
+
+1. Call `client.system.list_downloaded_models()` to enumerate everything on disk.
+2. Filter the returned collection based on metadata, e.g. `model.info.architecture == "llama"`.
+3. Load a model directly from the wrapper:
+
+    ```python
+    llama = next(m for m in models if m.model_key.endswith("llama-3.2-3b-instruct"))
+    handle = llama.model(ttl=3600)
+    response = handle.respond("Summarise the latest release notes.")
+    ```
+
+4. When finished, clean up with [`client.llm.unload(handle.identifier)`](./llm-namespace.md#unload-a-model)
+   or allow the idle TTL to release memory automatically.
+
+## Relationship to other namespaces
+
+- [`client.llm`](./llm-namespace.md) and `client.embedding` expose additional lifecycle controls once
+you know which model key you want to operate on.
+- [`client.repository`](../model-management/download-models.md) queries the online model hub for
+resources that are not yet downloaded. Combine it with `client.system` to offer download + load flows
+in tooling.
+- The top-level helpers [`lmstudio.list_downloaded_models()`](../model-management/download-models.md)
+and [`lmstudio.list_loaded_models()`](../model-management/loading.md#list-loaded-models) forward to the
+same underlying RPCs if you prefer not to create a scoped client.


### PR DESCRIPTION
## Summary
- document the Python `Chat` helper with creation patterns and mutation APIs
- expand `client.llm` namespace docs covering lifecycle methods, streaming, and async usage
- describe the `client.system` namespace and how to work with downloaded model listings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ed3075a398832fa12354a296202fe5