### PR TITLE
Fix mode defaults handling in VariedResearchAgent

### DIFF
--- a/agents/research.py
+++ b/agents/research.py
@@ -488,10 +488,10 @@ class VariedResearchAgent:
         for name, payload in merged.items():
             normalised = dict(self._normalise_parameters(payload))
             profile_name = payload.get("profile")
-        if isinstance(profile_name, str) and profile_name.strip():
-            normalised["profile"] = profile_name.strip().lower()
-        if normalised:
-            modes[name.lower()] = normalised
+            if isinstance(profile_name, str) and profile_name.strip():
+                normalised["profile"] = profile_name.strip().lower()
+            if normalised:
+                modes[name.lower()] = normalised
         if not modes:
             modes["balanced"] = dict(self._normalise_parameters({"profile": "balanced"}))
         return modes

--- a/tests/test_varied_research_agent.py
+++ b/tests/test_varied_research_agent.py
@@ -103,6 +103,8 @@ def test_varied_agent_modes_apply_defaults(mode: str, expected: dict[str, object
     base = RecordingResearchAgent()
     agent = VariedResearchAgent(base)
 
+    assert {"light", "balanced", "deep"}.issubset(agent.modes)
+
     agent.search("topic", mode=mode)
 
     call = base.calls[-1]
@@ -179,3 +181,13 @@ def test_varied_agent_exposes_multiple_profiles() -> None:
     assert len(agent.profiles) >= 5
     for key in ("skim", "survey", "balanced", "insight", "deep_dive"):
         assert key in agent.profiles
+
+
+def test_varied_agent_preserves_default_modes_with_overrides() -> None:
+    base = RecordingResearchAgent()
+    agent = VariedResearchAgent(
+        base,
+        mode_defaults={"explore": {"profile": "insight"}},
+    )
+
+    assert {"light", "balanced", "deep", "explore"}.issubset(agent.modes)


### PR DESCRIPTION
## Summary
- fix `_build_mode_defaults` to retain each mode definition while normalising profile names
- ensure the balanced fallback mode is only inserted when no other modes are defined
- extend VariedResearchAgent tests to cover default and overridden mode availability

## Testing
- pytest tests/test_varied_research_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68edf0afacb0832fb0bee3ec60f36f20