### PR TITLE
Remove tests package marker

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,0 @@
-"""Test package for LMStudioAutoCoder.
-
-Tests here are lightweight and avoid network calls by mocking
-Transformers model and pipeline objects.
-"""
-


### PR DESCRIPTION
## Summary
- remove the tests package marker file so pytest uses namespace discovery

## Testing
- pytest *(fails: multiple ModuleNotFoundError errors for optional dependencies such as `agents`, `internal`, and `numpy`)*

------
https://chatgpt.com/codex/tasks/task_b_68ee511e2068832fa21e8d62f46cdcb7