### PR TITLE
docs: add TypeScript API references for chat and namespaces

### DIFF
--- a/docs/LMStudio/developer/typescript/api-reference/chat.md
+++ b/docs/LMStudio/developer/typescript/api-reference/chat.md
@@ -5,4 +5,162 @@ description: "`Chat` - API reference for representing a chat conversation with a
 index: 5
 ---
 
-...
+`Chat` is a mutable helper for building and replaying multi-turn conversations. It owns an ordered
+collection of `ChatMessage` objects and understands every shape that the LM Studio TypeScript SDK
+accepts as a chat history. Use it to construct inputs for
+[`.respond()`](./respond.md), agent workflows such as
+[`LLM.act()`](../../agent/act.md), or utilities like
+[`LLM.applyPromptTemplate()`](./llm-namespace.md#preview-a-prompt-template).
+
+```ts
+import { Chat } from "@lmstudio/sdk";
+```
+
+## Creating a chat history
+
+### Start from an empty transcript
+
+```ts
+const chat = Chat.empty();
+chat.append("system", "You are a concise assistant.");
+```
+
+`Chat.empty()` returns a mutable instance. All mutators (`append`, `pop`, `withAppended`, …) operate on
+that instance until you branch it.
+
+### Bootstrap from existing data
+
+`Chat.from(initializer)` creates a mutable copy from any `ChatLike` value:
+
+```ts
+const chat = Chat.from([
+  { role: "system", content: "Stay upbeat." },
+  { role: "user", content: "Tell me a joke." },
+]);
+```
+
+Valid initializers include:
+
+- A plain string (treated as a single user message)
+- Arrays of `{ role, content }` objects or richer `ChatMessageInput` structures
+- A `Chat` or `ChatHistoryData` instance (creates a deep copy)
+- A single `ChatMessage` or `ChatMessageData` object
+
+This makes it easy to restore serialized transcripts or fork an in-memory conversation before
+continuing.
+
+### Functional branching with `withAppended`
+
+Prefer `withAppended(...)` when you want to stage changes without mutating the original:
+
+```ts
+const nextAttempt = chat.withAppended("user", "Rephrase that in fewer than 20 words.");
+```
+
+`withAppended` returns a brand-new `Chat` while leaving `chat` untouched—perfect for retries or A/B
+experiments.
+
+## Mutation helpers
+
+| Helper | Signature (simplified) | Description |
+| --- | --- | --- |
+| `append` | `append(role: ChatMessageRoleData, content: string, opts?: ChatAppendOpts)`<br/>`append(message: ChatMessageLike)` | Push a new turn into the transcript. The `ChatAppendOpts` bag currently accepts `images?: FileHandle[]`. |
+| `withAppended` | `withAppended(role, content, opts?)`<br/>`withAppended(message)` | Return a cloned chat that already includes the supplied message. |
+| `pop` | `pop(): ChatMessage` | Remove and return the most recent message; throws if the chat is empty. |
+| `at` | `at(index: number): ChatMessage` | Random-access getter. Negative indexes count from the end. |
+| `getMessagesArray` | `getMessagesArray(): ChatMessage[]` | Materialize the entire history as `ChatMessage` objects. |
+| `map` / `flatMap` | `map(mapper)` / `flatMap(mapper)` | Transform the transcript while preserving message metadata. |
+| `getSystemPrompt` | `getSystemPrompt(): string` | Return the first system message as plain text (empty string if none). |
+| `replaceSystemPrompt` | `replaceSystemPrompt(text: string): void` | Overwrite the leading system message, creating one if necessary. |
+| `hasFiles` | `hasFiles(): boolean` | Quick check for any attached `FileHandle`s. |
+| `getAllFiles` | `getAllFiles(client: LMStudioClient): FileHandle[]` | Collect every file handle present in the history. |
+| `consumeFiles` / `consumeFilesAsync` | `consumeFiles(client, predicate)` | Remove matching files while returning them for custom processing. |
+
+### Appending rich content
+
+Combine text and prepared files in a single turn. The SDK ensures role ordering stays valid (assistant
+messages never follow assistant messages, etc.).
+
+```ts
+const image = await client.files.prepareImage("./diagram.png");
+
+chat.append("user", "Summarize the attachment", {
+  images: [image],
+});
+```
+
+You can also copy pre-composed messages, for example when replaying streamed fragments:
+
+```ts
+import type { ChatMessage } from "@lmstudio/sdk";
+
+function appendFromStream(chat: Chat, message: ChatMessage) {
+  chat.append(message);
+}
+```
+
+### Inspecting and pruning history
+
+Use iteration helpers to walk the transcript, whether you need summary statistics or to filter out
+sensitive turns before logging:
+
+```ts
+const userTurns = chat
+  .map((message) => message)
+  .filter((message) => message.isUserMessage())
+  .map((message) => message.getText());
+
+chat.filterInPlace((message) => !message.isSystemPrompt());
+```
+
+`filterInPlace` keeps only the messages that satisfy the predicate, which is handy when trimming
+branches during long-running sessions. Call `pop()` to roll back the last turn.
+
+### Working with file attachments
+
+The file helpers require an `LMStudioClient` instance because the handles originate from the server.
+
+```ts
+const removed = chat.consumeFiles(client, (file) => file.mimeType?.startsWith("image/"));
+console.info("Stripped", removed.length, "inline images");
+```
+
+The asynchronous variant `consumeFilesAsync` lets you await transformations (for example, resizing
+images) before deciding whether to remove them.
+
+## Using `Chat` with predictions
+
+```ts
+import { Chat, LMStudioClient } from "@lmstudio/sdk";
+
+const client = new LMStudioClient();
+const model = await client.llm.model();
+
+const chat = Chat.empty();
+chat.append("system", "You are a travel planner.");
+chat.append("user", "Plan a 3 day trip to Tokyo.");
+
+const prediction = model.respond(chat, {
+  onMessage: (message) => chat.append(message),
+});
+
+for await (const fragment of prediction) {
+  process.stdout.write(fragment.content);
+}
+
+const result = await prediction.result();
+console.info("Stop reason:", result.stats.stopReason);
+```
+
+A single `Chat` instance can be reused across turns. Use `withAppended(...)` or `Chat.from(chat)` to
+branch if you need to retry with different [`LLMPredictionConfig`](./llm-prediction-config-input.md)
+settings.
+
+## See also
+
+- [Chat completion guide](../../llm-prediction/chat-completion.md) for an end-to-end walkthrough.
+- [Working with Chats](../../llm-prediction/working-with-chats.md) for additional patterns and
+  initializer shapes.
+- [`LLM.respond()`](./respond.md) – generate assistant replies from a loaded model.
+- [Apply prompt templates](../../more/apply-prompt-template.md) to inspect how a conversation will be
+  rendered.

--- a/docs/LMStudio/developer/typescript/api-reference/llm-namespace.md
+++ b/docs/LMStudio/developer/typescript/api-reference/llm-namespace.md
@@ -5,4 +5,164 @@ description: "`client.llm` - API reference for the llm namespace in an `LMStudio
 index: 6
 ---
 
-...
+The `llm` namespace surfaces lifecycle operations for large language models. It lives on every
+[`LMStudioClient`](./lmstudioclient.md) instance and returns strongly typed `LLM` handles whose
+methods cover prediction, tokenization, and prompt templating.
+
+```ts
+import { LMStudioClient } from "@lmstudio/sdk";
+
+const client = new LMStudioClient();
+const llama = await client.llm.model("lmstudio-community/llama-3.2-3b-instruct");
+const reply = await llama.respond("Hello there!");
+console.info(reply.content);
+```
+
+Once you have a handle, reuse it for subsequent requests to avoid reloading weights. The sections
+below document the namespace-level helpers that fetch, load, and enumerate those handles.
+
+## Core operations
+
+| Method | Description |
+| --- | --- |
+| [`model(modelKey?, options?)`](#retrieve-a-handle) | Get a handle to any loaded model, optionally loading it on demand. |
+| [`load(modelKey, options?)`](#load-additional-instances) | Force LM Studio to spin up a brand-new instance even if one already exists. |
+| [`listLoaded()`](#inspect-loaded-models) | Enumerate every LLM currently in memory. |
+| [`unload(identifier)`](#unload-a-model) | Free GPU/CPU resources tied to a specific instance identifier. |
+| [`createDynamicHandle(query)`](#dynamic-handles) | Obtain a handle that tracks "whichever model matches this query". |
+| [`createDynamicHandle(identifier)`](#dynamic-handles) | Short-hand for `createDynamicHandle({ identifier })`. |
+| [`createDynamicHandleFromInstanceReference(instanceRef)`](#dynamic-handles) | Build a handle from the server's immutable instance reference (advanced). |
+
+Every function returns a `Promise` and mirrors the options used by the CLI: auto-load models, control
+idle eviction (TTL), monitor load progress, and cancel work with `AbortController`.
+
+## Retrieve a handle
+
+```ts
+const model = await client.llm.model();
+```
+
+- Calling `.model()` with no arguments returns the first loaded model. The promise rejects if no LLMs
+  are in memory.
+- Pass a `modelKey` (for example `"lmstudio-community/phi-3.5-mini-instruct"`) to target a specific
+  download. LM Studio loads it on demand when necessary.
+- The optional `options` argument matches `BaseLoadModelOpts<LLMLoadModelConfig>`:
+
+  ```ts
+  const llama = await client.llm.model("lmstudio-community/llama-3.2-3b-instruct", {
+    identifier: "analysis-llama",      // Custom instance name
+    ttl: 3600,                         // Idle seconds before auto-unload
+    signal: abortController.signal,    // Cancel loading if needed
+    onProgress: (progress) => {
+      console.info(`Loading… ${Math.round(progress * 100)}%`);
+    },
+    config: {
+      contextLength: 8192,
+      gpu: { /* see LLMLoadModelConfig docs */ },
+      flashAttention: true,
+    },
+  });
+  ```
+
+  See [`LLMLoadModelConfig`](./llm-load-model-config.md) for the available load-time parameters.
+
+Subsequent calls to `client.llm.model("…")` reuse the same instance. To change load configuration,
+explicitly `unload` the current instance or create an additional one with [`client.llm.load`](#load-additional-instances).
+
+## Load additional instances
+
+```ts
+const streaming = await client.llm.load("lmstudio-community/llama-3.2-3b-instruct", {
+  identifier: "streaming-copy",
+  ttl: 600,
+});
+const analysis = await client.llm.load("lmstudio-community/llama-3.2-3b-instruct", {
+  identifier: "analysis-copy",
+  config: { contextLength: 16384 },
+});
+```
+
+`load()` always returns a fresh `LLM` handle even if another instance for the same model key already
+exists. Use this when you need separate runtime settings (for example, different context lengths or
+GPU splits). Options match those accepted by `.model()`.
+
+## Inspect loaded models
+
+```ts
+const handles = await client.llm.listLoaded();
+for (const handle of handles) {
+  const info = await handle.getModelInfo();
+  console.info(handle.identifier, info.displayName, info.maxContextLength);
+}
+```
+
+`listLoaded()` resolves to an array of `LLM` handles. Each handle exposes metadata (`identifier`,
+`path`, `instanceReference`) and the full suite of prediction helpers.
+
+To inspect loaded models without instantiating handles, call `handle.getModelInfo()` or query by
+identifier with [`client.llm.createDynamicHandle`](#dynamic-handles).
+
+## Unload a model
+
+```ts
+await client.llm.unload("analysis-copy");
+```
+
+Pass the instance identifier (the same value returned by `handle.identifier` or listed in the LM
+Studio UI). Unloading frees resources immediately instead of waiting for the idle TTL.
+
+You can also unload via the handle itself: `await handle.unload()`.
+
+## Dynamic handles
+
+Dynamic handles are lightweight references that stay valid even if the underlying model is reloaded.
+They are useful when you need to hold onto a capability rather than a specific runtime instance.
+
+```ts
+const dynamic = client.llm.createDynamicHandle({
+  path: "lmstudio-community/llama-3.2-3b-instruct",
+});
+
+const prediction = dynamic.respond("Summarize the release notes.");
+for await (const fragment of prediction) {
+  process.stdout.write(fragment.content);
+}
+```
+
+- Queries accept either a `string` identifier or a `ModelQuery` object (`domain`, `identifier`, `path`,
+  `vision`).
+- The handle stays constructed even if the matching model unloads; subsequent method calls fail until a
+  new instance satisfies the query.
+- Advanced integrations that cache the server-issued `instanceReference` can resurrect a handle via
+  `createDynamicHandleFromInstanceReference(instanceReference)`.
+
+## Preview a prompt template
+
+Prompt templating lives on the `LLM` handle returned by the methods above:
+
+```ts
+import { Chat } from "@lmstudio/sdk";
+
+const formatted = await llama.applyPromptTemplate(Chat.from("Hello"));
+console.info(formatted);
+```
+
+Use this to debug prompt rendering without triggering a prediction. The helper accepts anything that
+`Chat.from(...)` understands. See [Apply prompt templates](../../more/apply-prompt-template.md) for
+usage patterns and option details.
+
+## Asynchronous environments
+
+All namespace helpers are `async`. When using the SDK in ESM modules or top-level `await` contexts, no
+additional scaffolding is required. In CommonJS projects create an async function to wrap your
+workflow.
+
+## See also
+
+- [`.model()` API reference](./model.md) for handle semantics and streaming behaviour.
+- [Load and manage models](../model-management/loading.md) for higher-level lifecycle patterns.
+- [List loaded models](../model-management/list-loaded.md) and
+  [list downloaded models](../model-management/list-downloaded.md) for complementary utilities.
+- [Chat completion guide](../../llm-prediction/chat-completion.md) and
+  [text completion guide](../../llm-prediction/completion.md) to explore prediction flows once you
+  have an `LLM` handle.

--- a/docs/LMStudio/developer/typescript/api-reference/system-namespace.md
+++ b/docs/LMStudio/developer/typescript/api-reference/system-namespace.md
@@ -5,4 +5,111 @@ description: "`client.system` - API reference for the system namespace in an `LM
 index: 6
 ---
 
-...
+`client.system` exposes host-level utilities that apply to every runtime managed by LM Studio. Use it
+to list downloaded models, watch for disconnections, surface notifications, or control the embedded
+HTTP server.
+
+```ts
+import { LMStudioClient } from "@lmstudio/sdk";
+
+const client = new LMStudioClient();
+const downloads = await client.system.listDownloadedModels();
+console.table(downloads.map(({ modelKey, type, path }) => ({ modelKey, type, path })));
+```
+
+Returned items are plain data objects (`ModelInfo`, `LLMInfo`, or `EmbeddingModelInfo`) that you can
+pass back into the [`client.llm`](./llm-namespace.md) or `client.embedding` namespaces when you are
+ready to load them.
+
+## `listDownloadedModels()`
+
+```ts
+const all = await client.system.listDownloadedModels();
+const llmsOnly = await client.system.listDownloadedModels("llm");
+const embeddingsOnly = await client.system.listDownloadedModels("embedding");
+```
+
+- Without arguments the method returns every downloaded artifact, regardless of type.
+- Passing `"llm"` or `"embedding"` narrows the result to a single domain.
+- Each object includes the fields inherited from `ModelInfoBase`:
+  - `modelKey`, `displayName`, `path`, `sizeBytes`, `format`
+  - Optional metadata such as `architecture`, `paramsString`, `quantization`
+  - For LLMs you also receive `vision`, `trainedForToolUse`, and `maxContextLength`.
+
+You can feed a result back into `client.llm.model(download.modelKey)` to load it without looking up
+keys manually. Combine this with [`client.llm.listLoaded()`](./llm-namespace.md#inspect-loaded-models)
+to reconcile disk state with in-memory instances.
+
+## `whenDisconnected()`
+
+```ts
+await client.system.whenDisconnected();
+console.info("Lost connection to LM Studio");
+```
+
+Resolves when the underlying websocket connection closes. This is handy for long-lived services that
+need to clean up resources once the desktop app exits.
+
+## `notify()`
+
+```ts
+await client.system.notify({
+  title: "Model loaded",
+  description: "llama-3.2-3b-instruct is ready",
+});
+```
+
+Sends a toast notification to the LM Studio UI. The payload matches `BackendNotification` (`title`,
+optional `description`, and `noAutoDismiss` to keep the toast visible until dismissed manually).
+
+## `getLMStudioVersion()`
+
+```ts
+const { version, build } = await client.system.getLMStudioVersion();
+console.info(`Connected to LM Studio ${version} (build ${build})`);
+```
+
+Use this to gate features that depend on specific server capabilities.
+
+## Experimental helpers
+
+> **Note**
+> The following methods are marked experimental in the SDK and may change without notice.
+
+### `unstable_setExperimentFlag(flag, value)` / `unstable_getExperimentFlags()`
+
+Toggle or inspect LM Studio's internal experiment flags. These are primarily useful when testing
+pre-release features.
+
+```ts
+await client.system.unstable_setExperimentFlag("vision-tooling", true);
+const enabled = await client.system.unstable_getExperimentFlags();
+```
+
+### `startHttpServer(opts)` / `stopHttpServer()`
+
+Programmatically expose LM Studio's HTTP API from the desktop host.
+
+```ts
+await client.system.startHttpServer({
+  port: 12345,
+  cors: true,
+});
+
+// … later …
+await client.system.stopHttpServer();
+```
+
+`startHttpServer` accepts a `StartHttpServerOpts` object with two fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `port` | `number` | Port on which the API server should listen. Must be available on the host. |
+| `cors` | `boolean` | Whether to enable permissive CORS headers for browser-based clients. |
+
+## See also
+
+- [`client.llm`](./llm-namespace.md) for model lifecycle helpers once you know which key to load.
+- [List local models guide](../model-management/list-downloaded.md) for higher-level usage patterns.
+- [Manage models in memory](../model-management/loading.md) to load or unload items returned by
+  `listDownloadedModels()`.


### PR DESCRIPTION
## Summary
- document the TypeScript `Chat` helper, including creation patterns and mutators
- expand the `client.llm` namespace reference with lifecycle methods and examples
- add guidance for `client.system` utilities and HTTP server controls

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68ed5e11abb8832f91d3983aef32f7f6